### PR TITLE
replica_server: support update_app_envs by config sync

### DIFF
--- a/include/dsn/c/api_utilities.h
+++ b/include/dsn/c/api_utilities.h
@@ -60,6 +60,10 @@ extern DSN_API uint64_t dsn_config_get_value_uint64(const char *section,
                                                     const char *key,
                                                     uint64_t default_value,
                                                     const char *dsptr);
+extern DSN_API int64_t dsn_config_get_value_int64(const char *section,
+                                                  const char *key,
+                                                  int64_t default_value,
+                                                  const char *dsptr);
 extern DSN_API double dsn_config_get_value_double(const char *section,
                                                   const char *key,
                                                   double default_value,

--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -213,6 +213,12 @@ public:
     // do full compaction manually.
     virtual void manual_compact() = 0;
 
+    // update app envs.
+    virtual void update_app_envs(const std::map<std::string, std::string> &envs) = 0;
+
+    // query app envs.
+    virtual void query_app_envs(/*out*/ std::map<std::string, std::string> &envs) = 0;
+
 public:
     //
     // utility functions to be used by app

--- a/include/dsn/utility/strings.h
+++ b/include/dsn/utility/strings.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <map>
+#include <iostream>
 
 namespace dsn {
 namespace utils {
@@ -10,6 +12,30 @@ namespace utils {
 void split_args(const char *args, /*out*/ std::vector<std::string> &sargs, char splitter = ' ');
 
 void split_args(const char *args, /*out*/ std::list<std::string> &sargs, char splitter = ' ');
+
+// kv_map sample (when item_splitter = ',' and kv_splitter = ':'):
+//   k1:v1,k2:v2,k3:v3
+// we say that 'k1:v1' is an item.
+// return false if:
+//   - bad format: no kv_splitter found in any non-empty item
+//   - allow_dup_key = false and the same key appears for more than once
+// if allow_dup_key = true and the same key appears for more than once,
+// the last value will be returned.
+bool parse_kv_map(const char *args,
+                  /*out*/ std::map<std::string, std::string> &kv_map,
+                  char item_splitter,
+                  char kv_splitter,
+                  bool allow_dup_key = false);
+
+// format sample (when item_splitter = ',' and kv_splitter = ':'):
+//   k1:v1,k2:v2,k3:v3
+void kv_map_to_stream(const std::map<std::string, std::string> &kv_map,
+                      /*out*/ std::ostream &oss,
+                      char item_splitter,
+                      char kv_splitter);
+std::string kv_map_to_string(const std::map<std::string, std::string> &kv_map,
+                             char item_splitter,
+                             char kv_splitter);
 
 std::string
 replace_string(std::string subject, const std::string &search, const std::string &replace);

--- a/src/apps/skv/simple_kv.server.impl.h
+++ b/src/apps/skv/simple_kv.server.impl.h
@@ -84,7 +84,11 @@ public:
     virtual ::dsn::error_code storage_apply_checkpoint(chkpt_apply_mode mode,
                                                        const learn_state &state) override;
 
-    virtual void manual_compact() {};
+    virtual void manual_compact() {}
+
+    virtual void update_app_envs(const std::map<std::string, std::string> &envs) {}
+
+    virtual void query_app_envs(/*out*/ std::map<std::string, std::string> &envs) {}
 
 private:
     void recover();

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -120,6 +120,14 @@ DSN_API uint64_t dsn_config_get_value_uint64(const char *section,
     return dsn_all.config->get_value<uint64_t>(section, key, default_value, dsptr);
 }
 
+DSN_API int64_t dsn_config_get_value_int64(const char *section,
+                                           const char *key,
+                                           int64_t default_value,
+                                           const char *dsptr)
+{
+    return dsn_all.config->get_value<int64_t>(section, key, default_value, dsptr);
+}
+
 DSN_API double dsn_config_get_value_double(const char *section,
                                            const char *key,
                                            double default_value,

--- a/src/core/core/strings.cpp
+++ b/src/core/core/strings.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <sstream>
 #include <dsn/utility/strings.h>
 
 namespace dsn {
@@ -78,6 +79,55 @@ void split_args(const char *args, /*out*/ std::list<std::string> &sargs, char sp
             break;
         }
     }
+}
+
+bool parse_kv_map(const char *args,
+                  /*out*/ std::map<std::string, std::string> &kv_map,
+                  char item_splitter,
+                  char kv_splitter,
+                  bool allow_dup_key)
+{
+    kv_map.clear();
+    std::vector<std::string> splits;
+    split_args(args, splits, item_splitter);
+    for (std::string &i : splits) {
+        if (i.empty())
+            continue;
+        size_t pos = i.find(kv_splitter);
+        if (pos == std::string::npos) {
+            return false;
+        }
+        std::string key = i.substr(0, pos);
+        std::string value = i.substr(pos + 1);
+        if (!allow_dup_key && kv_map.find(key) != kv_map.end()) {
+            return false;
+        }
+        kv_map[key] = value;
+    }
+    return true;
+}
+
+void kv_map_to_stream(const std::map<std::string, std::string> &kv_map,
+                      /*out*/ std::ostream &oss,
+                      char item_splitter,
+                      char kv_splitter)
+{
+    int i = 0;
+    for (auto &kv : kv_map) {
+        if (i > 0)
+            oss << item_splitter;
+        oss << kv.first << kv_splitter << kv.second;
+        i++;
+    }
+}
+
+std::string kv_map_to_string(const std::map<std::string, std::string> &kv_map,
+                             char item_splitter,
+                             char kv_splitter)
+{
+    std::ostringstream oss;
+    kv_map_to_stream(kv_map, oss, item_splitter, kv_splitter);
+    return oss.str();
 }
 
 std::string

--- a/src/dist/replication/client_lib/replication_common.cpp
+++ b/src/dist/replication/client_lib/replication_common.cpp
@@ -550,7 +550,7 @@ const std::string cold_backup_constant::BACKUP_METADATA("backup_metadata");
 const std::string cold_backup_constant::BACKUP_INFO("backup_info");
 const int32_t cold_backup_constant::PROGRESS_FINISHED = 1000;
 
-const std::string backup_restore_constant::FORCE_RESORE("restore.force_restore");
+const std::string backup_restore_constant::FORCE_RESTORE("restore.force_restore");
 const std::string backup_restore_constant::BLOCK_SERVICE_PROVIDER("restore.block_service_provider");
 const std::string backup_restore_constant::CLUSTER_NAME("restore.cluster_name");
 const std::string backup_restore_constant::POLICY_NAME("restore.policy_name");

--- a/src/dist/replication/client_lib/replication_common.h
+++ b/src/dist/replication/client_lib/replication_common.h
@@ -143,7 +143,7 @@ public:
 class backup_restore_constant
 {
 public:
-    static const std::string FORCE_RESORE;
+    static const std::string FORCE_RESTORE;
     static const std::string BLOCK_SERVICE_PROVIDER;
     static const std::string CLUSTER_NAME;
     static const std::string POLICY_NAME;

--- a/src/dist/replication/ddl_lib/replication_ddl_client.cpp
+++ b/src/dist/replication/ddl_lib/replication_ddl_client.cpp
@@ -1344,7 +1344,7 @@ void replication_ddl_client::end_meta_request(
     if (response.err != ERR_OK) {
         return response.err;
     } else {
-        std::cout << "set app env succeed" << std::endl;
+        std::cout << "set app envs succeed" << std::endl;
         if (!response.hint_message.empty()) {
             std::cout << "=============================" << std::endl;
             std::cout << response.hint_message << std::endl;

--- a/src/dist/replication/ddl_lib/replication_ddl_client.cpp
+++ b/src/dist/replication/ddl_lib/replication_ddl_client.cpp
@@ -387,8 +387,8 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
         << std::setw(max_app_name_size) << std::left << "app_name" << std::setw(20) << std::left
         << "app_type" << std::setw(20) << std::left << "partition_count" << std::setw(20)
         << std::left << "replica_count" << std::setw(20) << std::left << "is_stateful"
-        << std::setw(20) << std::left << "settings" << std::setw(20) << std::left
-        << "drop_expire_time" << std::endl;
+        << std::setw(20) << std::left << "drop_expire_time" << std::setw(20) << std::left << "envs"
+        << std::endl;
     int available_app_count = 0;
     for (int i = 0; i < apps.size(); i++) {
         dsn::app_info info = apps[i];
@@ -397,15 +397,7 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
         }
         std::string status_str = enum_to_string(info.status);
         status_str = status_str.substr(status_str.find("AS_") + 3);
-        std::string settings = "{";
-        for (auto kv : info.envs) {
-            settings += (kv.first + ":" + kv.second + ",");
-        }
-        if (settings.length() > 1) {
-            settings.back() = '}';
-        } else {
-            settings = "{}";
-        }
+        std::string envs_str = "{" + dsn::utils::kv_map_to_string(info.envs, ',', '=') + "}";
         std::string drop_expire_time = "-";
         if (info.status == app_status::AS_AVAILABLE) {
             available_app_count++;
@@ -418,8 +410,8 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
             << std::setw(max_app_name_size) << std::left << info.app_name << std::setw(20)
             << std::left << info.app_type << std::setw(20) << std::left << info.partition_count
             << std::setw(20) << std::left << info.max_replica_count << std::setw(20) << std::left
-            << (info.is_stateful ? "true" : "false") << std::setw(20) << std::left << settings
-            << std::setw(20) << std::left << drop_expire_time << std::endl;
+            << (info.is_stateful ? "true" : "false") << std::setw(20) << std::left
+            << drop_expire_time << std::setw(20) << std::left << envs_str << std::endl;
     }
     out << std::endl << std::flush;
 

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -82,7 +82,7 @@ replica::replica(
     if (need_restore) {
         // add an extra env for restore
         _extra_envs.insert(
-            std::make_pair(backup_restore_constant::FORCE_RESORE, std::string("true")));
+            std::make_pair(backup_restore_constant::FORCE_RESTORE, std::string("true")));
     }
 }
 

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -96,7 +96,7 @@ public:
     //    messages and tools from/for meta server
     //
     void on_config_proposal(configuration_update_request &proposal);
-    void on_config_sync(const partition_configuration &config);
+    void on_config_sync(const app_info &info, const partition_configuration &config);
     void on_cold_backup(const backup_request &request, /*out*/ backup_response &response);
 
     //
@@ -227,6 +227,8 @@ private:
                                               partition_status::type news);
 
     // return false when update fails or replica is going to be closed
+    bool update_app_envs(const std::map<std::string, std::string> &envs);
+    bool query_app_envs(/*out*/ std::map<std::string, std::string> &envs);
     bool update_configuration(const partition_configuration &config);
     bool update_local_configuration(const replica_configuration &config, bool same_ballot = false);
 

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -61,6 +61,7 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
       _trigger_chkpt_command(nullptr),
       _manual_compact_command(nullptr),
       _query_compact_command(nullptr),
+      _query_app_envs_command(nullptr),
       _deny_client(false),
       _verbose_client_log(false),
       _verbose_commit_log(false),
@@ -1190,7 +1191,7 @@ void replica_stub::on_node_query_reply_scatter(replica_stub_ptr this_,
 {
     replica_ptr replica = get_replica(req.config.pid);
     if (replica != nullptr) {
-        replica->on_config_sync(req.config);
+        replica->on_config_sync(req.info, req.config);
     } else {
         if (req.config.primary == _primary_address) {
             ddebug("%d.%d@%s: replica not exists on replica server, which is primary, remove it "
@@ -2095,7 +2096,90 @@ void replica_stub::open_service()
                                 << " : ignored because not primary or secondary";
                     ignored++;
                 } else {
-                    query_state << "\n    " << r->name() << " : " << r->get_compact_state();
+                    char t = status == partition_status::PS_PRIMARY ? 'P' : 'S';
+                    query_state << "\n    " << r->name() << "@" << t << " : "
+                                << r->get_compact_state();
+                    queried++;
+                }
+            }
+
+            std::stringstream total_state;
+            total_state << queried << " queried, " << ignored << " ignored, " << not_found
+                        << " not found";
+            return total_state.str() + query_state.str();
+        });
+
+    _query_app_envs_command = ::dsn::command_manager::instance().register_app_command(
+        {"query-app-envs"},
+        "query-app-envs [app_id,app_id.partition_id,...]",
+        "query-app-envs - query app envs on rocksdb",
+        [this](const std::vector<std::string> &args) {
+            replicas rs;
+            {
+                zauto_read_lock l(_replicas_lock);
+                rs = _replicas;
+            }
+
+            std::map<gpid, bool> ids; // gpid -> found
+            if (!args.empty()) {
+                std::vector<std::string> arg_strs;
+                utils::split_args(args[0].c_str(), arg_strs, ',');
+                if (arg_strs.empty()) {
+                    return std::string("invalid arguments");
+                }
+
+                for (const std::string &arg : arg_strs) {
+                    if (arg.empty())
+                        continue;
+                    gpid id;
+                    int pid;
+                    if (id.parse_from(arg.c_str())) {
+                        if (rs.count(id) > 0) {
+                            ids[id] = true;
+                        } else {
+                            ids[id] = false;
+                        }
+                    } else if (sscanf(arg.c_str(), "%d", &pid) == 1) {
+                        for (auto r : rs) {
+                            id = r.second->get_gpid();
+                            if (id.get_app_id() == pid) {
+                                ids[id] = true;
+                            }
+                        }
+                    } else {
+                        return std::string("invalid arguments");
+                    }
+                }
+            } else {
+                for (auto kv : rs) {
+                    ids[kv.first] = true;
+                }
+            }
+
+            std::stringstream query_state;
+            int queried = 0;
+            int ignored = 0;
+            int not_found = 0;
+            for (auto kv : ids) {
+                if (!kv.second) {
+                    query_state << "\n    " << kv.first.to_string() << "@"
+                                << _primary_address.to_string() << " : not found";
+                    not_found++;
+                    continue;
+                }
+                const replica_ptr &r = rs[kv.first];
+                partition_status::type status = r->status();
+                if (status != partition_status::PS_PRIMARY &&
+                    status != partition_status::PS_SECONDARY) {
+                    query_state << "\n    " << r->name()
+                                << " : ignored because not primary or secondary";
+                    ignored++;
+                } else {
+                    char t = status == partition_status::PS_PRIMARY ? 'P' : 'S';
+                    std::map<std::string, std::string> kv_map;
+                    r->query_app_envs(kv_map);
+                    query_state << "\n    " << r->name() << "@" << t << " : ";
+                    dsn::utils::kv_map_to_stream(kv_map, query_state, ',', '=');
                     queried++;
                 }
             }
@@ -2123,6 +2207,7 @@ void replica_stub::close()
     dsn::command_manager::instance().deregister_command(_trigger_chkpt_command);
     dsn::command_manager::instance().deregister_command(_manual_compact_command);
     dsn::command_manager::instance().deregister_command(_query_compact_command);
+    dsn::command_manager::instance().deregister_command(_query_app_envs_command);
 
     _kill_partition_command = nullptr;
     _deny_client_command = nullptr;
@@ -2131,6 +2216,7 @@ void replica_stub::close()
     _trigger_chkpt_command = nullptr;
     _manual_compact_command = nullptr;
     _query_compact_command = nullptr;
+    _query_app_envs_command = nullptr;
 
     if (_config_sync_timer_task != nullptr) {
         _config_sync_timer_task->cancel(true);

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -1951,8 +1951,8 @@ void replica_stub::open_service()
 
     _manual_compact_command = ::dsn::command_manager::instance().register_app_command(
         {"manual-compact"},
-        "manual-compact <app_id,app_id.partition_id,...>",
-        "manual-compact - full compact on rocksdb",
+        "manual-compact <id1,id2,...> (where id is 'app_id' or 'app_id.partition_id')",
+        "manual-compact - do full compact on the underlying storage engine",
         [this](const std::vector<std::string> &args) {
             if (args.empty()) {
                 return std::string("invalid arguments");
@@ -2032,8 +2032,8 @@ void replica_stub::open_service()
 
     _query_compact_command = ::dsn::command_manager::instance().register_app_command(
         {"query-compact"},
-        "query-compact [app_id,app_id.partition_id,...]",
-        "query-compact - query full compact state on rocksdb",
+        "query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+        "query-compact - query full compact status on the underlying storage engine",
         [this](const std::vector<std::string> &args) {
             replicas rs;
             {
@@ -2111,8 +2111,8 @@ void replica_stub::open_service()
 
     _query_app_envs_command = ::dsn::command_manager::instance().register_app_command(
         {"query-app-envs"},
-        "query-app-envs [app_id,app_id.partition_id,...]",
-        "query-app-envs - query app envs on rocksdb",
+        "query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+        "query-app-envs - query app envs on the underlying storage engine",
         [this](const std::vector<std::string> &args) {
             replicas rs;
             {

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -235,6 +235,7 @@ private:
     dsn_handle_t _trigger_chkpt_command;
     dsn_handle_t _manual_compact_command;
     dsn_handle_t _query_compact_command;
+    dsn_handle_t _query_app_envs_command;
 
     bool _deny_client;
     bool _verbose_client_log;

--- a/src/dist/replication/test/simple_kv/simple_kv.server.impl.h
+++ b/src/dist/replication/test/simple_kv/simple_kv.server.impl.h
@@ -81,7 +81,11 @@ public:
     virtual ::dsn::error_code storage_apply_checkpoint(chkpt_apply_mode mode,
                                                        const learn_state &state) override;
 
-    virtual void manual_compact() {};
+    virtual void manual_compact() {}
+
+    virtual void update_app_envs(const std::map<std::string, std::string> &envs) {}
+
+    virtual void query_app_envs(/*out*/ std::map<std::string, std::string> &envs) {}
 
 private:
     void recover();


### PR DESCRIPTION
Replication_service_app's envs can be updated by config_sync, which is useful when we want to adjust parameters of storage engine without updating server's configuration. A typical usage is "bulk load", in which case storage engine is adjusted firstly for better writing throughput, then for better reading latency.