### PR TITLE
rdsn: fix asio_rpc_session bug which may cause double free

### DIFF
--- a/include/dsn/c/api_utilities.h
+++ b/include/dsn/c/api_utilities.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <dsn/c/api_common.h>
+#include <dsn/utility/ports.h>
 
 /*!
 @defgroup logging Logging Service

--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -48,14 +48,15 @@ public:
     virtual ~ref_counter()
     {
         // 0xdeadbeef: 3735928559
-        // 0xfacedead: 4207861421
         dassert(_magic == 0xdeadbeef, "memory corrupted, could be double free or others");
 
+        // 0xfacedead: 4207861421
         _magic = 0xfacedead;
     }
 
     void add_ref()
     {
+        // 0xdeadbeef: 3735928559
         dassert(_magic == 0xdeadbeef, "memory corrupted, could be double free or others");
 
         // Increasing the reference counter can always be done with memory_order_relaxed:
@@ -67,6 +68,7 @@ public:
 
     void release_ref()
     {
+        // 0xdeadbeef: 3735928559
         dassert(_magic == 0xdeadbeef, "memory corrupted, could be double free or others");
 
         // It is important to enforce any possible access to the object in one thread

--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -37,7 +37,6 @@
 
 #include <atomic>
 #include <cassert>
-#include <dsn/c/api_utilities.h>
 
 namespace dsn {
 class ref_counter
@@ -48,7 +47,7 @@ public:
     virtual ~ref_counter()
     {
         // 0xdeadbeef: 3735928559
-        dassert(_magic == 0xdeadbeef, "memory corrupted, could be double free or others");
+        assert(_magic == 0xdeadbeef);
 
         // 0xfacedead: 4207861421
         _magic = 0xfacedead;
@@ -57,7 +56,7 @@ public:
     void add_ref()
     {
         // 0xdeadbeef: 3735928559
-        dassert(_magic == 0xdeadbeef, "memory corrupted, could be double free or others");
+        assert(_magic == 0xdeadbeef);
 
         // Increasing the reference counter can always be done with memory_order_relaxed:
         // New references to an object can only be formed from an existing reference,
@@ -69,7 +68,7 @@ public:
     void release_ref()
     {
         // 0xdeadbeef: 3735928559
-        dassert(_magic == 0xdeadbeef, "memory corrupted, could be double free or others");
+        assert(_magic == 0xdeadbeef);
 
         // It is important to enforce any possible access to the object in one thread
         //(through an existing reference) to happen before deleting the object in a different

--- a/include/dsn/utility/endians.h
+++ b/include/dsn/utility/endians.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <cstdint>
+#include <cassert>
 #include <endian.h>
-#include <dsn/service_api_c.h>
 #include <dsn/utility/string_view.h>
 
 namespace dsn {
@@ -57,7 +57,7 @@ private:
     void ensure(size_t sz)
     {
         size_t cap = _end - _ptr;
-        dassert(cap >= sz, "capacity %zu is not enough for %zu", cap, sz);
+        assert(cap >= sz);
     }
 
 private:
@@ -107,10 +107,7 @@ private:
         _size -= sz;
     }
 
-    void ensure(size_t sz)
-    {
-        dassert(_size >= sz, " content(%zu) is not enough for reading %zu size", _size, sz);
-    }
+    void ensure(size_t sz) { assert(_size >= sz); }
 
 private:
     const char *_p{nullptr};

--- a/src/core/tools/common/asio_net_provider.cpp
+++ b/src/core/tools/common/asio_net_provider.cpp
@@ -137,7 +137,9 @@ void asio_network_provider::do_accept()
                                      (std::shared_ptr<boost::asio::ip::tcp::socket> &)socket,
                                      null_parser,
                                      false);
-            this->on_server_session_accepted(s);
+            on_server_session_accepted(s);
+            // we should start read next after rpc session is completely created.
+            s->start_read_next();
         }
 
         do_accept();

--- a/src/core/tools/common/asio_net_provider.cpp
+++ b/src/core/tools/common/asio_net_provider.cpp
@@ -138,7 +138,8 @@ void asio_network_provider::do_accept()
                                      null_parser,
                                      false);
             on_server_session_accepted(s);
-            // we should start read next after rpc session is completely created.
+
+            // we should start read immediately after the rpc session is completely created.
             s->start_read_next();
         }
 

--- a/src/core/tools/common/asio_rpc_session.cpp
+++ b/src/core/tools/common/asio_rpc_session.cpp
@@ -170,8 +170,6 @@ asio_rpc_session::asio_rpc_session(asio_network_provider &net,
     : rpc_session(net, remote_addr, parser, is_client), _socket(socket)
 {
     set_options();
-    if (!is_client)
-        start_read_next();
 }
 
 void asio_rpc_session::on_failure(bool is_write)

--- a/src/core/tools/common/thrift_message_parser.cpp
+++ b/src/core/tools/common/thrift_message_parser.cpp
@@ -268,6 +268,7 @@ dsn::message_ex *thrift_message_parser::parse_message(const thrift_message_heade
 
     dsn_hdr->id = seqid;
     strncpy(dsn_hdr->rpc_name, fname.c_str(), DSN_MAX_TASK_CODE_NAME_LENGTH);
+    dsn_hdr->rpc_name[DSN_MAX_TASK_CODE_NAME_LENGTH - 1] = '\0';
     dsn_hdr->gpid.set_app_id(thrift_header.app_id);
     dsn_hdr->gpid.set_partition_index(thrift_header.partition_index);
     dsn_hdr->client.timeout_ms = thrift_header.client_timeout;


### PR DESCRIPTION
to fix #114 

原因是：在asio_network_provider::do_accept()中，新建的asio_rpc_session的构造函数中，调用了start_read_next()，进一步调用 asio_rpc_session::do_read()：先add_ref()，如果立即调用回调函数，会release_ref()，如果该release_ref()发生在构造函数返回之前，这个新建的对象asio_rpc_session就会被立即析构。在构造函数返回之后，do_accept()中继续持有和使用该对象，就会造成double free。

解决办法：asio_rpc_session的构造函数中不调用start_read_next()，而是在对象创建完成后，在外面调用start_read_next()。