### PR TITLE
meta_backup_service: modify cold_backup_constant and backup_restore_c…

### DIFF
--- a/src/dist/replication/client_lib/replication_common.cpp
+++ b/src/dist/replication/client_lib/replication_common.cpp
@@ -547,17 +547,17 @@ const std::string cold_backup_constant::APP_METADATA("app_metadata");
 const std::string cold_backup_constant::APP_BACKUP_STATUS("app_backup_status");
 const std::string cold_backup_constant::CURRENT_CHECKPOINT("current_checkpoint");
 const std::string cold_backup_constant::BACKUP_METADATA("backup_metadata");
-const std::string cold_backup_constant::BLOCK_SERVICE_PROVIDER("block_service_provider");
-const std::string cold_backup_constant::CLUSTER_NAME("cluster_name");
-const std::string cold_backup_constant::POLICY_NAME("policy_name");
-const std::string cold_backup_constant::APP_NAME("app_name");
-const std::string cold_backup_constant::APP_ID("app_id");
-const std::string cold_backup_constant::BACKUP_ID("backup_id");
 const std::string cold_backup_constant::BACKUP_INFO("backup_info");
-const std::string cold_backup_constant::SKIP_BAD_PARTITION("skip_bad_partition");
 const int32_t cold_backup_constant::PROGRESS_FINISHED = 1000;
 
-const std::string backup_restore_constant::FORCE_RESORE("force_restore");
+const std::string backup_restore_constant::FORCE_RESORE("restore.force_restore");
+const std::string backup_restore_constant::BLOCK_SERVICE_PROVIDER("restore.block_service_provider");
+const std::string backup_restore_constant::CLUSTER_NAME("restore.cluster_name");
+const std::string backup_restore_constant::POLICY_NAME("restore.policy_name");
+const std::string backup_restore_constant::APP_NAME("restore.app_name");
+const std::string backup_restore_constant::APP_ID("restore.app_id");
+const std::string backup_restore_constant::BACKUP_ID("restore.backup_id");
+const std::string backup_restore_constant::SKIP_BAD_PARTITION("restore.skip_bad_partition");
 
 namespace cold_backup {
 std::string get_policy_path(const std::string &root, const std::string &policy_name)

--- a/src/dist/replication/client_lib/replication_common.h
+++ b/src/dist/replication/client_lib/replication_common.h
@@ -136,15 +136,7 @@ public:
     static const std::string APP_BACKUP_STATUS;
     static const std::string CURRENT_CHECKPOINT;
     static const std::string BACKUP_METADATA;
-
-    static const std::string BLOCK_SERVICE_PROVIDER;
-    static const std::string CLUSTER_NAME;
-    static const std::string POLICY_NAME;
-    static const std::string APP_NAME;
-    static const std::string APP_ID;
-    static const std::string BACKUP_ID;
     static const std::string BACKUP_INFO;
-    static const std::string SKIP_BAD_PARTITION;
     static const int32_t PROGRESS_FINISHED;
 };
 
@@ -152,6 +144,13 @@ class backup_restore_constant
 {
 public:
     static const std::string FORCE_RESORE;
+    static const std::string BLOCK_SERVICE_PROVIDER;
+    static const std::string CLUSTER_NAME;
+    static const std::string POLICY_NAME;
+    static const std::string APP_NAME;
+    static const std::string APP_ID;
+    static const std::string BACKUP_ID;
+    static const std::string SKIP_BAD_PARTITION;
 };
 
 namespace cold_backup {

--- a/src/dist/replication/lib/replica_restore.cpp
+++ b/src/dist/replication/lib/replica_restore.cpp
@@ -380,46 +380,46 @@ dsn::error_code replica::restore_checkpoint()
 {
     // first check the parameter
     configuration_restore_request restore_req;
-    auto iter = _app_info.envs.find(cold_backup_constant::BLOCK_SERVICE_PROVIDER);
+    auto iter = _app_info.envs.find(backup_restore_constant::BLOCK_SERVICE_PROVIDER);
     dassert(iter != _app_info.envs.end(),
             "%s: can't find %s in app_info.envs",
             name(),
-            cold_backup_constant::BLOCK_SERVICE_PROVIDER.c_str());
+            backup_restore_constant::BLOCK_SERVICE_PROVIDER.c_str());
     restore_req.backup_provider_name = iter->second;
-    iter = _app_info.envs.find(cold_backup_constant::CLUSTER_NAME);
+    iter = _app_info.envs.find(backup_restore_constant::CLUSTER_NAME);
     dassert(iter != _app_info.envs.end(),
             "%s: can't find %s in app_info.envs",
             name(),
-            cold_backup_constant::CLUSTER_NAME.c_str());
+            backup_restore_constant::CLUSTER_NAME.c_str());
     restore_req.cluster_name = iter->second;
-    iter = _app_info.envs.find(cold_backup_constant::POLICY_NAME);
+    iter = _app_info.envs.find(backup_restore_constant::POLICY_NAME);
     dassert(iter != _app_info.envs.end(),
             "%s: can't find %s in app_info.envs",
             name(),
-            cold_backup_constant::POLICY_NAME.c_str());
+            backup_restore_constant::POLICY_NAME.c_str());
     restore_req.policy_name = iter->second;
-    iter = _app_info.envs.find(cold_backup_constant::APP_NAME);
+    iter = _app_info.envs.find(backup_restore_constant::APP_NAME);
     dassert(iter != _app_info.envs.end(),
             "%s: can't find %s in app_info.envs",
             name(),
-            cold_backup_constant::APP_NAME.c_str());
+            backup_restore_constant::APP_NAME.c_str());
     restore_req.app_name = iter->second;
-    iter = _app_info.envs.find(cold_backup_constant::APP_ID);
+    iter = _app_info.envs.find(backup_restore_constant::APP_ID);
     dassert(iter != _app_info.envs.end(),
             "%s: can't find %s in app_info.envs",
             name(),
-            cold_backup_constant::APP_ID.c_str());
+            backup_restore_constant::APP_ID.c_str());
     restore_req.app_id = boost::lexical_cast<int32_t>(iter->second);
 
-    iter = _app_info.envs.find(cold_backup_constant::BACKUP_ID);
+    iter = _app_info.envs.find(backup_restore_constant::BACKUP_ID);
     dassert(iter != _app_info.envs.end(),
             "%s: can't find %s in app_info.envs",
             name(),
-            cold_backup_constant::BACKUP_ID.c_str());
+            backup_restore_constant::BACKUP_ID.c_str());
     restore_req.time_stamp = boost::lexical_cast<int64_t>(iter->second);
 
     bool skip_bad_partition = false;
-    if (_app_info.envs.find(cold_backup_constant::SKIP_BAD_PARTITION) != _app_info.envs.end()) {
+    if (_app_info.envs.find(backup_restore_constant::SKIP_BAD_PARTITION) != _app_info.envs.end()) {
         skip_bad_partition = true;
     }
 

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -631,8 +631,7 @@ dsn::error_code replica_stub::on_kill_replica(gpid pid)
                 r->inject_error(ERR_INJECTED);
         }
         return ERR_OK;
-    }
-    else {
+    } else {
         error_code err = ERR_INVALID_PARAMETERS;
         replica_ptr r = get_replica(pid);
         if (r == nullptr) {
@@ -1603,11 +1602,10 @@ void replica_stub::on_disk_stat()
                           dsn_now_ms() - current_time_ms);
                     _counter_replicas_recent_replica_remove_dir_count->increment();
                 }
-            }
-            else {
+            } else {
                 ddebug("gc_disk: reserve directory '%s', wait_seconds = %" PRIu64,
-                        fpath.c_str(),
-                        last_write_time + interval_seconds - current_time_ms / 1000);
+                       fpath.c_str(),
+                       last_write_time + interval_seconds - current_time_ms / 1000);
             }
         }
     }
@@ -1722,7 +1720,7 @@ void replica_stub::open_replica(const app_info &app,
 
         bool restore_if_necessary =
             ((req2 != nullptr) && (req2->type == config_type::CT_ASSIGN_PRIMARY) &&
-             (app.envs.find(cold_backup_constant::POLICY_NAME) != app.envs.end()));
+             (app.envs.find(backup_restore_constant::POLICY_NAME) != app.envs.end()));
 
         // NOTICE: when we don't need execute restore-process, we should remove a.b.pegasus
         // directory because it don't contain the valid data dir and also we need create a new
@@ -1891,16 +1889,13 @@ void replica_stub::open_service()
             if (args.size() == 0) {
                 pid.set_app_id(-1);
                 pid.set_partition_index(-1);
-            }
-            else if (args.size() == 1) {
+            } else if (args.size() == 1) {
                 pid.set_app_id(atoi(args[0].c_str()));
                 pid.set_partition_index(-1);
-            }
-            else if (args.size() == 2) {
+            } else if (args.size() == 2) {
                 pid.set_app_id(atoi(args[0].c_str()));
                 pid.set_partition_index(atoi(args[1].c_str()));
-            }
-            else {
+            } else {
                 return std::string(ERR_INVALID_PARAMETERS.to_string());
             }
             dsn::error_code e = this->on_kill_replica(pid);

--- a/src/dist/replication/meta_server/server_state_restore.cpp
+++ b/src/dist/replication/meta_server/server_state_restore.cpp
@@ -133,14 +133,14 @@ std::pair<dsn::error_code, std::shared_ptr<app_state>> server_state::restore_app
         }
     }
     // TODO: using one single env to replace
-    app->envs[cold_backup_constant::BLOCK_SERVICE_PROVIDER] = req.backup_provider_name;
-    app->envs[cold_backup_constant::CLUSTER_NAME] = req.cluster_name;
-    app->envs[cold_backup_constant::POLICY_NAME] = req.policy_name;
-    app->envs[cold_backup_constant::APP_NAME] = old_app_name;
-    app->envs[cold_backup_constant::APP_ID] = std::to_string(old_app_id);
-    app->envs[cold_backup_constant::BACKUP_ID] = std::to_string(req.time_stamp);
+    app->envs[backup_restore_constant::BLOCK_SERVICE_PROVIDER] = req.backup_provider_name;
+    app->envs[backup_restore_constant::CLUSTER_NAME] = req.cluster_name;
+    app->envs[backup_restore_constant::POLICY_NAME] = req.policy_name;
+    app->envs[backup_restore_constant::APP_NAME] = old_app_name;
+    app->envs[backup_restore_constant::APP_ID] = std::to_string(old_app_id);
+    app->envs[backup_restore_constant::BACKUP_ID] = std::to_string(req.time_stamp);
     if (req.skip_bad_partition) {
-        app->envs[cold_backup_constant::SKIP_BAD_PARTITION] = std::string("true");
+        app->envs[backup_restore_constant::SKIP_BAD_PARTITION] = std::string("true");
     }
     res.second.swap(app);
     return res;


### PR DESCRIPTION
…onstant

1. move some constant from cold_backup_constant to backup_restore_constant which
is only used by restore
2. add prefix for backup_restore_constant which can be used as namespace, such as restore.xxx