### PR TITLE
json: bug fix of json decode & encode

### DIFF
--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -43,6 +43,9 @@
 #include <string>
 #include <type_traits>
 #include <cctype>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/writer.h>
+#include <rapidjson/document.h>
 #include <boost/lexical_cast.hpp>
 #include <dsn/utility/autoref_ptr.h>
 #include <dsn/utility/utils.h>
@@ -50,61 +53,53 @@
 #include <dsn/dist/replication/replication_types.h>
 #include <dsn/dist/replication/replication_enums.h>
 
-#define JsonSplitter "{}[]:,\""
-
 #define JSON_ENCODE_ENTRY(out, prefix, T)                                                          \
-    out << "\"" #T "\":";                                                                          \
+    out.Key(#T);                                                                                   \
     ::dsn::json::json_forwarder<std::decay<decltype((prefix).T)>::type>::encode(out, (prefix).T)
 #define JSON_ENCODE_ENTRIES2(out, prefix, T1, T2)                                                  \
     JSON_ENCODE_ENTRY(out, prefix, T1);                                                            \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T2)
 #define JSON_ENCODE_ENTRIES3(out, prefix, T1, T2, T3)                                              \
     JSON_ENCODE_ENTRIES2(out, prefix, T1, T2);                                                     \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T3)
 #define JSON_ENCODE_ENTRIES4(out, prefix, T1, T2, T3, T4)                                          \
     JSON_ENCODE_ENTRIES3(out, prefix, T1, T2, T3);                                                 \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T4)
 #define JSON_ENCODE_ENTRIES5(out, prefix, T1, T2, T3, T4, T5)                                      \
     JSON_ENCODE_ENTRIES4(out, prefix, T1, T2, T3, T4);                                             \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T5)
 #define JSON_ENCODE_ENTRIES6(out, prefix, T1, T2, T3, T4, T5, T6)                                  \
     JSON_ENCODE_ENTRIES5(out, prefix, T1, T2, T3, T4, T5);                                         \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T6)
 #define JSON_ENCODE_ENTRIES7(out, prefix, T1, T2, T3, T4, T5, T6, T7)                              \
     JSON_ENCODE_ENTRIES6(out, prefix, T1, T2, T3, T4, T5, T6);                                     \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T7)
 #define JSON_ENCODE_ENTRIES8(out, prefix, T1, T2, T3, T4, T5, T6, T7, T8)                          \
     JSON_ENCODE_ENTRIES7(out, prefix, T1, T2, T3, T4, T5, T6, T7);                                 \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T8)
 #define JSON_ENCODE_ENTRIES9(out, prefix, T1, T2, T3, T4, T5, T6, T7, T8, T9)                      \
     JSON_ENCODE_ENTRIES8(out, prefix, T1, T2, T3, T4, T5, T6, T7, T8);                             \
-    out << ",";                                                                                    \
     JSON_ENCODE_ENTRY(out, prefix, T9)
 
 #define JSON_DECODE_ENTRY(in, prefix, T)                                                           \
     do {                                                                                           \
-        dverify(in.expect_token("\"" #T "\""));                                                    \
-        dverify(in.expect_token(':'));                                                             \
+        dverify(in.HasMember(#T));                                                                 \
         dverify(::dsn::json::json_forwarder<std::decay<decltype((prefix).T)>::type>::decode(       \
-            in, (prefix).T));                                                                      \
+            in[#T], (prefix).T));                                                                  \
     } while (0)
 
 #define JSON_TRY_DECODE_ENTRY(in, prefix, T)                                                       \
     do {                                                                                           \
-        if (in.verify_token(',')) {                                                                \
-            JSON_DECODE_ENTRY(in, prefix, T);                                                      \
+        ++arguments_count;                                                                         \
+        if (in.HasMember(#T)) {                                                                    \
+            dverify(::dsn::json::json_forwarder<std::decay<decltype((prefix).T)>::type>::decode(   \
+                in[#T], (prefix).T));                                                              \
+            ++parsed_count;                                                                        \
         }                                                                                          \
     } while (0)
 
 #define JSON_DECODE_ENTRIES2(in, prefix, T1, T2)                                                   \
-    JSON_DECODE_ENTRY(in, prefix, T1);                                                             \
+    JSON_TRY_DECODE_ENTRY(in, prefix, T1);                                                         \
     JSON_TRY_DECODE_ENTRY(in, prefix, T2)
 #define JSON_DECODE_ENTRIES3(in, prefix, T1, T2, T3)                                               \
     JSON_DECODE_ENTRIES2(in, prefix, T1, T2);                                                      \
@@ -133,7 +128,7 @@
 #define JSON_ENTRIES_GET_MACRO_(tuple) JSON_ENTRIES_GET_MACRO tuple
 
 #define JSON_ENCODE_ENTRIES(out, prefix, ...)                                                      \
-    out << "{";                                                                                    \
+    out.StartObject();                                                                             \
     JSON_ENTRIES_GET_MACRO_((__VA_ARGS__,                                                          \
                              JSON_ENCODE_ENTRIES9,                                                 \
                              JSON_ENCODE_ENTRIES8,                                                 \
@@ -145,10 +140,12 @@
                              JSON_ENCODE_ENTRIES2,                                                 \
                              JSON_ENCODE_ENTRY))                                                   \
     (out, prefix, __VA_ARGS__);                                                                    \
-    out << "}"
+    out.EndObject()
 
 #define JSON_DECODE_ENTRIES(in, prefix, ...)                                                       \
-    dverify(in.expect_token('{'));                                                                 \
+    dverify(in.IsObject());                                                                        \
+    int arguments_count = 0;                                                                       \
+    int parsed_count = 0;                                                                          \
     JSON_ENTRIES_GET_MACRO_((__VA_ARGS__,                                                          \
                              JSON_DECODE_ENTRIES9,                                                 \
                              JSON_DECODE_ENTRIES8,                                                 \
@@ -160,14 +157,20 @@
                              JSON_DECODE_ENTRIES2,                                                 \
                              JSON_DECODE_ENTRY))                                                   \
     (in, prefix, __VA_ARGS__);                                                                     \
-    return in.expect_token('}')
+    return parsed_count == arguments_count || parsed_count == in.MemberCount();
 
 #define DEFINE_JSON_SERIALIZATION(...)                                                             \
-    void encode_json_state(std::stringstream &out) const                                           \
+    void encode_json_state(std::ostream &os)                                                       \
+    {                                                                                              \
+        rapidjson::OStreamWrapper wrapper(os);                                                     \
+        dsn::json::JsonWriter w(wrapper);                                                          \
+        encode_json_state(w);                                                                      \
+    }                                                                                              \
+    void encode_json_state(dsn::json::JsonWriter &out) const                                       \
     {                                                                                              \
         JSON_ENCODE_ENTRIES(out, *this, __VA_ARGS__);                                              \
     }                                                                                              \
-    bool decode_json_state(dsn::json::string_tokenizer &in)                                        \
+    bool decode_json_state(const dsn::json::JsonObject &in)                                        \
     {                                                                                              \
         JSON_DECODE_ENTRIES(in, *this, __VA_ARGS__);                                               \
     }
@@ -175,157 +178,81 @@
 namespace dsn {
 namespace json {
 
-class string_tokenizer
-{
-private:
-    const char *buffer;
-    unsigned pos;
-    unsigned length;
-
-public:
-    static bool is_json_splitter(char token)
-    {
-        const char *s = JsonSplitter;
-        for (int i = 0; s[i]; ++i)
-            if (s[i] == token)
-                return true;
-        return false;
-    }
-
-public:
-    string_tokenizer(const char *b, unsigned offset, unsigned len)
-        : buffer(b), pos(offset), length(len)
-    {
-        dassert(pos < length, "%u vs %u", pos, length);
-    }
-    string_tokenizer(const dsn::blob &source, unsigned from)
-        : string_tokenizer(source.data(), from, source.length())
-    {
-    }
-    string_tokenizer(const dsn::blob &source) : string_tokenizer(source.data(), 0, source.length())
-    {
-    }
-    string_tokenizer(const std::string &source, unsigned from)
-        : string_tokenizer(source.c_str(), from, source.size())
-    {
-    }
-    string_tokenizer(const std::string &source) : string_tokenizer(source.c_str(), 0, source.size())
-    {
-    }
-
-    bool expect_token(const char *token)
-    {
-        while (pos < length && isblank(buffer[pos]))
-            ++pos;
-        int j = 0;
-        while (pos < length && token[j] != 0 && buffer[pos] == token[j])
-            ++pos, ++j;
-        if (token[j] != 0) {
-            return false;
-        }
-        return true;
-    }
-    bool expect_token(char token)
-    {
-        while (pos < length && isblank(buffer[pos]))
-            ++pos;
-        if (pos < length && buffer[pos] == token)
-            ++pos;
-        else {
-            return false;
-        }
-        return true;
-    }
-    bool verify_token(char token)
-    {
-        while (pos < length && isblank(buffer[pos]))
-            ++pos;
-        if (pos < length && buffer[pos] == token) {
-            ++pos;
-            return true;
-        }
-        return false;
-    }
-    char peek_next() const
-    {
-        int i = pos;
-        while (i < length && isblank(buffer[i]))
-            ++i;
-        return buffer[i];
-    }
-    bool walk_until(char token)
-    {
-        while (pos < length && buffer[pos] != token)
-            ++pos;
-        if (pos < length && buffer[pos] == token)
-            return true;
-        else {
-            return false;
-        }
-    }
-    bool walk_until_json_splitter()
-    {
-        while (pos < length && !is_json_splitter(buffer[pos]))
-            ++pos;
-        return pos < length;
-    }
-    unsigned tell() const { return pos; }
-    void forward() { ++pos; }
-    // assign substring [from, to) in buffer to output
-    void assign(unsigned from, unsigned to, std::string &output)
-    {
-        output.assign(buffer + from, to - from);
-    }
-};
+typedef rapidjson::GenericValue<rapidjson::UTF8<>> JsonObject;
+typedef rapidjson::Writer<rapidjson::OStreamWrapper> JsonWriter;
 
 template <typename>
 class json_forwarder;
 
-#define DSN_BASE_TYPE_JSON_STATE(TName)                                                            \
-    inline void json_encode(std::stringstream &out, const TName &t) { out << t; }                  \
-    inline bool json_decode(string_tokenizer &in, TName &t)                                        \
-    {                                                                                              \
-        int start_pos = in.tell();                                                                 \
-        dverify(in.walk_until_json_splitter());                                                    \
-        std::string string_data;                                                                   \
-        in.assign(start_pos, in.tell(), string_data);                                              \
-        std::istringstream is(string_data);                                                        \
-        is >> t;                                                                                   \
-        return true;                                                                               \
-    }
-
-DSN_BASE_TYPE_JSON_STATE(bool)
-DSN_BASE_TYPE_JSON_STATE(float)
-DSN_BASE_TYPE_JSON_STATE(double)
-DSN_BASE_TYPE_JSON_STATE(int8_t)
-DSN_BASE_TYPE_JSON_STATE(int16_t)
-DSN_BASE_TYPE_JSON_STATE(int32_t)
-DSN_BASE_TYPE_JSON_STATE(int64_t)
-DSN_BASE_TYPE_JSON_STATE(uint8_t)
-DSN_BASE_TYPE_JSON_STATE(uint16_t)
-DSN_BASE_TYPE_JSON_STATE(uint32_t)
-DSN_BASE_TYPE_JSON_STATE(uint64_t)
-
-inline void json_encode(std::stringstream &out, const std::string &t) { out << "\"" << t << "\""; }
-
-inline void json_encode(std::stringstream &out, const char *t) { out << "\"" << t << "\""; }
-
-inline bool json_decode(string_tokenizer &in, std::string &t)
+inline void json_encode(JsonWriter &out, const std::string &str)
 {
-    dverify(in.expect_token('\"'));
-    unsigned start_pos = in.tell();
-    dverify(in.walk_until('\"'));
-    in.assign(start_pos, in.tell(), t);
-    in.forward();
+    out.String(str.c_str(), str.length(), true);
+}
+inline void json_encode(JsonWriter &out, const char *str) { out.String(str, strlen(str), true); }
+inline bool json_decode(const JsonObject &in, std::string &str)
+{
+    dverify(in.IsString());
+    str = in.GetString();
     return true;
 }
 
-#define ENUM_TYPE_SERIALIZATION(EnumType, InvalidEnum)                                             \
-    inline void json_encode(std::stringstream &out, const EnumType &enum_variable)                 \
+inline void json_encode(JsonWriter &out, bool t) { out.Int(t ? 1 : 0); }
+inline bool json_decode(const JsonObject &in, bool &t)
+{
+    dverify(in.IsInt());
+    int ans = in.GetInt();
+    t = (ans != 0);
+    return true;
+}
+
+inline void json_encode(JsonWriter &out, double d) { out.Double(d); }
+inline bool json_decode(const JsonObject &in, double &t)
+{
+    dverify(in.IsDouble());
+    t = in.GetDouble();
+    return true;
+}
+
+#define INT_TYPE_SERIALIZATION(TName)                                                              \
+    inline void json_encode(JsonWriter &out, TName t) { out.Int64((int64_t)t); }                   \
+    inline bool json_decode(const JsonObject &in, TName &t)                                        \
     {                                                                                              \
-        out << "\"" << enum_to_string(enum_variable) << "\"";                                      \
+        dverify(in.IsInt64());                                                                     \
+        int64_t ans = in.GetInt64();                                                               \
+        dverify(ans >= std::numeric_limits<TName>::min() &&                                        \
+                ans <= std::numeric_limits<TName>::max());                                         \
+        t = (TName)ans;                                                                            \
+        return true;                                                                               \
+    }
+
+#define UINT_TYPE_SERIALIZATION(TName)                                                             \
+    inline void json_encode(JsonWriter &out, TName t) { out.Uint64((uint64_t)t); }                 \
+    inline bool json_decode(const JsonObject &in, TName &t)                                        \
+    {                                                                                              \
+        dverify(in.IsUint64());                                                                    \
+        int64_t ans = in.GetUint64();                                                              \
+        dverify(ans >= std::numeric_limits<TName>::min() &&                                        \
+                ans <= std::numeric_limits<TName>::max());                                         \
+        t = (TName)ans;                                                                            \
+        return true;                                                                               \
+    }
+
+INT_TYPE_SERIALIZATION(int8_t)
+INT_TYPE_SERIALIZATION(int16_t)
+INT_TYPE_SERIALIZATION(int32_t)
+INT_TYPE_SERIALIZATION(int64_t)
+
+UINT_TYPE_SERIALIZATION(uint8_t)
+UINT_TYPE_SERIALIZATION(uint16_t)
+UINT_TYPE_SERIALIZATION(uint32_t)
+UINT_TYPE_SERIALIZATION(uint64_t)
+
+#define ENUM_TYPE_SERIALIZATION(EnumType, InvalidEnum)                                             \
+    inline void json_encode(dsn::json::JsonWriter &out, const EnumType &enum_variable)             \
+    {                                                                                              \
+        dsn::json::json_encode(out, enum_to_string(enum_variable));                                \
     }                                                                                              \
-    inline bool json_decode(dsn::json::string_tokenizer &in, EnumType &enum_variable)              \
+    inline bool json_decode(const dsn::json::JsonObject &in, EnumType &enum_variable)              \
     {                                                                                              \
         std::string status_message;                                                                \
         dverify(dsn::json::json_decode(in, status_message));                                       \
@@ -337,22 +264,22 @@ ENUM_TYPE_SERIALIZATION(dsn::replication::partition_status::type,
                         dsn::replication::partition_status::PS_INVALID)
 ENUM_TYPE_SERIALIZATION(dsn::app_status::type, dsn::app_status::AS_INVALID)
 
-inline void json_encode(std::stringstream &out, const dsn::gpid &pid)
+inline void json_encode(JsonWriter &out, const dsn::gpid &pid)
 {
-    out << "\"" << pid.to_string() << "\"";
+    json_encode(out, pid.to_string());
 }
-inline bool json_decode(dsn::json::string_tokenizer &in, dsn::gpid &pid)
+inline bool json_decode(const dsn::json::JsonObject &in, dsn::gpid &pid)
 {
     std::string gpid_message;
     dverify(json_decode(in, gpid_message));
     return pid.parse_from(gpid_message.c_str());
 }
 
-inline void json_encode(std::stringstream &out, const dsn::rpc_address &address)
+inline void json_encode(JsonWriter &out, const dsn::rpc_address &address)
 {
-    out << "\"" << address.to_string() << "\"";
+    json_encode(out, address.to_string());
 }
-inline bool json_decode(dsn::json::string_tokenizer &in, dsn::rpc_address &address)
+inline bool json_decode(const dsn::json::JsonObject &in, dsn::rpc_address &address)
 {
     std::string rpc_address_string;
     dverify(json_decode(in, rpc_address_string));
@@ -362,156 +289,137 @@ inline bool json_decode(dsn::json::string_tokenizer &in, dsn::rpc_address &addre
     return address.from_string_ipv4(rpc_address_string.c_str());
 }
 
-inline void json_encode(std::stringstream &out, const dsn::partition_configuration &config);
-inline bool json_decode(string_tokenizer &in, dsn::partition_configuration &config);
-inline void json_encode(std::stringstream &out, const dsn::app_info &info);
-inline bool json_decode(string_tokenizer &in, dsn::app_info &info);
+inline void json_encode(JsonWriter &out, const dsn::partition_configuration &config);
+inline bool json_decode(const JsonObject &in, dsn::partition_configuration &config);
+inline void json_encode(JsonWriter &out, const dsn::app_info &info);
+inline bool json_decode(const JsonObject &in, dsn::app_info &info);
 
 template <typename T>
-inline void json_encode_iterable(std::stringstream &out, const T &t)
+inline void json_encode_iterable(JsonWriter &out, const T &t)
 {
-    out << "[";
+    out.StartArray();
     for (auto it = t.begin(); it != t.end(); ++it) {
         json_forwarder<typename std::decay<decltype(*it)>::type>::encode(out, *it);
-        if (std::next(it) != t.end()) {
-            out << ",";
-        }
     }
-    out << "]";
+    out.EndArray();
 }
 
 template <typename T>
-inline void json_encode_map(std::stringstream &out, const T &t)
+inline void json_encode_map(JsonWriter &out, const T &t)
 {
-    out << "{";
+    out.StartObject();
     for (auto it = t.begin(); it != t.end(); ++it) {
         std::string key_string = boost::lexical_cast<std::string>(it->first);
-        json_encode(out, key_string);
-        out << ":";
+        out.Key(key_string.c_str(), key_string.size(), true);
         json_forwarder<typename std::decay<decltype(it->second)>::type>::encode(out, it->second);
-        if (std::next(it) != t.end()) {
-            out << ",";
-        }
     }
-    out << "}";
+    out.EndObject();
 }
 
 template <typename TMap>
-inline bool json_decode_map(string_tokenizer &in, TMap &t)
+inline bool json_decode_map(const JsonObject &in, TMap &t)
 {
+    dverify(in.IsObject());
     t.clear();
-    dverify(in.expect_token('{'));
-    while (in.peek_next() != '}') {
-        if (!t.empty()) {
-            dverify(in.expect_token(','));
-        }
-
-        std::string key_string;
-        dverify(json_decode(in, key_string));
-        typename TMap::key_type key;
-        dverify_exception(key = boost::lexical_cast<typename TMap::key_type>(key_string));
-
+    for (rapidjson::Value::ConstMemberIterator it = in.MemberBegin(); it != in.MemberEnd(); ++it) {
+        typename TMap::key_type key =
+            boost::lexical_cast<typename TMap::key_type>(it->name.GetString());
         typename TMap::mapped_type value;
-        dverify(in.expect_token(':'));
-        dverify(json_forwarder<decltype(value)>::decode(in, value));
-
-        if (!t.emplace(key, value).second) {
+        dverify(json_forwarder<decltype(value)>::decode(it->value, value));
+        if (!t.emplace(key, value).second)
             return false;
-        }
     }
-    return in.expect_token('}');
+    return true;
 }
 
 template <typename T>
-inline void json_encode(std::stringstream &out, const std::vector<T> &t)
+inline void json_encode(JsonWriter &out, const std::vector<T> &t)
 {
     json_encode_iterable(out, t);
 }
 
 template <typename T>
-inline bool json_decode(string_tokenizer &in, std::vector<T> &t)
+inline bool json_decode(const JsonObject &in, std::vector<T> &t)
 {
+    dverify(in.IsArray());
     t.clear();
-    dverify(in.expect_token('['));
-    while (in.peek_next() != ']') {
-        if (!t.empty()) {
-            dverify(in.expect_token(','));
-        }
-        T result;
-        dverify(json_forwarder<T>::decode(in, result));
-        t.emplace_back(std::move(result));
+    t.reserve(in.Size());
+
+    for (rapidjson::Value::ConstValueIterator it = in.Begin(); it != in.End(); ++it) {
+        T value;
+        dverify(json_forwarder<T>::decode(*it, value));
+        t.emplace_back(std::move(value));
     }
-    return in.expect_token(']');
+    return true;
 }
 
 template <typename T>
-inline void json_encode(std::stringstream &out, const std::set<T> &t)
+inline void json_encode(JsonWriter &out, const std::set<T> &t)
 {
     json_encode_iterable(out, t);
 }
 
 template <typename T>
-inline bool json_decode(string_tokenizer &in, std::set<T> &t)
+inline bool json_decode(const JsonObject &in, std::set<T> &t)
 {
+    dverify(in.IsArray());
     t.clear();
-    dverify(in.expect_token('['));
-    while (in.peek_next() != ']') {
-        if (!t.empty()) {
-            dverify(in.expect_token(','));
-        }
-        T result;
-        dverify(json_forwarder<T>::decode(in, result));
-        if (!t.emplace(std::move(result)).second) {
-            return false;
-        }
+
+    for (rapidjson::Value::ConstValueIterator it = in.Begin(); it != in.End(); ++it) {
+        T value;
+        dverify(json_forwarder<T>::decode(*it, value));
+        dverify(t.emplace(std::move(value)).second);
     }
-    return in.expect_token(']');
+    return true;
 }
 
 template <typename T1, typename T2>
-inline void json_encode(std::stringstream &out, const std::unordered_map<T1, T2> &t)
+inline void json_encode(JsonWriter &out, const std::unordered_map<T1, T2> &t)
 {
     json_encode_map(out, t);
 }
 
 template <typename T1, typename T2>
-inline bool json_decode(string_tokenizer &in, std::unordered_map<T1, T2> &t)
+inline bool json_decode(const JsonObject &in, std::unordered_map<T1, T2> &t)
 {
     return json_decode_map(in, t);
 }
 
 template <typename T1, typename T2>
-inline void json_encode(std::stringstream &out, const std::map<T1, T2> &t)
+inline void json_encode(JsonWriter &out, const std::map<T1, T2> &t)
 {
     json_encode_map(out, t);
 }
 
 template <typename T1, typename T2>
-inline bool json_decode(string_tokenizer &in, std::map<T1, T2> &t)
+inline bool json_decode(const JsonObject &in, std::map<T1, T2> &t)
 {
     return json_decode_map(in, t);
 }
 
 template <typename T>
-inline void json_encode(std::stringstream &out, const dsn::ref_ptr<T> &t)
+inline void json_encode(JsonWriter &out, const dsn::ref_ptr<T> &t)
 {
+    assert(t.get() != nullptr);
     json_encode(out, *t);
 }
 
 template <typename T>
-inline bool json_decode(string_tokenizer &in, dsn::ref_ptr<T> &t)
+inline bool json_decode(const JsonObject &in, dsn::ref_ptr<T> &t)
 {
+    t = new T();
     return json_decode(in, *t);
 }
 
 template <typename T>
-inline void json_encode(std::stringstream &out, const std::shared_ptr<T> &t)
+inline void json_encode(JsonWriter &out, const std::shared_ptr<T> &t)
 {
+    assert(t.get() != nullptr);
     json_encode(out, *t);
 }
 
 template <typename T>
-inline bool json_decode(string_tokenizer &in, std::shared_ptr<T> &t)
+inline bool json_decode(const JsonObject &in, std::shared_ptr<T> &t)
 {
     t.reset(new T());
     return json_decode(in, *t);
@@ -524,7 +432,7 @@ private:
     // check if C has C.encode_json_state(sstream&) function
     template <typename C>
     static auto check_json_state(C *) -> typename std::is_same<
-        decltype(std::declval<C>().encode_json_state(std::declval<std::stringstream &>())),
+        decltype(std::declval<C>().encode_json_state(std::declval<::dsn::json::JsonWriter &>())),
         void>::type;
 
     template <typename>
@@ -533,7 +441,7 @@ private:
     // check if C has C->json_state(sstream&) function
     template <typename C>
     static auto p_check_json_state(C *) -> typename std::is_same<
-        decltype(std::declval<C>()->encode_json_state(std::declval<std::stringstream &>())),
+        decltype(std::declval<C>()->encode_json_state(std::declval<::dsn::json::JsonWriter &>())),
         void>::type;
 
     template <typename>
@@ -543,74 +451,87 @@ private:
     typedef decltype(p_check_json_state<T>(0)) p_has_json_state;
 
     // internal serialization
-    static void encode_inner(std::stringstream &out, const T &t, std::true_type, std::false_type)
+    static void encode_inner(JsonWriter &out, const T &t, std::true_type, std::false_type)
     {
         t.encode_json_state(out);
     }
-    static void encode_inner(std::stringstream &out, const T &t, std::false_type, std::true_type)
+    static void encode_inner(JsonWriter &out, const T &t, std::false_type, std::true_type)
     {
         t->encode_json_state(out);
     }
-    static void encode_inner(std::stringstream &out, const T &t, std::true_type, std::true_type)
+    static void encode_inner(JsonWriter &out, const T &t, std::true_type, std::true_type)
     {
         t->encode_json_state(out);
     }
-    static void encode_inner(std::stringstream &out, const T &t, std::false_type, std::false_type)
+    static void encode_inner(JsonWriter &out, const T &t, std::false_type, std::false_type)
     {
         json_encode(out, t);
     }
 
     // internal deserialization
-    static bool decode_inner(string_tokenizer &in, T &t, std::true_type, std::false_type)
+    static bool decode_inner(const JsonObject &in, T &t, std::true_type, std::false_type)
     {
         return t.decode_json_state(in);
     }
-    static bool decode_inner(string_tokenizer &in, T &t, std::false_type, std::true_type)
+    static bool decode_inner(const JsonObject &in, T &t, std::false_type, std::true_type)
     {
         return t->decode_json_state(in);
     }
-    static bool decode_inner(string_tokenizer &in, T &t, std::true_type, std::true_type)
+    static bool decode_inner(const JsonObject &in, T &t, std::true_type, std::true_type)
     {
         return t->decode_json_state(in);
     }
-    static bool decode_inner(string_tokenizer &in, T &t, std::false_type, std::false_type)
+    static bool decode_inner(const JsonObject &in, T &t, std::false_type, std::false_type)
     {
         return json_decode(in, t);
     }
 
 public:
-    static void encode(std::stringstream &out, const T &t)
+    static void encode(JsonWriter &out, const T &t)
     {
         encode_inner(out, t, has_json_state{}, p_has_json_state{});
     }
+    static void encode(std::ostream &os, const T &t)
+    {
+        rapidjson::OStreamWrapper wrapper(os);
+        JsonWriter writer(wrapper);
+        encode(writer, t);
+    }
     static dsn::blob encode(const T &t)
     {
-        std::stringstream out;
-        encode_inner(out, t, has_json_state{}, p_has_json_state{});
-        std::string *result = new std::string(out.str());
+        std::ostringstream os;
+        encode(os, t);
+        std::string *result = new std::string(os.str());
         return dsn::blob(std::shared_ptr<char>(const_cast<char *>(result->c_str()),
                                                [result](char *) { delete result; }),
                          result->length());
     }
-    static bool decode(string_tokenizer &in, T &t)
+
+    static bool decode(const JsonObject &in, T &t)
     {
         return decode_inner(in, t, has_json_state{}, p_has_json_state{});
     }
     static bool decode(const dsn::blob &bb, T &t)
     {
-        dsn::json::string_tokenizer tokenizer(bb);
-        return decode(tokenizer, t);
+        rapidjson::Document doc;
+        dverify(!doc.Parse(bb.data(), bb.length()).HasParseError());
+        return decode(doc, t);
     }
 
     // decode the member that's const qualified.
-    static bool decode(string_tokenizer &in, const T &t)
+    static bool decode(const JsonObject &in, const T &t)
     {
         using MutableT = typename std::remove_const<T>::type;
-        return decode_inner(in, const_cast<MutableT &>(t), has_json_state{}, p_has_json_state{});
+        return decode(in, const_cast<MutableT &>(t));
+    }
+    static bool decode(const dsn::blob &bb, const T &t)
+    {
+        using MutableT = typename std::remove_const<T>::type;
+        return decode(bb, const_cast<MutableT &>(t));
     }
 };
 
-inline void json_encode(std::stringstream &out, const dsn::partition_configuration &config)
+inline void json_encode(JsonWriter &out, const dsn::partition_configuration &config)
 {
     JSON_ENCODE_ENTRIES(out,
                         config,
@@ -623,7 +544,7 @@ inline void json_encode(std::stringstream &out, const dsn::partition_configurati
                         last_committed_decree,
                         partition_flags);
 }
-inline bool json_decode(dsn::json::string_tokenizer &in, dsn::partition_configuration &config)
+inline bool json_decode(const JsonObject &in, dsn::partition_configuration &config)
 {
     JSON_DECODE_ENTRIES(in,
                         config,
@@ -636,7 +557,7 @@ inline bool json_decode(dsn::json::string_tokenizer &in, dsn::partition_configur
                         last_committed_decree,
                         partition_flags);
 }
-inline void json_encode(std::stringstream &out, const dsn::app_info &info)
+inline void json_encode(JsonWriter &out, const dsn::app_info &info)
 {
     JSON_ENCODE_ENTRIES(out,
                         info,
@@ -650,7 +571,7 @@ inline void json_encode(std::stringstream &out, const dsn::app_info &info)
                         max_replica_count,
                         expire_second);
 }
-inline bool json_decode(dsn::json::string_tokenizer &in, dsn::app_info &info)
+inline bool json_decode(const JsonObject &in, dsn::app_info &info)
 {
     JSON_DECODE_ENTRIES(in,
                         info,

--- a/include/dsn/dist/replication/duplication_common.h
+++ b/include/dsn/dist/replication/duplication_common.h
@@ -54,9 +54,9 @@ inline const char *duplication_status_to_string(const duplication_status::type &
     return it->second;
 }
 
-inline void json_encode(std::stringstream &out, const duplication_status::type &s)
+inline void json_encode(dsn::json::JsonWriter &out, const duplication_status::type &s)
 {
-    out << duplication_status_to_string(s);
+    json_encode(out, duplication_status_to_string(s));
 }
 
 inline bool json_decode(const dsn::json::JsonObject &in, duplication_status::type &s)

--- a/include/dsn/dist/replication/duplication_common.h
+++ b/include/dsn/dist/replication/duplication_common.h
@@ -59,7 +59,7 @@ inline void json_encode(std::stringstream &out, const duplication_status::type &
     out << duplication_status_to_string(s);
 }
 
-inline bool json_decode(::dsn::json::string_tokenizer &in, duplication_status::type &s)
+inline bool json_decode(const dsn::json::JsonObject &in, duplication_status::type &s)
 {
     static const std::map<std::string, duplication_status::type>
         _duplication_status_NAMES_TO_VALUES = {

--- a/src/core/core/perf_counters.cpp
+++ b/src/core/core/perf_counters.cpp
@@ -206,7 +206,7 @@ std::string perf_counters::list_counter_internal(const std::vector<std::string> 
     }
 
     std::stringstream ss;
-    dsn::json::json_encode(ss, counters);
+    dsn::json::json_forwarder<decltype(counters)>::encode(ss, counters);
     return ss.str();
 }
 
@@ -218,7 +218,7 @@ std::string perf_counters::get_counter_value(const std::vector<std::string> &arg
     double value = 0;
 
     if (args.size() < 1) {
-        value_resp{value, ts, std::string()}.encode_json_state(ss);
+        dsn::json::json_forwarder<value_resp>::encode(ss, value_resp{value, ts, std::string()});
         return ss.str();
     }
 

--- a/src/core/tests/json_helper_test.cpp
+++ b/src/core/tests/json_helper_test.cpp
@@ -49,22 +49,96 @@ public:
     }
 };
 
+#define EXTERNAL_JSON_SERIALIZATION(type, ...)                                                     \
+    inline void json_encode(json::JsonWriter &output, const type &t)                               \
+    {                                                                                              \
+        JSON_ENCODE_ENTRIES(output, t, __VA_ARGS__);                                               \
+    }                                                                                              \
+    inline bool json_decode(const json::JsonObject &input, type &t)                                \
+    {                                                                                              \
+        JSON_DECODE_ENTRIES(input, t, __VA_ARGS__);                                                \
+    }
+
+struct struct_type1
+{
+    bool b;
+    std::string s;
+    double d;
+
+    bool operator==(const struct_type1 &another) const
+    {
+        return b == another.b && s == another.s && d == another.d;
+    }
+};
+EXTERNAL_JSON_SERIALIZATION(struct_type1, b, s, d)
+
+struct struct_type2
+{
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    bool operator==(const struct_type2 &another) const
+    {
+        return i8 == another.i8 && i16 == another.i16 && i32 == another.i32 && i64 == another.i64;
+    }
+};
+EXTERNAL_JSON_SERIALIZATION(struct_type2, i8, i16, i32, i64)
+
+struct struct_type3
+{
+    uint8_t u8;
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    bool operator==(const struct_type3 &another) const
+    {
+        return u8 == another.u8 && u16 == another.u16 && u32 == another.u32 && u64 == another.u64;
+    }
+};
+EXTERNAL_JSON_SERIALIZATION(struct_type3, u8, u16, u32, u64)
+
+struct nested_type
+{
+    std::shared_ptr<std::string> str;
+    struct_type1 t1;
+    std::vector<struct_type2> t2_vec;
+    std::map<std::string, struct_type3> t3_map;
+    std::unordered_map<int, double> t4_umap;
+    std::set<uint32_t> t5_set;
+    bool operator==(const nested_type &another) const
+    {
+        return *(str.get()) == *(another.str.get()) && t1 == another.t1 &&
+               t2_vec == another.t2_vec && t3_map == another.t3_map && t4_umap == another.t4_umap &&
+               t5_set == another.t5_set;
+    }
+};
+EXTERNAL_JSON_SERIALIZATION(nested_type, str, t1, t2_vec, t3_map, t4_umap, t5_set)
+
 struct older_struct
 {
     int a;
     std::string b;
+    struct_type1 t1;
     std::map<std::string, std::string> c;
-    DEFINE_JSON_SERIALIZATION(a, b, c)
+    DEFINE_JSON_SERIALIZATION(a, b, t1, c)
+};
+
+struct new_struct_type1 : struct_type1
+{
+    std::vector<std::string> new_vecs;
+    DEFINE_JSON_SERIALIZATION(b, s, d, new_vecs)
 };
 
 struct newer_struct
 {
     int a;
     std::string b;
+    new_struct_type1 t1;
     std::map<std::string, std::string> c;
     std::vector<int> d;
     std::map<int, int> e;
-    DEFINE_JSON_SERIALIZATION(a, b, c, d, e)
+    DEFINE_JSON_SERIALIZATION(a, b, t1, c, d, e)
 };
 
 // This test verifies that json_forwarder can correctly encode an object with private
@@ -72,8 +146,8 @@ struct newer_struct
 TEST(json_helper, encode_and_decode)
 {
     test_entity entity;
-    entity.field =
-        5; // ensures that `entity` doesn't equal to the default value of `decoded_entity`
+    // ensures that `entity` doesn't equal to the default value of `decoded_entity`
+    entity.field = 5;
 
     blob encoded_entity = dsn::json::json_forwarder<test_entity>::encode(entity);
 
@@ -83,23 +157,194 @@ TEST(json_helper, encode_and_decode)
     ASSERT_EQ(entity, decoded_entity);
 }
 
-TEST(json_helper, struct_add_fields)
+TEST(json_helper, simple_type_encode_decode)
 {
-    // newer version of json cann't be decoded with older version of struct
-    newer_struct n;
-    n.a = 1;
-    n.b = "hehe";
-    n.c = {{"aa", "bb"}, {"cc", "dd"}};
-    n.d = {1, 3, 4};
-    n.e = {{1, 4}, {2, 3}};
-    blob bb = dsn::json::json_forwarder<newer_struct>::encode(n);
+    struct_type1 t1_in, t1_out;
+    t1_in.b = true;
+    t1_in.d = -0.00;
+    t1_in.s = "hahaha";
 
-    older_struct o;
-    o.a = -1;
-    o.b = "xixi";
-    dsn::json::string_tokenizer tok(bb.data(), 0, bb.length());
-    bool result = o.decode_json_state(tok);
-    ASSERT_FALSE(result);
+    t1_out.b = false;
+    t1_out.d = -0.0;
+    t1_out.s = "";
+
+    dsn::blob bb = dsn::json::json_forwarder<struct_type1>::encode(t1_in);
+    t1_in.s = "";
+    ASSERT_TRUE(dsn::json::json_forwarder<struct_type1>::decode(bb, t1_out));
+
+    ASSERT_EQ(t1_in.b, t1_out.b);
+    ASSERT_EQ(t1_in.d, t1_out.d);
+    ASSERT_EQ("hahaha", t1_out.s);
+
+    t1_in.b = false;
+    t1_in.d = 99.999;
+    t1_in.s = "";
+
+    bb = dsn::json::json_forwarder<struct_type1>::encode(t1_in);
+    ASSERT_TRUE(dsn::json::json_forwarder<struct_type1>::decode(bb, t1_out));
+
+    ASSERT_EQ(t1_in, t1_out);
+
+    t1_in.s = "string with escape: \\\\, \\\"";
+    bb = dsn::json::json_forwarder<struct_type1>::encode(t1_in);
+    ASSERT_TRUE(dsn::json::json_forwarder<struct_type1>::decode(bb, t1_out));
+    std::cout << bb.data() << std::endl;
+    ASSERT_EQ(t1_in.s, t1_out.s);
+}
+
+TEST(json_helper, int_type_encode_decode)
+{
+    struct_type2 t_in, t_out;
+    t_in.i8 = 0x80;
+    t_in.i16 = 0x8000;
+    t_in.i32 = 0x80000000;
+    t_in.i64 = 0x8000000000000000;
+
+    t_out.i8 = 0;
+    t_out.i16 = 0;
+    t_out.i32 = 0;
+    t_out.i64 = 0;
+
+    dsn::blob bb = dsn::json::json_forwarder<struct_type2>::encode(t_in);
+    ASSERT_TRUE(dsn::json::json_forwarder<struct_type2>::decode(bb, t_out));
+
+    ASSERT_EQ(t_in, t_out);
+
+    t_in.i8 = 0x7f;
+    t_in.i16 = 0x7fff;
+    t_in.i32 = 0x7fffffff;
+    t_in.i64 = 0x7fffffffffffffff;
+
+    bb = dsn::json::json_forwarder<struct_type2>::encode(t_in);
+    ASSERT_TRUE(dsn::json::json_forwarder<struct_type2>::decode(bb, t_out));
+
+    ASSERT_EQ(t_in, t_out);
+}
+
+TEST(json_helper, int_overflow_underflow)
+{
+    const char *abnormal_targets[] = {
+        "{\"i8\":128,\"i16\":32767,\"i32\":2147483647,\"i64\":9223372036854775807}",
+        "{\"i8\":127,\"i16\":32768,\"i32\":2147483647,\"i64\":9223372036854775807}",
+        "{\"i8\":127,\"i16\":32767,\"i32\":2147483648,\"i64\":9223372036854775807}",
+        "{\"i8\":127,\"i16\":32767,\"i32\":2147483647,\"i64\":9223372036854775808}",
+        "{\"i8\":-129,\"i16\":-32768,\"i32\":-2147483648,\"i64\":-9223372036854775808}",
+        "{\"i8\":-128,\"i16\":-32769,\"i32\":-2147483648,\"i64\":-9223372036854775808}",
+        "{\"i8\":-128,\"i16\":-32768,\"i32\":-2147483649,\"i64\":-9223372036854775808}",
+        "{\"i8\":-128,\"i16\":-32768,\"i32\":-2147483648,\"i64\":-9223372036854775809}"};
+
+    struct_type2 t;
+
+    for (int i = 0; i < 8; ++i) {
+        dsn::blob bb(abnormal_targets[i], 0, strlen(abnormal_targets[i]));
+        bool result = dsn::json::json_forwarder<struct_type2>::decode(bb, t);
+        ASSERT_FALSE(result);
+    }
+
+    const char *normal_targets[] = {
+        "{\"i8\":-128,\"i16\":-32768,\"i32\":-2147483648,\"i64\":-9223372036854775808}",
+        "{\"i8\":127,\"i16\":32767,\"i32\":2147483647,\"i64\":9223372036854775807}"};
+
+    struct_type2 normal_results[2];
+    normal_results[0].i8 = 0x80;
+    normal_results[0].i16 = 0x8000;
+    normal_results[0].i32 = 0x80000000;
+    normal_results[0].i64 = 0x8000000000000000;
+
+    normal_results[1].i8 = 0x7f;
+    normal_results[1].i16 = 0x7fff;
+    normal_results[1].i32 = 0x7fffffff;
+    normal_results[1].i64 = 0x7fffffffffffffff;
+
+    for (int i = 0; i < 2; ++i) {
+        dsn::blob bb(normal_targets[i], 0, strlen(normal_targets[i]));
+        bool result = dsn::json::json_forwarder<struct_type2>::decode(bb, t);
+        ASSERT_TRUE(result);
+
+        ASSERT_EQ(normal_results[i], t);
+    }
+}
+
+TEST(json_helper, uint_encode_decode)
+{
+    struct_type3 t_in, t_out;
+    t_in.u8 = 0xff;
+    t_in.u16 = 0xffff;
+    t_in.u32 = 0xffffffff;
+    t_in.u64 = 0xffffffffffffffff;
+
+    dsn::blob bb = dsn::json::json_forwarder<struct_type3>::encode(t_in);
+
+    t_out.u8 = 0;
+    t_out.u16 = 0;
+    t_out.u32 = 0;
+    t_out.u64 = 0;
+    dsn::json::json_forwarder<struct_type3>::decode(bb, t_out);
+
+    ASSERT_EQ(t_in, t_out);
+}
+
+TEST(json_helper, uint_overflow_underflow)
+{
+    const char *abnormal_cases[] = {
+        "{\"u8\":256,\"u16\":65535,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65536,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":4294967296,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":4294967295,\"u64\":18446744073709551616}",
+        "{\"u8\":-1,\"u16\":65535,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":-1,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":-1,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":4294967295,\"u64\":-1}",
+    };
+
+    struct_type3 t;
+    for (int i = 0; i < 8; ++i) {
+        dsn::blob bb(abnormal_cases[i], 0, strlen(abnormal_cases[i]));
+        bool ans = dsn::json::json_forwarder<struct_type3>::decode(bb, t);
+        ASSERT_FALSE(ans);
+    }
+
+    const char *normal_cases[] = {
+        "{\"u8\":255,\"u16\":65535,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":0,\"u16\":0,\"u32\":0,\"u64\":0}",
+    };
+
+    struct_type3 normal_results[2];
+    normal_results[0].u8 = 0xff;
+    normal_results[0].u16 = 0xffff;
+    normal_results[0].u32 = 0xffffffff;
+    normal_results[0].u64 = 0xffffffffffffffff;
+
+    normal_results[1].u8 = 0;
+    normal_results[1].u16 = 0;
+    normal_results[1].u32 = 0;
+    normal_results[1].u64 = 0;
+
+    for (int i = 0; i < 2; ++i) {
+        dsn::blob bb(normal_cases[i], 0, strlen(normal_cases[i]));
+        bool result = dsn::json::json_forwarder<struct_type3>::decode(bb, t);
+        ASSERT_TRUE(result);
+
+        ASSERT_EQ(normal_results[i], t);
+    }
+}
+
+TEST(json_helper, nested_type_encode_decode)
+{
+    nested_type nt;
+    nt.str = std::make_shared<std::string>("this is a shared ptr string");
+    nt.t1 = struct_type1{false, "simple", 99.99999};
+    nt.t2_vec = {struct_type2{2, 4, 6, 8}, struct_type2{-3, -5, -7, -9}};
+    nt.t3_map = {{"string1", struct_type3{1, 3, 4, 6}}, {"string2", struct_type3{0, 0, 0, 0}}};
+    nt.t4_umap = {{123, 0.23333354}, {-123, 99.99999}};
+    nt.t5_set = {1, 3, 5, 7, 9};
+
+    dsn::blob bb = dsn::json::json_forwarder<decltype(nt)>::encode(nt);
+
+    nested_type nt2;
+    dsn::json::json_forwarder<decltype(nt)>::decode(bb, nt2);
+
+    ASSERT_EQ(nt, nt2);
 }
 
 TEST(json_helper, decode_invalid_json)
@@ -108,6 +353,7 @@ TEST(json_helper, decode_invalid_json)
     const char *json[] = {
         "{\"a\":1,\"b\":\"hehe\",\"c\":{\"aa\":\"bb\",\"cc\":\"dd\"},\"c\":[1,3,4],"
         "\"d\":{\"1\":4,\"2\":3},\"hehe\"}",
+        "{\"a\":[]}",
         "{\"c\":1}",
         "{\"a\":1,\"xxx\":\"hehe\"}",
         "{\"a\":1,\"b\":\"hehe\"",
@@ -118,9 +364,140 @@ TEST(json_helper, decode_invalid_json)
 
     older_struct o;
     for (int i = 0; json[i]; ++i) {
-        dsn::json::string_tokenizer in(json[i], 0, strlen(json[i]));
-        ASSERT_FALSE(o.decode_json_state(in));
+        dsn::blob in(json[i], 0, strlen(json[i]));
+        ASSERT_FALSE(dsn::json::json_forwarder<older_struct>::decode(in, o));
     }
+}
+
+TEST(json_helper, type_mismatch)
+{
+    struct_type1 t1;
+    const char *type_mismatch1[] = {
+        "{\"b\":\"heheda\",\"s\":\"heheda\",\"d\":12.345}",
+        "{\"b\":1,\"s\":[1, 2, 3],\"d\":12.345}",
+        "{\"b\":1,\"s\":\"heheda\",\"d\":12.3.4.5}",
+        "{\"b\":1,\"s\":\"heheda\",\"d\":2345}",
+        "{\"b\":1,\"s\":\"heheda\",\"d\":{}}",
+        "{\"b\":1,\"s\":\"heheda\",\"d\":12.345}",
+        nullptr,
+    };
+    bool expected1[] = {false, false, false, false, false, true};
+    for (int i = 0; type_mismatch1[i]; ++i) {
+        dsn::blob bb(type_mismatch1[i], 0, strlen(type_mismatch1[i]));
+        bool result = dsn::json::json_forwarder<struct_type1>::decode(bb, t1);
+        ASSERT_EQ(expected1[i], result);
+    }
+
+    struct_type2 t2;
+    const char *int_mismatch[] = {
+        "{\"i8\":\"aa\",\"i16\":32767,\"i32\":2147483647,\"i64\":9223372036854775807}",
+        "{\"i8\":127,\"i16\":[1, 3, 5],\"i32\":2147483647,\"i64\":9223372036854775807}",
+        "{\"i8\":127,\"i16\":32767,\"i32\":{},\"i64\":9223372036854775807}",
+        "{\"i8\":127,\"i16\":32767,\"i32\":2147483647,\"i64\":0.256}",
+        "{\"i8\":127,\"i16\":32767,\"i32\":2147483647,\"i64\":0}",
+        nullptr,
+    };
+    bool expected[] = {false, false, false, false, true};
+    for (int i = 0; int_mismatch[i]; ++i) {
+        dsn::blob bb(int_mismatch[i], 0, strlen(int_mismatch[i]));
+        bool result = dsn::json::json_forwarder<struct_type2>::decode(bb, t2);
+        ASSERT_EQ(expected[i], result) << "case " << i << " failed";
+    }
+
+    struct_type3 t3;
+    const char *uint_mismatch[] = {
+        "{\"u8\":[],\"u16\":65535,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":{\"a\":1, \"b\":2},\"u32\":4294967295,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":23.456,\"u64\":18446744073709551615}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":4294967295,\"u64\":\"hehe\"}",
+        "{\"u8\":255,\"u16\":65535,\"u32\":4294967295,\"u64\":18446744073709551615}",
+        nullptr,
+    };
+    bool expected_uint[] = {false, false, false, false, true};
+    for (int i = 0; uint_mismatch[i]; ++i) {
+        dsn::blob bb(uint_mismatch[i], 0, strlen(uint_mismatch[i]));
+        bool result = dsn::json::json_forwarder<struct_type3>::decode(bb, t3);
+        ASSERT_EQ(expected_uint[i], result);
+    }
+
+    nested_type nt;
+    const char *nt_mismatch[] = {
+        /// str is not string
+        "{\"str\":12,\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":[],\"t3_map\":{},"
+        "\"t4_umap\":{},\"t5_set\":[]}",
+        /// t1 is not object
+        "{\"str\":\"a\",\"t1\":[],\"t2_vec\":[],\"t3_map\":{},\"t4_umap\":{},\"t5_set\":[]}",
+        /// t2 is not vector
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":\"heheda\",\"t3_"
+        "map\":{},\"t4_umap\":{},\"t5_set\":[]}",
+        /// t3 is not map
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":[],\"t3_map\":[],"
+        "\"t4_umap\":{},\"t5_set\":[]}",
+        /// t4 is not unordered_map
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":[],\"t3_map\":{},"
+        "\"t4_umap\":234.5,\"t5_set\":[]}",
+        /// t5 is not set
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":[],\"t3_map\":{},"
+        "\"t4_umap\":{},\"t5_set\":1}",
+        /// t1.s is not string
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":12,\"d\":3.26e-322},\"t2_vec\":[],\"t3_map\":{},"
+        "\"t4_umap\":{},\"t5_set\":[]}",
+        /// t2_vec is vector of integer
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":[1, 3, "
+        "5],\"t3_map\":{},\"t4_umap\":{},\"t5_set\":[]}",
+        /// normal case
+        "{\"str\":\"a\",\"t1\":{\"b\":232,\"s\":\"\",\"d\":3.26e-322},\"t2_vec\":[],\"t3_map\":{},"
+        "\"t4_umap\":{},\"t5_set\":[]}",
+        nullptr,
+    };
+    bool expected_nt[] = {false, false, false, false, false, false, false, false, true};
+    for (int i = 0; nt_mismatch[i]; ++i) {
+        dsn::blob bb(nt_mismatch[i], 0, strlen(nt_mismatch[i]));
+        bool result = dsn::json::json_forwarder<nested_type>::decode(bb, nt);
+        ASSERT_EQ(expected_nt[i], result) << "case " << i << " failed";
+    }
+}
+
+TEST(json_helper, upgrade_downgrade)
+{
+    // newer version of json can be decoded with older version of struct
+    newer_struct n;
+    n.a = 1;
+    n.b = "hehe";
+    n.t1.b = false;
+    n.t1.d = 23.445;
+    n.t1.new_vecs = {"t1", "t2", "t3"};
+    n.t1.s = "haha";
+    n.c = {{"aa", "bb"}, {"cc", "dd"}};
+    n.d = {1, 3, 4};
+    n.e = {{1, 4}, {2, 3}};
+    blob bb = dsn::json::json_forwarder<newer_struct>::encode(n);
+
+    older_struct o;
+    o.a = -1;
+    o.b = "xixi";
+    bool result = dsn::json::json_forwarder<older_struct>::decode(bb, o);
+    ASSERT_TRUE(result);
+
+    ASSERT_EQ(n.a, o.a);
+    ASSERT_EQ(n.b, o.b);
+    ASSERT_EQ(n.t1.b, o.t1.b);
+    ASSERT_EQ(n.t1.d, o.t1.d);
+    ASSERT_EQ(n.t1.s, o.t1.s);
+    ASSERT_EQ(n.c, o.c);
+
+    // older version of json can be decoded by newer version of struct
+    newer_struct n2;
+    blob bb2 = dsn::json::json_forwarder<older_struct>::encode(o);
+    result = dsn::json::json_forwarder<newer_struct>::decode(bb2, n2);
+    ASSERT_TRUE(result);
+
+    ASSERT_EQ(n2.a, o.a);
+    ASSERT_EQ(n2.b, o.b);
+    ASSERT_EQ(n2.t1.b, o.t1.b);
+    ASSERT_EQ(n2.t1.d, o.t1.d);
+    ASSERT_EQ(n2.t1.s, o.t1.s);
+    ASSERT_EQ(n2.c, o.c);
 }
 
 } // namespace dsn

--- a/src/core/tests/json_helper_test.cpp
+++ b/src/core/tests/json_helper_test.cpp
@@ -49,16 +49,6 @@ public:
     }
 };
 
-#define EXTERNAL_JSON_SERIALIZATION(type, ...)                                                     \
-    inline void json_encode(json::JsonWriter &output, const type &t)                               \
-    {                                                                                              \
-        JSON_ENCODE_ENTRIES(output, t, __VA_ARGS__);                                               \
-    }                                                                                              \
-    inline bool json_decode(const json::JsonObject &input, type &t)                                \
-    {                                                                                              \
-        JSON_DECODE_ENTRIES(input, t, __VA_ARGS__);                                                \
-    }
-
 struct struct_type1
 {
     bool b;
@@ -70,7 +60,7 @@ struct struct_type1
         return b == another.b && s == another.s && d == another.d;
     }
 };
-EXTERNAL_JSON_SERIALIZATION(struct_type1, b, s, d)
+NON_MEMBER_JSON_SERIALIZATION(struct_type1, b, s, d)
 
 struct struct_type2
 {
@@ -83,7 +73,7 @@ struct struct_type2
         return i8 == another.i8 && i16 == another.i16 && i32 == another.i32 && i64 == another.i64;
     }
 };
-EXTERNAL_JSON_SERIALIZATION(struct_type2, i8, i16, i32, i64)
+NON_MEMBER_JSON_SERIALIZATION(struct_type2, i8, i16, i32, i64)
 
 struct struct_type3
 {
@@ -96,7 +86,7 @@ struct struct_type3
         return u8 == another.u8 && u16 == another.u16 && u32 == another.u32 && u64 == another.u64;
     }
 };
-EXTERNAL_JSON_SERIALIZATION(struct_type3, u8, u16, u32, u64)
+NON_MEMBER_JSON_SERIALIZATION(struct_type3, u8, u16, u32, u64)
 
 struct nested_type
 {
@@ -113,7 +103,7 @@ struct nested_type
                t5_set == another.t5_set;
     }
 };
-EXTERNAL_JSON_SERIALIZATION(nested_type, str, t1, t2_vec, t3_map, t4_umap, t5_set)
+NON_MEMBER_JSON_SERIALIZATION(nested_type, str, t1, t2_vec, t3_map, t4_umap, t5_set)
 
 struct older_struct
 {

--- a/src/core/tools/common/profiler_command.cpp
+++ b/src/core/tools/common/profiler_command.cpp
@@ -343,7 +343,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                 continue;
             task_list.push_back(dsn::task_code(task_id).to_string());
         }
-        dsn::json::json_encode(ss, task_list);
+        dsn::json::json_forwarder<decltype(task_list)>::encode(ss, task_list);
         return ss.str();
     }
     // return a list of 2 elements for a specific task:
@@ -435,7 +435,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                 task_id = task_spec::get(task_id)->rpc_paired_code;
         } while (task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE);
 
-        dsn::json::json_encode(ss, total_resp);
+        dsn::json::json_forwarder<decltype(total_resp)>::encode(ss, total_resp);
         return ss.str();
     }
     // return 6 types of latency times for a specific task
@@ -520,7 +520,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
         // timeList[0] = (timeList[3] - timeList[0]) / 2;
         // timeList[3] = timeList[0];
 
-        dsn::json::json_encode(ss, timeList);
+        dsn::json::json_forwarder<decltype(timeList)>::encode(ss, timeList);
         return ss.str();
     }
     // return a list of current counter value for a specific task
@@ -646,7 +646,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
         }
         call_list.push_back(caller_list);
         call_list.push_back(callee_list);
-        dsn::json::json_encode(ss, call_list);
+        dsn::json::json_forwarder<decltype(call_list)>::encode(ss, call_list);
         return ss.str();
     }
     // return a list of all sharer using the same pool with a specific task
@@ -670,7 +670,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
             if (j != TASK_CODE_INVALID && j != task_id && task_spec::get(j)->pool_code == pool &&
                 task_spec::get(j)->type == TASK_TYPE_RPC_RESPONSE)
                 sharer_list.push_back(std::string(dsn::task_code(j).to_string()));
-        dsn::json::json_encode(ss, sharer_list);
+        dsn::json::json_forwarder<decltype(sharer_list)>::encode(ss, sharer_list);
         return ss.str();
     }
     // query time

--- a/src/dist/replication/meta_server/meta_backup_service.cpp
+++ b/src/dist/replication/meta_server/meta_backup_service.cpp
@@ -1085,9 +1085,8 @@ error_code backup_service::sync_policies_from_remote_storage()
         auto after_get_backup_info = [this, &err, policy_name](error_code ec, const blob &value) {
             if (ec == ERR_OK) {
                 dinfo("sync a backup string(%s) from remote storage", value.data());
-                ::dsn::json::string_tokenizer tokenizer(value);
                 backup_info tbackup_info;
-                tbackup_info.decode_json_state(tokenizer);
+                dsn::json::json_forwarder<backup_info>::decode(value, tbackup_info);
 
                 policy_context *ptr = nullptr;
                 {
@@ -1156,8 +1155,7 @@ error_code backup_service::sync_policies_from_remote_storage()
                     if (ec == ERR_OK) {
                         std::shared_ptr<policy_context> policy_ctx = _factory(this);
                         policy tpolicy;
-                        ::dsn::json::string_tokenizer tokenizer(value);
-                        tpolicy.decode_json_state(tokenizer);
+                        dsn::json::json_forwarder<policy>::decode(value, tpolicy);
                         policy_ctx->set_policy(std::move(tpolicy));
 
                         {

--- a/src/dist/replication/meta_server/meta_data.h
+++ b/src/dist/replication/meta_server/meta_data.h
@@ -529,12 +529,12 @@ inline bool has_milliseconds_expired(uint64_t milliseconds_ts)
 namespace dsn {
 namespace json {
 
-inline void json_encode(std::stringstream &out, const replication::app_state &state)
+inline void json_encode(dsn::json::JsonWriter &out, const replication::app_state &state)
 {
     json_forwarder<dsn::app_info>::encode(out, (const dsn::app_info &)state);
 }
 
-inline bool json_decode(dsn::json::string_tokenizer &in, replication::app_state &state)
+inline bool json_decode(const dsn::json::JsonObject &in, replication::app_state &state)
 {
     return json_forwarder<dsn::app_info>::decode(in, (dsn::app_info &)state);
 }

--- a/src/dist/replication/meta_server/server_state.cpp
+++ b/src/dist/replication/meta_server/server_state.cpp
@@ -565,8 +565,7 @@ dsn::error_code server_state::sync_apps_from_remote_storage()
                                                             const blob &value) mutable {
                 if (ec == ERR_OK) {
                     partition_configuration pc;
-                    dsn::json::string_tokenizer tokenizer(value);
-                    json_decode(tokenizer, pc);
+                    dsn::json::json_forwarder<partition_configuration>::decode(value, pc);
 
                     dassert(pc.pid.get_app_id() == app->app_id &&
                                 pc.pid.get_partition_index() == partition_id,

--- a/src/dist/replication/test/meta_test/unit_test/json_compacity.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/json_compacity.cpp
@@ -24,7 +24,7 @@ void meta_service_test_app::json_compacity()
     // 1. encoded data can be decoded
     dsn::blob bb = dsn::json::json_forwarder<dsn::app_info>::encode(info);
     std::cout << bb.data() << std::endl;
-    dsn::json::json_forwarder<dsn::app_info>::decode(bb, info2);
+    ASSERT_TRUE(dsn::json::json_forwarder<dsn::app_info>::decode(bb, info2));
     ASSERT_EQ(info2, info);
 
     // 2. old version of json can be decoded to new struct
@@ -64,12 +64,9 @@ void meta_service_test_app::json_compacity()
     const char *json4 = "{\"pid\":\"1.1\",\"ballot\":234,\"max_replica_count\":3,"
                         "\"primary\":\"invalid address\",\"secondaries\":[\"127.0.0.1:6\","
                         "\"last_drops\":[],\"last_committed_decree\":157}";
-    dsn::json::string_tokenizer in(json4, 0, strlen(json4));
+    dsn::blob in(json4, 0, strlen(json4));
     bool result = dsn::json::json_forwarder<dsn::partition_configuration>::decode(in, pc);
     ASSERT_FALSE(result);
-    if (!result) {
-        std::cout << "invalid pos: " << json4 + in.tell() << std::endl;
-    }
 
     // 6 app_name with ':'
     const char *json6 = "{\"status\":\"app_status::AS_AVAILABLE\","

--- a/src/dist/replication/test/meta_test/unit_test/json_compacity.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/json_compacity.cpp
@@ -5,6 +5,7 @@
 
 #include "dist/replication/meta_server/meta_service.h"
 #include "dist/replication/meta_server/server_state.h"
+#include "dist/replication/meta_server/meta_backup_service.h"
 #include "meta_service_test_app.h"
 
 void meta_service_test_app::json_compacity()
@@ -73,7 +74,60 @@ void meta_service_test_app::json_compacity()
                         "\"app_type\":\"pegasus\",\"app_name\":\"CL769:test\","
                         "\"app_id\":1,\"partition_count\":16,\"envs\":{},"
                         "\"is_stateful\":1,\"max_replica_count\":3}";
-    dsn::json::json_forwarder<dsn::app_info>::decode(dsn::blob(json6, 0, strlen(json6)), info2);
+    result =
+        dsn::json::json_forwarder<dsn::app_info>::decode(dsn::blob(json6, 0, strlen(json6)), info2);
+    ASSERT_TRUE(result);
     ASSERT_EQ(info2.app_name, "CL769:test");
     ASSERT_EQ(info2.max_replica_count, 3);
+
+    // 7. policy can be decoded correctly
+    const char *json7 = "{\"policy_name\":\"every_day\",\"backup_provider_type\":\"simple\",\"app_"
+                        "ids\":[4,5,6,7,8,9,10,11,14,15,16,17,18,19,21,22,23,24],\"app_names\":{"
+                        "\"4\":\"aaaa\",\"5\":\"aaaa\",\"6\":\"aaaa\",\"7\":\"aaaa\",\"8\":"
+                        "\"aaaa\",\"9\":\"aaaa\",\"10\":\"aaaa\",\"11\":\"aaaa\",\"14\":\"aaaa\","
+                        "\"15\":\"aaaa\",\"16\":\"aaaa\",\"17\":\"aaaa\",\"18\":\"aaaa\",\"19\":"
+                        "\"aaaa\",\"21\":\"aaaa\",\"22\":\"aaaa\",\"23\":\"aaaa\",\"24\":\"aaaa\"},"
+                        "\"backup_interval_seconds\":86400,\"backup_history_count_to_keep\":3,\"is_"
+                        "disable\":0,\"start_time\":{\"hour\":0,\"minute\":30}}";
+    dsn::replication::policy p;
+    result = dsn::json::json_forwarder<dsn::replication::policy>::decode(
+        dsn::blob(json7, 0, strlen(json7)), p);
+    ASSERT_TRUE(result);
+    ASSERT_EQ("every_day", p.policy_name);
+    ASSERT_EQ("simple", p.backup_provider_type);
+
+    std::set<int32_t> app_ids = {4, 5, 6, 7, 8, 9, 10, 11, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24};
+    ASSERT_EQ(app_ids, p.app_ids);
+
+    std::map<int32_t, std::string> app_names;
+    for (int32_t i : app_ids) {
+        app_names.emplace(i, "aaaa");
+    }
+    ASSERT_EQ(app_names, p.app_names);
+    ASSERT_EQ(86400, p.backup_interval_seconds);
+    ASSERT_EQ(3, p.backup_history_count_to_keep);
+    ASSERT_EQ(0, p.is_disable);
+    ASSERT_EQ(0, p.start_time.hour);
+    ASSERT_EQ(30, p.start_time.minute);
+
+    // 8. backup info can be decoded correctly
+    const char *json8 =
+        "{\"backup_id\":1528216470578,\"start_time_ms\":1528216470578,\"end_time_"
+        "ms\":1528217091629,\"app_ids\":[4,5,6,7,8,9,10,11,14,15,16,17,18,19,21,22,"
+        "23,24],\"app_names\":{\"4\":\"aaaa\",\"5\":\"aaaa\",\"6\":\"aaaa\",\"7\":\"aaaa\",\"8\":"
+        "\"aaaa\",\"9\":\"aaaa\",\"10\":\"aaaa\",\"11\":\"aaaa\",\"14\":\"aaaa\",\"15\":\"aaaa\","
+        "\"16\":"
+        "\"aaaa\",\"17\":\"aaaa\",\"18\":\"aaaa\",\"19\":\"aaaa\",\"21\":\"aaaa\",\"22\":\"aaaa\","
+        "\"23\":"
+        "\"aaaa\",\"24\":\"aaaa\"},\"info_status\":1}";
+    dsn::replication::backup_info binfo;
+    result = dsn::json::json_forwarder<dsn::replication::backup_info>::decode(
+        dsn::blob(json8, 0, strlen(json8)), binfo);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(1528216470578, binfo.backup_id);
+    ASSERT_EQ(1528216470578, binfo.start_time_ms);
+    ASSERT_EQ(1528217091629, binfo.end_time_ms);
+    ASSERT_EQ(app_ids, binfo.app_ids);
+    ASSERT_EQ(app_names, binfo.app_names);
+    ASSERT_EQ(1, binfo.info_status);
 }


### PR DESCRIPTION
reimplement the json_encode/decode with rapidjson so that the json output will more closer to standard.

currently only one rule are disobey the standard: we encode "Bool" to "0/1", but not "True/False"

