### PR TITLE
meta: change backup policy node on zookeeper to handle json compatibility

### DIFF
--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -246,7 +246,7 @@ error_code meta_service::start()
         ddebug("initialize backup handler");
         _backup_handler = std::make_shared<backup_service>(
             this,
-            meta_options::concat_path_unix_style(_cluster_root, "backup_policy"),
+            meta_options::concat_path_unix_style(_cluster_root, "backup"),
             _opts.cold_backup_root,
             [](backup_service *bs) { return std::make_shared<policy_context>(bs); });
     }


### PR DESCRIPTION
因为json库重构造成对map<int,int>中key的序列化/反序列化方式发生变化。
原来：{1:1,2:2}
现在：{"1":1,"2":2}

为了避免兼容性带来的集群无法加载的问题，我们将backup policy在zookeeper上的存储节点路径换为一个新的路径。在升级集群时，需要将原集群的backup policy信息转换后写入到新路径中，将会提供专门的工具来做这件事情。