### PR TITLE
replica_server: reimplement uniq_timestamp generator

### DIFF
--- a/include/dsn/tool-api/uniq_timestamp_us.h
+++ b/include/dsn/tool-api/uniq_timestamp_us.h
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include <cstdint>
+#include <algorithm>
+#include <dsn/c/api_layer1.h>
+
+namespace dsn {
+//
+// uniq_timestamp_us is used to generate an increasing unique microsecond timestamp
+// in rdsn, it's mainly used for replica to set mutation's timestamp
+//
+// Notice: this module is not thread-safe, 
+// please ensure that it is accessed only by one thread
+//
+class uniq_timestamp_us {
+private:
+    uint64_t last_ts;
+public:
+    uniq_timestamp_us() { last_ts = dsn_now_us(); }
+
+    void try_update(uint64_t new_ts)
+    {
+        if (new_ts > last_ts)
+            last_ts = new_ts;
+    }
+
+    uint64_t next()
+    {
+        last_ts = std::max(dsn_now_us(), last_ts+1);
+        return last_ts;
+    }
+};
+}

--- a/include/dsn/tool-api/uniq_timestamp_us.h
+++ b/include/dsn/tool-api/uniq_timestamp_us.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <algorithm>
+#include <dsn/utility/ports.h>
 #include <dsn/c/api_layer1.h>
 
 namespace dsn {
@@ -39,20 +40,20 @@ namespace dsn {
 //
 class uniq_timestamp_us {
 private:
-    uint64_t last_ts;
+    uint64_t _last_ts;
 public:
-    uniq_timestamp_us() { last_ts = dsn_now_us(); }
+    uniq_timestamp_us() { _last_ts = dsn_now_us(); }
 
     void try_update(uint64_t new_ts)
     {
-        if (new_ts > last_ts)
-            last_ts = new_ts;
+        if ( dsn_likely(new_ts > _last_ts) )
+            _last_ts = new_ts;
     }
 
     uint64_t next()
     {
-        last_ts = std::max(dsn_now_us(), last_ts+1);
-        return last_ts;
+        _last_ts = std::max(dsn_now_us(), _last_ts+1);
+        return _last_ts;
     }
 };
 }

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -42,6 +42,7 @@
 // which is binded to this replication partition
 //
 
+#include <dsn/tool-api/uniq_timestamp_us.h>
 #include <dsn/cpp/serverlet.h>
 #include <dsn/cpp/perf_counter_wrapper.h>
 #include "dist/replication/client_lib/replication_common.h"
@@ -328,6 +329,19 @@ private:
     replication_options *_options;
     const app_info _app_info;
     std::map<std::string, std::string> _extra_envs;
+
+    // uniq timestamp generator for this replica.
+    //
+    // we use it to generate an increasing timestamp for current replica
+    // and replicate it to secondary in preparing mutations, and secodaries'
+    // timestamp value will also updated if value from primary is larger
+    //
+    // as the timestamp is recorded in mutation log with mutations, we also update the value
+    // when do replaying
+    //
+    // in addition, as a replica can only be accessed by one thread,
+    // so the "thread-unsafe" generator works fine
+    uniq_timestamp_us _uniq_timestamp_us;
 
     // replica status specific states
     primary_context _primary_states;

--- a/src/dist/replication/lib/replica_init.cpp
+++ b/src/dist/replication/lib/replica_init.cpp
@@ -437,6 +437,7 @@ bool replica::replay_mutation(mutation_ptr &mu, bool is_private)
           mu->data.header.last_committed_decree);
 
     // prepare
+    _uniq_timestamp_us.try_update(mu->data.header.timestamp);
     error_code err = _prepare_list->prepare(mu, partition_status::PS_INACTIVE);
     dassert(err == ERR_OK, "prepare failed, err = %s", err.to_string());
 


### PR DESCRIPTION
Reimplement this for 2 reasons:

1. All threads shared a lock in the old implementation, which was
not friendly to performance. As a matter of fact, it's not necessary
for different replicas to keep an global increasing timestamp, so we
can try this optimization

2. Although the timestamp was replicated to secondaries from primary,
timestamp value of secondaries never updated accordingly, for which reason
we were exposed to the risks that a newer mutation may had smaller timestamp
if primary switched.