### PR TITLE
json_helper: bug fix

### DIFF
--- a/include/dsn/c/api_utilities.h
+++ b/include/dsn/c/api_utilities.h
@@ -126,6 +126,16 @@ extern DSN_API void dsn_coredump();
 #define dverify(exp)                                                                               \
     if (!(exp))                                                                                    \
     return false
+
+#define dverify_exception(exp)                                                                     \
+    do {                                                                                           \
+        try {                                                                                      \
+            exp;                                                                                   \
+        } catch (...) {                                                                            \
+            return false;                                                                          \
+        }                                                                                          \
+    } while (0)
+
 #define dverify_logged(exp, level, ...)                                                            \
     do {                                                                                           \
         if (!(exp)) {                                                                              \

--- a/src/core/tests/json_helper_test.cpp
+++ b/src/core/tests/json_helper_test.cpp
@@ -40,13 +40,31 @@ private:
     const int private_const_field = 4;
 
 public:
-    DEFINE_JSON_SERIALIZATION(field, const_field, private_field, private_const_field);
+    DEFINE_JSON_SERIALIZATION(field, const_field, private_field, private_const_field)
 
     bool operator==(const test_entity &rhs) const
     {
         return field == rhs.field && const_field == rhs.const_field &&
                private_field == rhs.private_field && private_const_field == rhs.private_const_field;
     }
+};
+
+struct older_struct
+{
+    int a;
+    std::string b;
+    std::map<std::string, std::string> c;
+    DEFINE_JSON_SERIALIZATION(a, b, c)
+};
+
+struct newer_struct
+{
+    int a;
+    std::string b;
+    std::map<std::string, std::string> c;
+    std::vector<int> d;
+    std::map<int, int> e;
+    DEFINE_JSON_SERIALIZATION(a, b, c, d, e)
 };
 
 // This test verifies that json_forwarder can correctly encode an object with private
@@ -63,6 +81,46 @@ TEST(json_helper, encode_and_decode)
     dsn::json::json_forwarder<test_entity>::decode(encoded_entity, decoded_entity);
 
     ASSERT_EQ(entity, decoded_entity);
+}
+
+TEST(json_helper, struct_add_fields)
+{
+    // newer version of json cann't be decoded with older version of struct
+    newer_struct n;
+    n.a = 1;
+    n.b = "hehe";
+    n.c = {{"aa", "bb"}, {"cc", "dd"}};
+    n.d = {1, 3, 4};
+    n.e = {{1, 4}, {2, 3}};
+    blob bb = dsn::json::json_forwarder<newer_struct>::encode(n);
+
+    older_struct o;
+    o.a = -1;
+    o.b = "xixi";
+    dsn::json::string_tokenizer tok(bb.data(), 0, bb.length());
+    bool result = o.decode_json_state(tok);
+    ASSERT_FALSE(result);
+}
+
+TEST(json_helper, decode_invalid_json)
+{
+    // decode from invalid json
+    const char *json[] = {
+        "{\"a\":1,\"b\":\"hehe\",\"c\":{\"aa\":\"bb\",\"cc\":\"dd\"},\"c\":[1,3,4],"
+        "\"d\":{\"1\":4,\"2\":3},\"hehe\"}",
+        "{\"c\":1}",
+        "{\"a\":1,\"xxx\":\"hehe\"}",
+        "{\"a\":1,\"b\":\"hehe\"",
+        "{\"a\":1,\"b\":\"hehe\",",
+        "{\"a\":1,\"b\":\"hehe\",}",
+        "{\"a\":1,\"b\":\"hehe\",{\"x\":\"y\"}}}",
+        nullptr};
+
+    older_struct o;
+    for (int i = 0; json[i]; ++i) {
+        dsn::json::string_tokenizer in(json[i], 0, strlen(json[i]));
+        ASSERT_FALSE(o.decode_json_state(in));
+    }
 }
 
 } // namespace dsn


### PR DESCRIPTION
1. encode map's key to string, which is a requirement of json's standard
