### PR TITLE
meta_server: introduce get_children for mss::meta_storage

### DIFF
--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -44,6 +44,7 @@
 #include "dist/replication/client_lib/replication_common.h"
 #include "dist/replication/meta_server/meta_options.h"
 #include "dist/replication/meta_server/meta_backup_service.h"
+#include "dist/replication/meta_server/meta_state_service_utils.h"
 #include "dist/replication/client_lib/block_service_manager.h"
 
 class meta_service_test_app;
@@ -73,7 +74,11 @@ public:
 
     const replication_options &get_options() const { return _opts; }
     const meta_options &get_meta_options() const { return _meta_opts; }
-    dist::meta_state_service *get_remote_storage() { return _storage.get(); }
+
+    /// DEPRECATE: use mss::meta_storage instead.
+    dist::meta_state_service *get_remote_storage() const { return _storage.get(); }
+    mss::meta_storage *get_meta_storage() const { return _meta_storage.get(); }
+
     server_state *get_server_state() { return _state.get(); }
     server_load_balancer *get_balancer() { return _balancer.get(); }
     block_service_manager &get_block_service_manager() { return _block_service_manager; }
@@ -173,7 +178,10 @@ private:
 
     std::shared_ptr<server_state> _state;
     std::shared_ptr<meta_server_failure_detector> _failure_detector;
+
     std::shared_ptr<dist::meta_state_service> _storage;
+    std::unique_ptr<mss::meta_storage> _meta_storage;
+
     std::shared_ptr<server_load_balancer> _balancer;
     std::shared_ptr<backup_service> _backup_handler;
 

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -75,7 +75,7 @@ public:
     const replication_options &get_options() const { return _opts; }
     const meta_options &get_meta_options() const { return _meta_opts; }
 
-    /// DEPRECATE: use mss::meta_storage instead.
+    /// NOTE: prefer using mss::meta_storage instead.
     dist::meta_state_service *get_remote_storage() const { return _storage.get(); }
     mss::meta_storage *get_meta_storage() const { return _meta_storage.get(); }
 

--- a/src/dist/replication/meta_server/meta_state_service_utils.cpp
+++ b/src/dist/replication/meta_server/meta_state_service_utils.cpp
@@ -104,7 +104,7 @@ void meta_storage::get_data(std::string &&node, std::function<void(const blob &)
 }
 
 void meta_storage::get_children(std::string &&node,
-                                std::function<void(const std::vector<std::string> &)> &&cb)
+                                std::function<void(bool, const std::vector<std::string> &)> &&cb)
 {
     on_get_children op;
     op.initialize(this);

--- a/src/dist/replication/meta_server/meta_state_service_utils.cpp
+++ b/src/dist/replication/meta_server/meta_state_service_utils.cpp
@@ -103,6 +103,15 @@ void meta_storage::get_data(std::string &&node, std::function<void(const blob &)
     op.run();
 }
 
+void meta_storage::get_children(std::string &&node,
+                                std::function<void(const std::vector<std::string> &)> &&cb)
+{
+    on_get_children op;
+    op.initialize(this);
+    op.args.reset(new on_get_children::arguments{std::move(cb), std::move(node)});
+    op.run();
+}
+
 } // namespace mss
 } // namespace replication
 } // namespace dsn

--- a/src/dist/replication/meta_server/meta_state_service_utils.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils.h
@@ -69,10 +69,11 @@ struct meta_storage
     void get_data(std::string &&node, std::function<void(const blob &)> &&cb);
 
     /// Will fatal if node doesn't exists.
-    /// \param cb: void (const std::vector<std::string> &children)
+    /// \param cb: void (bool node_exists, const std::vector<std::string> &children)
     ///            `children` contains the name (not full path) of children nodes.
+    ///            `node_exists` indicates whether this node exists.
     void get_children(std::string &&node,
-                      std::function<void(const std::vector<std::string> &)> &&cb);
+                      std::function<void(bool, const std::vector<std::string> &)> &&cb);
 
 private:
     void delete_node_impl(std::string &&node, std::function<void()> &&cb, bool is_recursive);

--- a/src/dist/replication/meta_server/meta_state_service_utils.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils.h
@@ -57,10 +57,8 @@ struct meta_storage
 
     void create_node(std::string &&node, blob &&value, std::function<void()> &&cb);
 
-    /// Will fatal if node doesn't exists.
     void delete_node_recursively(std::string &&node, std::function<void()> &&cb);
 
-    /// Will fatal if node doesn't exists.
     void delete_node(std::string &&node, std::function<void()> &&cb);
 
     /// Will fatal if node doesn't exists.

--- a/src/dist/replication/meta_server/meta_state_service_utils.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils.h
@@ -33,7 +33,7 @@ namespace replication {
 namespace mss { // abbreviation of meta_state_service
 
 /// This class is a convenience wrapper over meta_state_service.
-/// It wraps every operation in an error handling mechanism, and provides utilities
+/// It wraps every operation with a simple error handling mechanism, and provides utilities
 /// like recursive node creation.
 /// Notice: The operations always run in THREAD_POOL_META_STATE: LPC_META_STATE_HIGH.
 ///         This class is thread-safe.
@@ -41,7 +41,8 @@ namespace mss { // abbreviation of meta_state_service
 /// ERROR HANDLING:
 /// Currently it retries for every timeout(ERR_TIMEOUT) operation infinitely,
 /// and delays 1sec for each attempt. For unexpected failures it will terminate
-/// the program.
+/// the program. This is somewhat brute force but suitable for most cases.
+/// For more fine-grained error handling strategy, use meta_state_service instead.
 /// \see meta_state_service_utils_impl.h # operation
 struct meta_storage
 {

--- a/src/dist/replication/meta_server/meta_state_service_utils.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils.h
@@ -68,7 +68,6 @@ struct meta_storage
     /// If node does not exist, cb will receive an empty blob.
     void get_data(std::string &&node, std::function<void(const blob &)> &&cb);
 
-    /// Will fatal if node doesn't exists.
     /// \param cb: void (bool node_exists, const std::vector<std::string> &children)
     ///            `children` contains the name (not full path) of children nodes.
     ///            `node_exists` indicates whether this node exists.

--- a/src/dist/replication/meta_server/meta_state_service_utils_impl.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils_impl.h
@@ -284,7 +284,7 @@ struct on_get_children : operation
 {
     struct arguments
     {
-        std::function<void(const std::vector<std::string> &)> cb;
+        std::function<void(bool, const std::vector<std::string> &)> cb;
         std::string node;
     };
     std::shared_ptr<arguments> args;
@@ -303,7 +303,11 @@ struct on_get_children : operation
     void on_error(error_code ec, const std::vector<std::string> &children)
     {
         if (ec == ERR_OK) {
-            args->cb(children);
+            args->cb(true, children);
+            return;
+        }
+        if (ec == ERR_OBJECT_NOT_FOUND) {
+            args->cb(false, children);
             return;
         }
         operation::on_error(this, op_type::OP_GET_CHILDREN, ec, args->node);

--- a/src/dist/replication/meta_server/meta_state_service_utils_impl.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils_impl.h
@@ -47,6 +47,7 @@ struct op_type
         OP_DELETE,
         OP_SET_DATA,
         OP_GET_DATA,
+        OP_GET_CHILDREN,
     };
 
     static const char *to_string(type v)
@@ -58,6 +59,7 @@ struct op_type
             "OP_DELETE",
             "OP_SET_DATA",
             "OP_GET_DATA",
+            "OP_GET_CHILDREN",
         };
 
         dassert_f(v != OP_NONE && v <= (sizeof(op_type_to_string_map) / sizeof(char *)),
@@ -275,6 +277,36 @@ struct on_set_data : operation
         }
 
         operation::on_error(this, op_type::OP_SET_DATA, ec, args->node);
+    }
+};
+
+struct on_get_children : operation
+{
+    struct arguments
+    {
+        std::function<void(const std::vector<std::string> &)> cb;
+        std::string node;
+    };
+    std::shared_ptr<arguments> args;
+
+    void run()
+    {
+        remote_storage()->get_children(
+            args->node,
+            LPC_META_STATE_HIGH,
+            [op = *this](error_code ec, const std::vector<std::string> &children) mutable {
+                op.on_error(ec, children);
+            },
+            tracker());
+    }
+
+    void on_error(error_code ec, const std::vector<std::string> &children)
+    {
+        if (ec == ERR_OK) {
+            args->cb(children);
+            return;
+        }
+        operation::on_error(this, op_type::OP_GET_CHILDREN, ec, args->node);
     }
 };
 

--- a/src/dist/replication/test/meta_test/unit_test/meta_state_service_utils_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_state_service_utils_test.cpp
@@ -141,3 +141,29 @@ TEST_F(meta_state_service_utils_test, concurrent)
     }
     _tracker.wait_outstanding_tasks();
 }
+
+TEST_F(meta_state_service_utils_test, get_children)
+{
+    _storage->create_node("/1", dsn::blob(), [this]() {
+        _storage->create_node("/1/99", dsn::blob(), [this]() {});
+        _storage->create_node("/1/999", dsn::blob(), [this]() {});
+        _storage->create_node("/1/9999", dsn::blob(), [this]() {});
+    });
+    _tracker.wait_outstanding_tasks();
+
+    _storage->get_children("/1", [](const std::vector<std::string> &children) {
+        auto children_copy = children;
+        std::sort(children_copy.begin(), children_copy.end());
+        ASSERT_EQ(children_copy, std::vector<std::string>({"99", "999", "9999"}));
+    });
+    _tracker.wait_outstanding_tasks();
+
+    _storage->delete_node("/1/99", []() {});
+    _storage->delete_node("/1/999", []() {});
+    _storage->delete_node("/1/9999", []() {});
+    _tracker.wait_outstanding_tasks();
+
+    _storage->get_children(
+        "/1", [](const std::vector<std::string> &children) { ASSERT_EQ(children.size(), 0); });
+    _tracker.wait_outstanding_tasks();
+}

--- a/src/dist/replication/test/meta_test/unit_test/meta_state_service_utils_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_state_service_utils_test.cpp
@@ -151,7 +151,9 @@ TEST_F(meta_state_service_utils_test, get_children)
     });
     _tracker.wait_outstanding_tasks();
 
-    _storage->get_children("/1", [](const std::vector<std::string> &children) {
+    _storage->get_children("/1", [](bool node_exists, const std::vector<std::string> &children) {
+        ASSERT_TRUE(node_exists);
+
         auto children_copy = children;
         std::sort(children_copy.begin(), children_copy.end());
         ASSERT_EQ(children_copy, std::vector<std::string>({"99", "999", "9999"}));
@@ -163,7 +165,18 @@ TEST_F(meta_state_service_utils_test, get_children)
     _storage->delete_node("/1/9999", []() {});
     _tracker.wait_outstanding_tasks();
 
-    _storage->get_children(
-        "/1", [](const std::vector<std::string> &children) { ASSERT_EQ(children.size(), 0); });
+    _storage->get_children("/1", [](bool node_exists, const std::vector<std::string> &children) {
+        ASSERT_TRUE(node_exists);
+        ASSERT_EQ(children.size(), 0);
+    });
+    _tracker.wait_outstanding_tasks();
+
+    _storage->delete_node_recursively("/1", []() {});
+    _tracker.wait_outstanding_tasks();
+
+    _storage->get_children("/1", [](bool node_exists, const std::vector<std::string> &children) {
+        ASSERT_FALSE(node_exists);
+        ASSERT_EQ(children.size(), 0);
+    });
     _tracker.wait_outstanding_tasks();
 }


### PR DESCRIPTION
`get_children` wraps upon the original `meta_state_service::get_children` and exposing similar interface.