### PR TITLE
*: fix asan error due to odr-violation

### DIFF
--- a/src/apps/skv/CMakeLists.txt
+++ b/src/apps/skv/CMakeLists.txt
@@ -13,7 +13,19 @@ set(MY_PROJ_INC_PATH "")
 
 set(MY_BOOST_PACKAGES system filesystem)
 
-set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server fmt)
+set(MY_PROJ_LIBS
+        dsn_replica_server
+        dsn_meta_server
+        dsn.replication.clientlib
+        dsn.block_service.fds
+        dsn.block_service.local
+        galaxy-fds-sdk-cpp
+        PocoNet
+        PocoFoundation
+        PocoNetSSL
+        PocoJSON
+        fmt
+        )
 
 set(MY_PROJ_LIB_PATH "")
 

--- a/src/core/tools/hpc/hpc_logger.cpp
+++ b/src/core/tools/hpc/hpc_logger.cpp
@@ -242,7 +242,7 @@ void hpc_logger::flush()
     hpc_log_manager::instance().get_all_keys(threads);
 
     for (auto &tid : threads) {
-        __hpc_log_info__ *log;
+        __hpc_log_info__ *log = nullptr;
         if (!hpc_log_manager::instance().get(tid, log))
             continue;
 

--- a/src/core/tools/hpc/hpc_tail_logger.cpp
+++ b/src/core/tools/hpc/hpc_tail_logger.cpp
@@ -175,7 +175,7 @@ std::string hpc_tail_logger::search(const char *keyword,
     int log_count = 0;
 
     for (auto &tid : threads) {
-        __tail_log_info__ *log;
+        __tail_log_info__ *log = nullptr;
         if (!tail_log_manager::instance().get(tid, log))
             continue;
 

--- a/src/dist/replication/lib/CMakeLists.txt
+++ b/src/dist/replication/lib/CMakeLists.txt
@@ -11,8 +11,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_INC_PATH "")
 
-set(MY_PROJ_LIBS 
-    dsn.replication.clientlib
+set(MY_PROJ_LIBS
     dsn.failure_detector
     dsn.failure_detector.multimaster
     )

--- a/src/dist/replication/meta_server/CMakeLists.txt
+++ b/src/dist/replication/meta_server/CMakeLists.txt
@@ -12,7 +12,6 @@ set(MY_SRC_SEARCH_MODE "GLOB_RECURSE")
 set(MY_PROJ_INC_PATH)
 
 set(MY_PROJ_LIBS
-    dsn.replication.clientlib
     dsn.block_service.local
     dsn.block_service.fds
     dsn.failure_detector

--- a/src/dist/replication/test/meta_test/balancer_simulator/CMakeLists.txt
+++ b/src/dist/replication/test/meta_test/balancer_simulator/CMakeLists.txt
@@ -15,6 +15,11 @@ set(MY_PROJ_LIBS dsn_meta_server
                  dsn.replication.clientlib
                  dsn.block_service.local
                  dsn.block_service.fds
+                 galaxy-fds-sdk-cpp
+                 PocoNet
+                 PocoFoundation
+                 PocoNetSSL
+                 PocoJSON
                  fmt
                  gtest)
 


### PR DESCRIPTION
Asan (`-fsanitize=address`) reported a problem of odr-violation, which is caused by duplicate linking with dsn.clientlib (where `_kpartition_statusValues` is from). 
```
pegasus_server <- dsn_replica_server <-dsn.clientlib
               <- dsn_meta_server    <-dsn.clientlib
```

Since both `dsn_replica_server` and `dsn_meta_server` link with `dsn.clientlib`, the static symbols of it are all defined twice.

```
=================================================================
==26775==ERROR: AddressSanitizer: odr-violation (0x7f4944595820):
  [1] size=24 'dsn::replication::_kpartition_statusValues' /pegasus/rdsn/src/dist/replication/client_lib/replication_types.cpp:17:5
  [2] size=24 'dsn::replication::_kpartition_statusValues' /pegasus/rdsn/src/dist/replication/client_lib/replication_types.cpp:17:5
These globals were registered at these points:
  [1]:
    #0 0x8d2d70  (/pegasus/rdsn/builder/output/bin/pegasus_server/pegasus_server+0x8d2d70)
    #1 0x7f4943ce175b  (/pegasus/DSN_ROOT/lib/libdsn_replica_server.so+0x87075b)

  [2]:
    #0 0x8d2d70  (/pegasus/rdsn/builder/output/bin/pegasus_server/pegasus_server+0x8d2d70)
    #1 0x7f4942a2b40b  (/pegasus/DSN_ROOT/lib/libdsn_meta_server.so+0x8fd40b)

==26775==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'dsn::replication::_kpartition_statusValues' at /pegasus/rdsn/src/dist/replication/client_lib/replication_types.cpp:17:5
==26775==ABORTING
```

Environments:
- ubuntu 16.04
- binutils 2.26.1
- compiler: clang-4.0,clang++-4.0, GCC-4.8 and GCC-5.4 don't have this problem.
