### PR TITLE
utils: support decoding json into a const object

### DIFF
--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -595,6 +595,13 @@ public:
         dsn::json::string_tokenizer tokenizer(bb);
         return decode(tokenizer, t);
     }
+
+    // decode the member that's const qualified.
+    static bool decode(string_tokenizer &in, const T &t)
+    {
+        using MutableT = typename std::remove_const<T>::type;
+        return decode_inner(in, const_cast<MutableT &>(t), has_json_state{}, p_has_json_state{});
+    }
 };
 
 inline void json_encode(std::stringstream &out, const dsn::partition_configuration &config)

--- a/src/core/tests/json_helper_test.cpp
+++ b/src/core/tests/json_helper_test.cpp
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <gtest/gtest.h>
+#include <dsn/cpp/json_helper.h>
+
+namespace dsn {
+
+class test_entity
+{
+public:
+    int field = 1;
+    const int const_field = 2;
+
+private:
+    int private_field = 3;
+    const int private_const_field = 4;
+
+public:
+    DEFINE_JSON_SERIALIZATION(field, const_field, private_field, private_const_field);
+
+    bool operator==(const test_entity &rhs) const
+    {
+        return field == rhs.field && const_field == rhs.const_field &&
+               private_field == rhs.private_field && private_const_field == rhs.private_const_field;
+    }
+};
+
+// This test verifies that json_forwarder can correctly encode an object with private
+// and const fields.
+TEST(json_helper, encode_and_decode)
+{
+    test_entity entity;
+    entity.field =
+        5; // ensures that `entity` doesn't equal to the default value of `decoded_entity`
+
+    blob encoded_entity = dsn::json::json_forwarder<test_entity>::encode(entity);
+
+    test_entity decoded_entity;
+    dsn::json::json_forwarder<test_entity>::decode(encoded_entity, decoded_entity);
+
+    ASSERT_EQ(entity, decoded_entity);
+}
+
+} // namespace dsn


### PR DESCRIPTION
现在 json_helper 不支持把 json 序列化到 const 对象里. 比如下面代码

```cpp
struct info {
  const int a;
};

dsn::json::json_forwarder<info>::decode(json, decoded_info);
```

编译时会报错.

我们现在的很多代码选择不用 const 定义, 使得可读性比较差, 不注释的话看不出来变量会不会在某处被修改.
这个问题在代码复杂的场景尤其明显.
