### PR TITLE
replication: some rename refactors

### DIFF
--- a/include/dsn/dist/replication/meta_service_app.h
+++ b/include/dsn/dist/replication/meta_service_app.h
@@ -37,9 +37,6 @@
 
 #include <dsn/cpp/service_app.h>
 
-dsn::error_code dsn_meta_server_bridge(int argc, char **argv);
-void dsn_meta_sever_register_providers();
-
 namespace dsn {
 namespace replication {
 
@@ -58,6 +55,9 @@ namespace service {
 class meta_service_app : public service_app
 {
 public:
+    static void register_components();
+    static void register_all();
+
     meta_service_app(const service_app_info *info);
     virtual ~meta_service_app();
 

--- a/include/dsn/dist/replication/replication_service_app.h
+++ b/include/dsn/dist/replication/replication_service_app.h
@@ -38,8 +38,6 @@
 #include <dsn/utility/autoref_ptr.h>
 #include <dsn/cpp/service_app.h>
 
-dsn::error_code dsn_layer2_stateful_type1_bridge(int argc, char **argv);
-
 namespace dsn {
 namespace replication {
 
@@ -54,6 +52,8 @@ typedef dsn::ref_ptr<replica_stub> replica_stub_ptr;
 class replication_service_app : public ::dsn::service_app
 {
 public:
+    static void register_all();
+
     replication_service_app(const dsn::service_app_info *info);
 
     virtual ~replication_service_app(void);

--- a/src/apps/skv/CMakeLists.txt
+++ b/src/apps/skv/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_PROJ_INC_PATH "")
 
 set(MY_BOOST_PACKAGES system filesystem)
 
-set(MY_PROJ_LIBS dsn_layer2_stateful_type1 dsn_meta_server fmt)
+set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server fmt)
 
 set(MY_PROJ_LIB_PATH "")
 

--- a/src/apps/skv/simple_kv.main.cpp
+++ b/src/apps/skv/simple_kv.main.cpp
@@ -47,8 +47,8 @@ static void dsn_app_registration_simple_kv()
 {
     dsn::replication::application::simple_kv_service_impl::register_service();
 
-    dsn_meta_server_bridge(0, nullptr);
-    dsn_layer2_stateful_type1_bridge(0, nullptr);
+    dsn::service::meta_service_app::register_all();
+    dsn::replication::replication_service_app::register_all();
 
     dsn::service_app::register_factory<dsn::replication::application::simple_kv_client_app>(
         "client");

--- a/src/dist/replication/lib/CMakeLists.txt
+++ b/src/dist/replication/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MY_PROJ_NAME dsn_layer2_stateful_type1)
+set(MY_PROJ_NAME dsn_replica_server)
 
 # Source files under CURRENT project directory will be automatically included.
 # You can manually set MY_PROJ_SRC to include source files under other directories.

--- a/src/dist/replication/lib/replication_service_app.cpp
+++ b/src/dist/replication/lib/replication_service_app.cpp
@@ -37,14 +37,13 @@
 #include "dist/replication/client_lib/replication_common.h"
 #include "replica_stub.h"
 
-dsn::error_code dsn_layer2_stateful_type1_bridge(int argc, char **argv)
-{
-    dsn::service_app::register_factory<::dsn::replication::replication_service_app>("replica");
-    return dsn::ERR_OK;
-}
-
 namespace dsn {
 namespace replication {
+
+void replication_service_app::register_all()
+{
+    dsn::service_app::register_factory<replication_service_app>("replica");
+}
 
 replication_service_app::replication_service_app(const service_app_info *info) : service_app(info)
 {

--- a/src/dist/replication/test/meta_test/unit_test/main.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/main.cpp
@@ -88,7 +88,7 @@ dsn::error_code meta_service_test_app::start(const std::vector<std::string> &arg
 GTEST_API_ int main(int argc, char **argv)
 {
     dsn::service_app::register_factory<meta_service_test_app>("test_meta");
-    dsn_meta_server_bridge(0, nullptr);
+    dsn::service::meta_service_app::register_all();
     if (argc < 2)
         dassert(dsn_run_config("config-test.ini", false), "");
     else

--- a/src/dist/replication/test/replica_test/unit_test/CMakeLists.txt
+++ b/src/dist/replication/test/replica_test/unit_test/CMakeLists.txt
@@ -12,7 +12,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_INC_PATH "")
 
 set(MY_PROJ_LIBS dsn_meta_server
-                 dsn_layer2_stateful_type1
+                 dsn_replica_server
                  dsn.replication.zookeeper_provider
                  dsn.replication.clientlib
                  dsn.block_service.local

--- a/src/dist/replication/test/simple_kv/CMakeLists.txt
+++ b/src/dist/replication/test/simple_kv/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_BOOST_PACKAGES system filesystem)
 
 set(MY_PROJ_LIBS gtest
                  dsn_runtime
-                 dsn_layer2_stateful_type1
+                 dsn_replica_server
                  dsn_meta_server
                  dsn.replication.clientlib
                  dsn.block_service.local

--- a/src/dist/replication/test/simple_kv/simple_kv.main.cpp
+++ b/src/dist/replication/test/simple_kv/simple_kv.main.cpp
@@ -43,8 +43,8 @@ void dsn_app_registration_simple_kv()
 {
     dsn::replication::test::simple_kv_service_impl::register_service();
 
-    dsn_meta_server_bridge(0, nullptr);
-    dsn_layer2_stateful_type1_bridge(0, nullptr);
+    dsn::service::meta_service_app::register_all();
+    dsn::replication::replication_service_app::register_all();
 
     dsn::service_app::register_factory<dsn::replication::test::simple_kv_client_app>("client");
     dsn::tools::register_toollet<dsn::replication::test::test_injector>("test_injector");

--- a/src/tests/dsn/CMakeLists.txt
+++ b/src/tests/dsn/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 set(MY_PROJ_LIBS 
     dsn_meta_server
-    dsn_layer2_stateful_type1
+    dsn_replica_server
     dsn.replication.clientlib
     dsn.block_service.local
     dsn.block_service.fds

--- a/src/tools/repli/CMakeLists.txt
+++ b/src/tools/repli/CMakeLists.txt
@@ -14,7 +14,7 @@ set(MY_PROJ_INC_PATH "")
 set(MY_BOOST_PACKAGES system filesystem)
 
 set(MY_PROJ_LIB_PATH "")
-set(MY_PROJ_LIBS dsn_layer2_stateful_type1
+set(MY_PROJ_LIBS dsn_replica_server
                  dsn.replication.clientlib
                  dsn.block_service.local
                  dsn.block_service.fds


### PR DESCRIPTION
1. rename initialization functions of replica_server/meta_server
   as the feature of loading shared library when running process
   has removed
2. rename dsn_layer2_stateful_type1 to dsn_replica_server
3. small refactor on meta_server's components init procedure