### PR TITLE
 uri_resolver: add cluster_id

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -262,6 +262,17 @@ rpc message read/write
 extern DSN_API dsn::rpc_address dsn_primary_address();
 
 /*!
+ This function returns the cluster id of url specified in the url-resolver section
+ of your configuration, for example:
+     [uri-resolver.dsn://slave-cluster]
+     factory = partition_resolver_simple
+     cluster_id = 3
+     arguments = 10.231.58.247:54601, 10.231.58.247:54602, 10.231.58.247:54603
+ The returned cluster id of url "dsn://slave-cluster" is 3.
+ */
+extern DSN_API int dsn_uri_to_cluster_id(const char *url);
+
+/*!
  create a rpc request message
 
  \param rpc_code              task code for this request

--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -269,6 +269,9 @@ extern DSN_API dsn::rpc_address dsn_primary_address();
      cluster_id = 3
      arguments = 10.231.58.247:54601, 10.231.58.247:54602, 10.231.58.247:54603
  The returned cluster id of url "dsn://slave-cluster" is 3.
+
+ \return -2 if failed to resolve the url.
+ \return -1 if the url doesn't have a valid cluster_id.
  */
 extern DSN_API int dsn_uri_to_cluster_id(const char *url);
 

--- a/include/dsn/tool-api/uniq_timestamp_us.h
+++ b/include/dsn/tool-api/uniq_timestamp_us.h
@@ -31,29 +31,33 @@
 #include <dsn/c/api_layer1.h>
 
 namespace dsn {
+
 //
 // uniq_timestamp_us is used to generate an increasing unique microsecond timestamp
 // in rdsn, it's mainly used for replica to set mutation's timestamp
 //
-// Notice: this module is not thread-safe, 
+// Notice: this module is not thread-safe,
 // please ensure that it is accessed only by one thread
 //
-class uniq_timestamp_us {
+class uniq_timestamp_us
+{
 private:
     uint64_t _last_ts;
+
 public:
     uniq_timestamp_us() { _last_ts = dsn_now_us(); }
 
     void try_update(uint64_t new_ts)
     {
-        if ( dsn_likely(new_ts > _last_ts) )
+        if (dsn_likely(new_ts > _last_ts))
             _last_ts = new_ts;
     }
 
     uint64_t next()
     {
-        _last_ts = std::max(dsn_now_us(), _last_ts+1);
+        _last_ts = std::max(dsn_now_us(), _last_ts + 1);
         return _last_ts;
     }
 };
+
 }

--- a/include/dsn/tool-api/uri_address.h
+++ b/include/dsn/tool-api/uri_address.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <algorithm>
+#include <dsn/utility/errors.h>
 #include <dsn/utility/config_api.h>
 #include <dsn/utility/synchronize.h>
 #include <dsn/tool-api/rpc_address.h>
@@ -55,6 +56,17 @@ public:
      *          protocol : // resolver-address / app-path
      */
     rpc_uri_address(const char *uri);
+
+    /**
+     * Creates an `rpc_uri_address` from `uri`.
+     * This function returns error when uri resolved failed rather than aborts
+     * the program as constructor `rpc_uri_address(const char *uri)` does.
+     *
+     * \param uri URI of the document, it is composed with three parts:
+     *            dsn://meta-server:23356/app1
+     *            protocol : // resolver-address / app-path
+     */
+    static error_with<rpc_uri_address> resolve(const char *uri);
 
     /**
      * Copy constructor.
@@ -77,6 +89,9 @@ public:
     const char *uri() const { return _uri.c_str(); }
 
     dist::partition_resolver_ptr get_resolver() { return _resolver; }
+
+private:
+    rpc_uri_address() = default;
 
 private:
     ::dsn::dist::partition_resolver_ptr _resolver;
@@ -124,13 +139,25 @@ public:
 
     std::shared_ptr<uri_resolver> get(rpc_uri_address *uri) const;
 
+    // Returns the uri_resolver for the given `uri` as `uri_resolver_manager::get` does,
+    // but it doesn't abort, instead it returns an error when resolved as failed.
+    error_with<std::shared_ptr<uri_resolver>> try_get(rpc_uri_address *uri);
+
     std::map<std::string, std::shared_ptr<uri_resolver>> get_all() const;
+
+    // return -2 if the uri is failed to resolve.
+    // return -1 if the uri doesn't have a valid cluster_id.
+    int get_cluster_id(const char *uri) const;
 
 private:
     void setup_resolvers();
 
     typedef std::unordered_map<std::string, std::shared_ptr<uri_resolver>> resolvers;
     resolvers _resolvers;
+
+    // address => cluster_id
+    std::map<std::string, int> _cluster_id_map;
+
     mutable utils::rw_lock_nr _lock;
 };
 

--- a/include/dsn/tool-api/uri_address.h
+++ b/include/dsn/tool-api/uri_address.h
@@ -84,7 +84,7 @@ public:
     *
     * \return The resolver address
     */
-    std::pair<std::string, std::string> get_uri_components();
+    std::pair<std::string, std::string> get_uri_components() const;
 
     const char *uri() const { return _uri.c_str(); }
 
@@ -139,9 +139,9 @@ public:
 
     std::shared_ptr<uri_resolver> get(rpc_uri_address *uri) const;
 
-    // Returns the uri_resolver for the given `uri` as `uri_resolver_manager::get` does,
+    // Returns the uri_resolver for the given `uri` like what `uri_resolver_manager::get` does,
     // but it doesn't abort, instead it returns an error when resolved as failed.
-    error_with<std::shared_ptr<uri_resolver>> try_get(rpc_uri_address *uri);
+    error_with<std::shared_ptr<uri_resolver>> try_get(const rpc_uri_address &uri);
 
     std::map<std::string, std::shared_ptr<uri_resolver>> get_all() const;
 
@@ -155,7 +155,7 @@ private:
     typedef std::unordered_map<std::string, std::shared_ptr<uri_resolver>> resolvers;
     resolvers _resolvers;
 
-    // address => cluster_id
+    // cluster_name => cluster_id (c4tst-tune => 2, eg.)
     std::map<std::string, int> _cluster_id_map;
 
     mutable utils::rw_lock_nr _lock;

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -51,6 +51,7 @@
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/transient_memory.h>
 #include <dsn/tool-api/command_manager.h>
+#include <dsn/tool-api/uri_address.h>
 #include "service_engine.h"
 #include "rpc_engine.h"
 #include "disk_engine.h"
@@ -264,6 +265,11 @@ DSN_API bool dsn_semaphore_wait_timeout(dsn_handle_t s, int timeout_milliseconds
 DSN_API dsn::rpc_address dsn_primary_address()
 {
     return ::dsn::task::get_current_rpc()->primary_address();
+}
+
+DSN_API int dsn_uri_to_cluster_id(const char *url)
+{
+    return ::dsn::task::get_current_rpc()->uri_resolver_mgr()->get_cluster_id(url);
 }
 
 DSN_API bool dsn_rpc_register_handler(dsn::task_code code,

--- a/src/core/core/uri_address.cpp
+++ b/src/core/core/uri_address.cpp
@@ -50,6 +50,7 @@ void uri_resolver_manager::setup_resolvers()
     // [uri-resolver.%resolver-address%]
     // factory = %uri-resolver-factory%
     // arguments = %uri-resolver-arguments%
+    // cluster_id = %cluster_id%
 
     std::vector<std::string> sections;
     dsn_config_get_all_sections(sections);
@@ -74,6 +75,17 @@ void uri_resolver_manager::setup_resolvers()
             "partition-resolver factory name which creates the concrete partition-resolver object");
         auto arguments =
             dsn_config_get_value_string(s.c_str(), "arguments", "", "uri-resolver ctor arguments");
+
+        // resolve cluster id
+        auto cluster_id =
+            dsn_config_get_value_uint64(s.c_str(), "cluster_id", 0, "remote cluster id");
+        dassert(cluster_id < 0xFF,
+                "cluster_id(%zu) for %s should in [0, 254]",
+                cluster_id,
+                resolver_addr.c_str());
+        if (cluster_id > 0) {
+            _cluster_id_map.insert({resolver_addr, static_cast<int>(cluster_id)});
+        }
 
         auto resolver = new uri_resolver(resolver_addr.c_str(), factory, arguments);
         _resolvers.emplace(resolver_addr, std::shared_ptr<uri_resolver>(resolver));
@@ -121,6 +133,29 @@ std::map<std::string, std::shared_ptr<uri_resolver>> uri_resolver_manager::get_a
     return result;
 }
 
+error_with<std::shared_ptr<uri_resolver>> uri_resolver_manager::try_get(rpc_uri_address *uri)
+{
+    std::shared_ptr<uri_resolver> ret = nullptr;
+    auto pr = uri->get_uri_components();
+    if (pr.first.length() == 0) {
+        return error_s::make(ERR_INVALID_PARAMETERS, "uri is empty");
+    }
+
+    {
+        utils::auto_read_lock l(_lock);
+        auto it = _resolvers.find(pr.first);
+        if (it != _resolvers.end())
+            ret = it->second;
+    }
+
+    if (ret == nullptr) {
+        return error_s::make(ERR_INVALID_PARAMETERS,
+                             std::string("resolver for uri is not configured"));
+    }
+
+    return ret;
+}
+
 //---------------------------------------------------------------
 
 rpc_uri_address::rpc_uri_address(const char *uri) : _uri(uri)
@@ -158,6 +193,22 @@ std::pair<std::string, std::string> rpc_uri_address::get_uri_components()
 
     else
         return std::make_pair(_uri.substr(0, it2), _uri.substr(it2 + 1));
+}
+
+/*static*/ error_with<rpc_uri_address> rpc_uri_address::resolve(const char *uri)
+{
+    rpc_uri_address addr;
+    addr._uri = uri;
+
+    auto result = task::get_current_rpc()->uri_resolver_mgr()->try_get(&addr);
+    if (!result.is_ok()) {
+        return result.get_error();
+    }
+    dassert(result.get_value(), "");
+
+    std::shared_ptr<uri_resolver> resolver = result.get_value();
+    addr._resolver = resolver->get_app_resolver(addr.get_uri_components().second.c_str());
+    return addr;
 }
 
 //---------------------------------------------------------------
@@ -222,5 +273,28 @@ std::map<std::string, dist::partition_resolver_ptr> uri_resolver::get_all_app_re
     }
 
     return result;
+}
+
+int uri_resolver_manager::get_cluster_id(const char *uri) const
+{
+    dassert(uri != nullptr, "");
+
+    auto result = rpc_uri_address::resolve(uri);
+    if (!result.is_ok()) {
+        derror("failed to resolve uri(%s): %s", uri, result.get_error().description().c_str());
+        return -2;
+    }
+
+    std::string addr = result.get_value().get_uri_components().first;
+    dassert(!addr.empty(), "");
+
+    {
+        utils::auto_read_lock l(_lock);
+        auto it = _cluster_id_map.find(addr);
+        if (it != _cluster_id_map.end()) {
+            return it->second;
+        }
+    }
+    return -1;
 }
 }

--- a/src/core/tests/address.cpp
+++ b/src/core/tests/address.cpp
@@ -36,6 +36,7 @@
 #include <dsn/tool-api/rpc_address.h>
 #include <dsn/tool-api/group_address.h>
 #include <dsn/tool-api/uri_address.h>
+#include <dsn/c/api_layer1.h>
 #include <gtest/gtest.h>
 
 using namespace ::dsn;
@@ -215,4 +216,14 @@ TEST(core, rpc_group_address)
     ASSERT_FALSE(g->contains(addr2));
     ASSERT_EQ(0u, g->members().size());
     ASSERT_EQ(invalid_addr, g->leader());
+}
+
+TEST(core, uri_to_cluster_id)
+{
+    ASSERT_EQ(dsn_uri_to_cluster_id("dsn://duplication_cluster"), 3);
+    ASSERT_EQ(dsn_uri_to_cluster_id("duplication_cluster"), -2);
+    ASSERT_EQ(dsn_uri_to_cluster_id("dsn://unknown_cluster"), -2);
+    ASSERT_EQ(dsn_uri_to_cluster_id("http://localhost:8080"), -1);
+    ASSERT_EQ(dsn_uri_to_cluster_id(" http://localhost:8080"), -2);
+    ASSERT_EQ(dsn_uri_to_cluster_id(""), -2);
 }

--- a/src/core/tests/config-test.ini
+++ b/src/core/tests/config-test.ini
@@ -145,3 +145,8 @@ run = true
 [uri-resolver.http://localhost:8080]
 factory = partition_resolver_simple
 arguments = 127.0.0.1:8080
+
+[uri-resolver.dsn://duplication_cluster]
+factory = partition_resolver_simple
+arguments = @LOCAL_IP@:34701,@LOCAL_IP@:34702,@LOCAL_IP@:34703
+cluster_id = 3

--- a/src/core/tests/gtest.filter
+++ b/src/core/tests/gtest.filter
@@ -1,4 +1,4 @@
 config-test.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*
-config-test-sim.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*
+config-test-sim.ini -core.corrupt_message:core.uri_to_cluster_id:core.aio*:core.operation_failed:tools_hpc.*
 config-test-fastrun.ini core.aio*:core.operation_failed:tools_hpc.*
 config-test-posix-aio.ini core.aio*:core.operation_failed


### PR DESCRIPTION
Cluster ID is used to determine the order of two writes from different clusters but happens to share the same value of timestamp (See "pegasus/src/base/pegasus_value_shema.h" for more details.). It's required to give each of the cluster an unique cluster ID to enable the duplication between two clusters. Currently to set up duplication on running clusters, it has to rolling update the configuration of all servers.

This PR provides a simple C API:
```c
extern DSN_API int dsn_uri_to_cluster_id(const char *url);
```
which helps retrieve the cluster id of an specified uri.