### PR TITLE
scripts: fix clang warning due to ccache

### DIFF
--- a/bin/compiler_info.cmake
+++ b/bin/compiler_info.cmake
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Sets COMPILER_FAMILY to 'clang' or 'gcc'
+# Sets COMPILER_VERSION to the version
+
+message("Running rdsn/bin/compiler_info.cmake")
+execute_process(COMMAND env LANG=C "${CMAKE_CXX_COMPILER}" -v
+                ERROR_VARIABLE COMPILER_VERSION_FULL)
+message(${COMPILER_VERSION_FULL})
+
+# clang on Linux and Mac OS X before 10.9
+if("${COMPILER_VERSION_FULL}" MATCHES ".*clang version.*")
+  set(COMPILER_FAMILY "clang")
+  string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1"
+    COMPILER_VERSION "${COMPILER_VERSION_FULL}")
+
+# gcc
+elseif("${COMPILER_VERSION_FULL}" MATCHES ".*gcc version.*")
+  set(COMPILER_FAMILY "gcc")
+  string(REGEX REPLACE ".*gcc version ([0-9\\.]+).*" "\\1"
+    COMPILER_VERSION "${COMPILER_VERSION_FULL}")
+else()
+  message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
+endif()
+message("Selected compiler ${COMPILER_FAMILY} ${COMPILER_VERSION}")
+
+# gcc (and some varieties of clang) mention the path prefix where system headers
+# and libraries are located.
+if("${COMPILER_VERSION_FULL}" MATCHES "Configured with: .* --prefix=([^ ]*)")
+  set(COMPILER_SYSTEM_PREFIX_PATH ${CMAKE_MATCH_1})
+  message("Selected compiler built with --prefix=${COMPILER_SYSTEM_PREFIX_PATH}")
+endif()
+

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -404,6 +404,7 @@ function(dsn_setup_compiler_flags)
         if(CCACHE_FOUND)
             set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
             set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+            add_compile_options(-Qunused-arguments)
             message("use ccache to speed up compilation")
         endif(CCACHE_FOUND)
 

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -1,3 +1,5 @@
+include(${CMAKE_CURRENT_LIST_DIR}/compiler_info.cmake)
+
 function(ms_add_project PROJ_LANG PROJ_TYPE PROJ_NAME PROJ_SRC PROJ_INC_PATH PROJ_LIBS PROJ_LIB_PATH PROJ_BINPLACES PROJ_BINDIRS DO_INSTALL)
     if(DEFINED DSN_DEBUG_CMAKE)
         message(STATUS "PROJ_LANG = ${PROJ_LANG}")
@@ -404,7 +406,9 @@ function(dsn_setup_compiler_flags)
         if(CCACHE_FOUND)
             set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
             set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-            add_compile_options(-Qunused-arguments)
+            if ("${COMPILER_FAMILY}" STREQUAL "clang")
+                add_compile_options(-Qunused-arguments)
+            endif()
             message("use ccache to speed up compilation")
         endif(CCACHE_FOUND)
 


### PR DESCRIPTION
This PR is to fix the compilation error (occurred after this commit: https://github.com/XiaoMi/rdsn/pull/105/files) when building with clang:

```sh
➜  rdsn git:(master) ✗ ./run.sh build --compiler clang-3.9,clang++-3.9

...
Scanning dependencies of target dsn.core
[  1%] Building CXX object src/apps/cli/CMakeFiles/dsn.cli.dir/cli_types.cpp.o
[  1%] Building CXX object src/dist/failure_detector/CMakeFiles/dsn.failure_detector.dir/failure_detector.cpp.o
[  1%] Building CXX object src/apps/nfs/CMakeFiles/dsn.nfs.dir/nfs_client_impl.cpp.o
[  1%] Building CXX object src/core/tools/hpc/CMakeFiles/dsn.tools.hpc.dir/fastrun.cpp.o
[  2%] Building CXX object src/core/tools/common/CMakeFiles/dsn.tools.common.dir/asio_net_provider.cpp.o
[  3%] Building CXX object src/dist/block_service/local/CMakeFiles/dsn.block_service.local.dir/local_service.cpp.o
[  3%] Building CXX object src/core/core/CMakeFiles/dsn.core.dir/admission_controller.cpp.o
clang: error: argument unused during compilation: '-I /home/mi/git/release/pegasus/rdsn/include'
clang: error: argument unused during compilation: '-I /home/mi/git/release/pegasus/rdsn/include/dsn/cpp/serialization_helper'
clang: error: argument unused during compilation: '-I /home/mi/git/release/pegasus/rdsn/src'
clang: error: argument unused during compilation: '-I /home/mi/git/release/pegasus/rdsn/thirdparty/output/include'
make[2]: *** [src/dist/failure_detector/CMakeFiles/dsn.failure_detector.dir/failure_detector.cpp.o] Error 1
make[1]: *** [src/dist/failure_detector/CMakeFiles/dsn.failure_detector.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

To ignore the warnings `clang: error: argument unused during compilation` we added an option to cmake 

```cmake
add_compile_options(-Qunused-arguments)
```

Since this option is only supported on clang, we added a compiler check (`compiler_info.cmake`, copied from cloudera/kudu) before it.