### PR TITLE
configuration: add dsn_config_get_value_int64 back

### DIFF
--- a/include/dsn/utility/config_api.h
+++ b/include/dsn/utility/config_api.h
@@ -92,6 +92,13 @@ uint64_t dsn_config_get_value_uint64(const char *section,
                                      uint64_t default_value,
                                      const char *dsptr);
 
+/// get value of a key in some section, the value should be decimal in range of int64_t
+/// this function is not thread safe if dsn_config_set is concurrently called
+int64_t dsn_config_get_value_int64(const char *section,
+                                   const char *key,
+                                   int64_t default_value,
+                                   const char *dsptr);
+
 /// get value of a key in some section, the value should be decimal in range of double
 /// this function is not thread safe if dsn_config_set is concurrently called
 double dsn_config_get_value_double(const char *section,

--- a/src/core/core/config_api.cpp
+++ b/src/core/core/config_api.cpp
@@ -35,6 +35,14 @@ uint64_t dsn_config_get_value_uint64(const char *section,
     return g_config.get_value<uint64_t>(section, key, default_value, dsptr);
 }
 
+int64_t dsn_config_get_value_int64(const char *section,
+                                   const char *key,
+                                   int64_t default_value,
+                                   const char *dsptr)
+{
+    return g_config.get_value<int64_t>(section, key, default_value, dsptr);
+}
+
 double dsn_config_get_value_double(const char *section,
                                    const char *key,
                                    double default_value,


### PR DESCRIPTION
this API is mistakenly removed from last pr due to merge from a old commit.
