### PR TITLE
perf-counter: bug fix & refactor

### DIFF
--- a/include/dsn/perf_counter/perf_counter.h
+++ b/include/dsn/perf_counter/perf_counter.h
@@ -53,11 +53,11 @@ typedef enum dsn_perf_counter_percentile_type_t {
     COUNTER_PERCENTILE_INVALID
 } dsn_perf_counter_percentile_type_t;
 
-const char *counter_type_to_string(dsn_perf_counter_type_t t);
-dsn_perf_counter_type_t counter_type_from_string(const char *str);
+const char *dsn_counter_type_to_string(dsn_perf_counter_type_t t);
+dsn_perf_counter_type_t dsn_counter_type_from_string(const char *str);
 
-const char *percentile_type_to_string(dsn_perf_counter_percentile_type_t t);
-dsn_perf_counter_percentile_type_t percentile_type_from_string(const char *str);
+const char *dsn_percentile_type_to_string(dsn_perf_counter_percentile_type_t t);
+dsn_perf_counter_percentile_type_t dsn_percentile_type_from_string(const char *str);
 
 namespace dsn {
 

--- a/include/dsn/perf_counter/perf_counter.h
+++ b/include/dsn/perf_counter/perf_counter.h
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
 #include <dsn/utility/enum_helper.h>
@@ -47,8 +38,8 @@ typedef enum dsn_perf_counter_type_t {
     COUNTER_TYPE_VOLATILE_NUMBER, // special kind of NUMBER which will be reset on get
     COUNTER_TYPE_RATE,
     COUNTER_TYPE_NUMBER_PERCENTILES,
-    COUNTER_TYPE_INVALID,
-    COUNTER_TYPE_COUNT
+    COUNTER_TYPE_COUNT,
+    COUNTER_TYPE_INVALID
 } dsn_perf_counter_type_t;
 
 typedef enum dsn_perf_counter_percentile_type_t {
@@ -62,29 +53,13 @@ typedef enum dsn_perf_counter_percentile_type_t {
     COUNTER_PERCENTILE_INVALID
 } dsn_perf_counter_percentile_type_t;
 
+const char *counter_type_to_string(dsn_perf_counter_type_t t);
+dsn_perf_counter_type_t counter_type_from_string(const char *str);
+
+const char *percentile_type_to_string(dsn_perf_counter_percentile_type_t t);
+dsn_perf_counter_percentile_type_t percentile_type_from_string(const char *str);
+
 namespace dsn {
-
-/*!
-@addtogroup tool-api-providers
-@{
-*/
-ENUM_BEGIN(dsn_perf_counter_type_t, COUNTER_TYPE_INVALID)
-ENUM_REG(COUNTER_TYPE_NUMBER)
-ENUM_REG(COUNTER_TYPE_VOLATILE_NUMBER)
-ENUM_REG(COUNTER_TYPE_RATE)
-ENUM_REG(COUNTER_TYPE_NUMBER_PERCENTILES)
-ENUM_END(dsn_perf_counter_type_t)
-
-ENUM_BEGIN(dsn_perf_counter_percentile_type_t, COUNTER_PERCENTILE_INVALID)
-ENUM_REG(COUNTER_PERCENTILE_50)
-ENUM_REG(COUNTER_PERCENTILE_90)
-ENUM_REG(COUNTER_PERCENTILE_95)
-ENUM_REG(COUNTER_PERCENTILE_99)
-ENUM_REG(COUNTER_PERCENTILE_999)
-ENUM_END(dsn_perf_counter_percentile_type_t)
-
-class perf_counter;
-typedef ref_ptr<perf_counter> perf_counter_ptr;
 
 class perf_counter : public ref_counter
 {
@@ -103,13 +78,13 @@ public:
 
     virtual void increment() = 0;
     virtual void decrement() = 0;
-    virtual void add(uint64_t val) = 0;
-    virtual void set(uint64_t val) = 0;
+    virtual void add(int64_t val) = 0;
+    virtual void set(int64_t val) = 0;
     virtual double get_value() = 0;
-    virtual uint64_t get_integer_value() = 0;
+    virtual int64_t get_integer_value() = 0;
     virtual double get_percentile(dsn_perf_counter_percentile_type_t type) = 0;
 
-    typedef std::vector<std::pair<uint64_t *, int>> samples_t;
+    typedef std::vector<std::pair<int64_t *, int>> samples_t;
 
     // return actual sample count, must <= required_sample_count
     virtual int get_latest_samples(int required_sample_count, /*out*/ samples_t &samples) const
@@ -118,7 +93,7 @@ public:
     }
 
     // return the latest sample value
-    virtual uint64_t get_latest_sample() const { return 0; }
+    virtual int64_t get_latest_sample() const { return 0; }
 
     const char *full_name() const { return _full_name.c_str(); }
     const char *app() const { return _app.c_str(); }
@@ -148,5 +123,6 @@ private:
     std::string _full_name;
     friend class perf_counters;
 };
-/*@}*/
+typedef ref_ptr<perf_counter> perf_counter_ptr;
+
 } // end namespace

--- a/include/dsn/perf_counter/perf_counter_utils.h
+++ b/include/dsn/perf_counter/perf_counter_utils.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <string>
+#include <dsn/cpp/json_helper.h>
+#include <dsn/perf_counter/perf_counter.h>
+
+namespace dsn {
+
+struct perf_counter_metric
+{
+    std::string name;
+    std::string type;
+    double value;
+    perf_counter_metric() : value(0) {}
+    perf_counter_metric(const char *n, dsn_perf_counter_type_t t, double v)
+        : name(n), type(counter_type_to_string(t)), value(v)
+    {
+    }
+    DEFINE_JSON_SERIALIZATION(name, type, value)
+};
+
+/// used for command of querying perf counter
+struct perf_counter_info
+{
+    std::string result; // OK or ERROR
+    int64_t timestamp;  // in seconds
+    std::string timestamp_str;
+    std::vector<perf_counter_metric> counters;
+    perf_counter_info() : timestamp(0) {}
+    DEFINE_JSON_SERIALIZATION(result, timestamp, timestamp_str, counters)
+};
+
+} // namespace dsn

--- a/include/dsn/perf_counter/perf_counter_utils.h
+++ b/include/dsn/perf_counter/perf_counter_utils.h
@@ -17,7 +17,7 @@ struct perf_counter_metric
     double value;
     perf_counter_metric() : value(0) {}
     perf_counter_metric(const char *n, dsn_perf_counter_type_t t, double v)
-        : name(n), type(counter_type_to_string(t)), value(v)
+        : name(n), type(dsn_counter_type_to_string(t)), value(v)
     {
     }
     DEFINE_JSON_SERIALIZATION(name, type, value)

--- a/include/dsn/perf_counter/perf_counter_wrapper.h
+++ b/include/dsn/perf_counter/perf_counter_wrapper.h
@@ -84,6 +84,7 @@ public:
     {
         dsn::perf_counter_ptr c =
             dsn::perf_counters::instance().get_app_counter(section, name, type, dsptr, true);
+        clear();
         _counter = c.get();
     }
 
@@ -96,6 +97,7 @@ public:
     {
         dsn::perf_counter_ptr c = dsn::perf_counters::instance().get_global_counter(
             app, section, name, type, dsptr, true);
+        clear();
         _counter = c.get();
     }
 

--- a/include/dsn/perf_counter/perf_counters.h
+++ b/include/dsn/perf_counter/perf_counters.h
@@ -32,29 +32,36 @@
 #include <map>
 #include <sstream>
 #include <queue>
+#include <functional>
 
 namespace dsn {
 
-// manager of all perf counters of the process, perf counter users can use get_xxx_counter
-// functions to get a specific perf counter and change the value.
-// monitor system can user get_all_counters to get all the perf counters values and push it to
-// some monitor dashboard
+///
+/// manager of all perf counters of the process, perf counter users can use get_xxx_counter
+/// functions to get a specific perf counter and change the value.
+/// monitor system can user get_all_counters to get all the perf counters values and push it to
+/// some monitor dashboard
+///
 class perf_counters : public dsn::utils::singleton<perf_counters>
 {
 public:
-    perf_counters(void);
-    ~perf_counters(void);
+    perf_counters();
+    ~perf_counters();
 
-    // get counter with (current_app_name, section, name), try to create a new one
-    // if create_if_not_exist==true
+    ///
+    /// get counter with (current_app_name, section, name), try to create a new one
+    /// if create_if_not_exist==true
+    ///
     perf_counter_ptr get_app_counter(const char *section,
                                      const char *name,
                                      dsn_perf_counter_type_t flags,
                                      const char *dsptr,
                                      bool create_if_not_exist);
 
-    // get counter with (app, section, name), try to create a new one
-    // if create_if_not_exist==true
+    ///
+    /// get counter with (app, section, name), try to create a new one
+    /// if create_if_not_exist==true
+    ///
     perf_counter_ptr get_global_counter(const char *app,
                                         const char *section,
                                         const char *name,
@@ -62,28 +69,63 @@ public:
                                         const char *dsptr,
                                         bool create_if_not_exist);
 
-    // please call remove_counter if a previous get_app_counter/get_global_counter is called
+    ///
+    /// please call remove_counter if a previous get_app_counter/get_global_counter is called
+    ///
     bool remove_counter(const char *full_name);
 
-    // get all the existed perf counters, useful for monitor system
-    void get_all_counters(/*out*/ std::vector<dsn::perf_counter_ptr> *counter_vec);
+    ///
+    /// Some types of perf counters(rate, volatile_number) may change it's value after you visit
+    /// it, so we'd better take a snapshot of all counters before the visiting in case that
+    /// we may get value of counters repeatedly.
+    ///
+    /// here we provider several functions to support these semantics:
+    ///     take_snapshot
+    ///     iterate_snapshot
+    ///     query_snapshot
+    ///
+    /// we you call take_snapshot, a snapshot of current counters and their values will be
+    /// stored in internal variables of perf_counters module,
+    /// then you can iterate all counters or query some specific counters.
+    /// if another take_snapshot is called, the old one will be overwrite.
+    ///
+    /// the snapshot will be protected by a read-write lock internally.
+    ///
+    /// when you read the snapshot, you should provide a callback called "snapshot_visitor".
+    /// this callback will be called once for each requested counter.
+    ///
+    /// TODO: totally eliminate this stupid snapshot feature with a better metrics library
+    /// (a metric library which doesn't have SIDE EFFECT when you visit metric!!!)
+    ///
+    typedef std::function<void(const dsn::perf_counter_ptr &counter, double value)>
+        snapshot_iterator;
+    void take_snapshot();
+    void iterate_snapshot(const snapshot_iterator &v);
 
-    static std::string list_counter(const std::vector<std::string> &args);
-    static std::string get_counter_value(const std::vector<std::string> &args);
-    static std::string get_counter_sample(const std::vector<std::string> &args);
+    // if found is not nullptr, then whether a counter was found will be stored in it
+    // that is to say:
+    //    if (found != nullptr && (*found)[i]==true) {
+    //        counters[i] is in the snapshot
+    //    }
+    void query_snapshot(const std::vector<std::string> &counters,
+                        const snapshot_iterator &v,
+                        std::vector<bool> *found);
+
+    // this function collects all counters to perf_counter_info which matches
+    // any of regular expression in args and returns the json representation
+    // of perf_counter_info
+    std::string list_snapshot_by_regexp(const std::vector<std::string> &args);
 
 private:
     // full_name = perf_counter::build_full_name(...);
-    perf_counter_ptr get_counter(const char *full_name);
-    std::string list_counter_internal(const std::vector<std::string> &args);
     perf_counter *new_counter(const char *app,
                               const char *section,
                               const char *name,
                               dsn_perf_counter_type_t type,
                               const char *dsptr);
+    void get_all_counters(std::vector<dsn::perf_counter_ptr> *all);
 
     mutable utils::rw_lock_nr _lock;
-
     // keep counter as a refptr to make the counter can be safely accessed
     // by get_all_counters and remove_counter concurrently
     //
@@ -94,7 +136,16 @@ private:
         perf_counter_ptr counter;
         int user_reference;
     };
-    std::map<std::string, counter_object> _counters;
+    std::unordered_map<std::string, counter_object> _counters;
+
+    mutable utils::rw_lock_nr _snapshot_lock;
+    struct counter_snapshot
+    {
+        perf_counter_ptr counter{nullptr};
+        double value{0.0};
+        bool updated_recently{false};
+    };
+    std::unordered_map<std::string, counter_snapshot> _snapshots;
 };
 
 } // end namespace dsn::utils

--- a/include/dsn/tool-api/task_queue.h
+++ b/include/dsn/tool-api/task_queue.h
@@ -77,7 +77,7 @@ public:
     int count() const { return _queue_length.load(std::memory_order_relaxed); }
     int decrease_count(int count = 1)
     {
-        _queue_length_counter->add((uint64_t)(-count));
+        _queue_length_counter->add((int64_t)(-count));
         return _queue_length.fetch_sub(count, std::memory_order_relaxed) - count;
     }
     int increase_count(int count = 1)

--- a/include/dsn/utility/utils.h
+++ b/include/dsn/utility/utils.h
@@ -104,5 +104,14 @@ inline int get_invalid_tid() { return -1; }
 // read it's stdout to output
 // and return the retcode of command
 int pipe_execute(const char *command, std::ostream &output);
+
+//
+// process_mem_usage(double &, double &) - takes two doubles by reference,
+// attempts to read the system-dependent data for a process' virtual memory
+// size and resident set size, and return the results in KB.
+//
+// On failure, returns 0.0, 0.0
+//
+void process_mem_usage(double &vm_usage, double &resident_set);
 }
 }

--- a/src/core/core/utils.cpp
+++ b/src/core/core/utils.cpp
@@ -39,6 +39,7 @@
 #include <sys/stat.h>
 #include <random>
 #include <iostream>
+#include <fstream>
 #include <memory>
 #include <array>
 
@@ -170,6 +171,43 @@ int pipe_execute(const char *command, std::ostream &output)
         }
     }
     return retcode;
+}
+
+void process_mem_usage(double &vm_usage, double &resident_set)
+{
+    using std::ios_base;
+    using std::ifstream;
+    using std::string;
+
+    vm_usage = 0.0;
+    resident_set = 0.0;
+
+    // 'file' stat seems to give the most reliable results
+    //
+    ifstream stat_stream("/proc/self/stat", ios_base::in);
+
+    // dummy vars for leading entries in stat that we don't care about
+    //
+    string pid, comm, state, ppid, pgrp, session, tty_nr;
+    string tpgid, flags, minflt, cminflt, majflt, cmajflt;
+    string utime, stime, cutime, cstime, priority, nice;
+    string O, itrealvalue, starttime;
+
+    // the two fields we want
+    //
+    unsigned long vsize;
+    long rss;
+
+    stat_stream >> pid >> comm >> state >> ppid >> pgrp >> session >> tty_nr >> tpgid >> flags >>
+        minflt >> cminflt >> majflt >> cmajflt >> utime >> stime >> cutime >> cstime >> priority >>
+        nice >> O >> itrealvalue >> starttime >> vsize >> rss; // don't care about the rest
+
+    stat_stream.close();
+
+    static long page_size_kb =
+        sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
+    vm_usage = vsize / 1024.0;
+    resident_set = rss * page_size_kb;
 }
 }
 }

--- a/src/core/perf_counter/builtin_counters.cpp
+++ b/src/core/perf_counter/builtin_counters.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <dsn/utility/utils.h>
+#include <dsn/c/api_utilities.h>
+#include "builtin_counters.h"
+
+namespace dsn {
+
+builtin_counters::builtin_counters()
+{
+    _memused_virt.init_global_counter("replica",
+                                      "server",
+                                      "memused.virt(MB)",
+                                      COUNTER_TYPE_NUMBER,
+                                      "virtual memory usages in MB");
+    _memused_res.init_global_counter("replica",
+                                     "server",
+                                     "memused.res(MB)",
+                                     COUNTER_TYPE_NUMBER,
+                                     "physically memory usages in MB");
+}
+
+builtin_counters::~builtin_counters() {}
+
+void builtin_counters::update_counters()
+{
+    double vm_usage;
+    double resident_set;
+    utils::process_mem_usage(vm_usage, resident_set);
+    uint64_t memused_virt = (uint64_t)vm_usage / 1024;
+    uint64_t memused_res = (uint64_t)resident_set / 1024;
+    _memused_virt->set(memused_virt);
+    _memused_res->set(memused_res);
+    ddebug("memused_virt = %" PRIu64 " MB, memused_res = %" PRIu64 "MB", memused_virt, memused_res);
+}
+}

--- a/src/core/perf_counter/builtin_counters.h
+++ b/src/core/perf_counter/builtin_counters.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <dsn/perf_counter/perf_counter_wrapper.h>
+
+namespace dsn {
+class builtin_counters : public dsn::utils::singleton<builtin_counters>
+{
+public:
+    builtin_counters();
+    ~builtin_counters();
+    void update_counters();
+
+private:
+    dsn::perf_counter_wrapper _memused_virt;
+    dsn::perf_counter_wrapper _memused_res;
+};
+}

--- a/src/core/perf_counter/perf_counter.cpp
+++ b/src/core/perf_counter/perf_counter.cpp
@@ -1,0 +1,37 @@
+#include <cstring>
+#include <dsn/perf_counter/perf_counter.h>
+
+static const char *ctypes[] = {
+    "NUMBER", "VOLATILE_NUMBER", "RATE", "PERCENTILE", "INVALID_COUNTER"};
+const char *counter_type_to_string(dsn_perf_counter_type_t t)
+{
+    if (t >= COUNTER_TYPE_COUNT)
+        return ctypes[COUNTER_TYPE_COUNT];
+    return ctypes[t];
+}
+
+dsn_perf_counter_type_t counter_type_from_string(const char *str)
+{
+    for (int i = 0; i < COUNTER_TYPE_COUNT; ++i) {
+        if (strcmp(str, ctypes[i]) == 0)
+            return (dsn_perf_counter_type_t)i;
+    }
+    return COUNTER_TYPE_INVALID;
+}
+
+static const char *ptypes[] = {"P50", "P90", "P95", "P99", "P999", "INVALID_PERCENTILE"};
+const char *percentile_type_to_string(dsn_perf_counter_percentile_type_t t)
+{
+    if (t >= COUNTER_PERCENTILE_COUNT)
+        return ptypes[COUNTER_PERCENTILE_COUNT];
+    return ptypes[t];
+}
+
+dsn_perf_counter_percentile_type_t percentile_type_from_string(const char *str)
+{
+    for (int i = 0; i < COUNTER_PERCENTILE_COUNT; ++i) {
+        if (strcmp(str, ptypes[i]) == 0)
+            return (dsn_perf_counter_percentile_type_t)i;
+    }
+    return COUNTER_PERCENTILE_INVALID;
+}

--- a/src/core/perf_counter/perf_counter.cpp
+++ b/src/core/perf_counter/perf_counter.cpp
@@ -3,14 +3,14 @@
 
 static const char *ctypes[] = {
     "NUMBER", "VOLATILE_NUMBER", "RATE", "PERCENTILE", "INVALID_COUNTER"};
-const char *counter_type_to_string(dsn_perf_counter_type_t t)
+const char *dsn_counter_type_to_string(dsn_perf_counter_type_t t)
 {
     if (t >= COUNTER_TYPE_COUNT)
         return ctypes[COUNTER_TYPE_COUNT];
     return ctypes[t];
 }
 
-dsn_perf_counter_type_t counter_type_from_string(const char *str)
+dsn_perf_counter_type_t dsn_counter_type_from_string(const char *str)
 {
     for (int i = 0; i < COUNTER_TYPE_COUNT; ++i) {
         if (strcmp(str, ctypes[i]) == 0)
@@ -20,14 +20,14 @@ dsn_perf_counter_type_t counter_type_from_string(const char *str)
 }
 
 static const char *ptypes[] = {"P50", "P90", "P95", "P99", "P999", "INVALID_PERCENTILE"};
-const char *percentile_type_to_string(dsn_perf_counter_percentile_type_t t)
+const char *dsn_percentile_type_to_string(dsn_perf_counter_percentile_type_t t)
 {
     if (t >= COUNTER_PERCENTILE_COUNT)
         return ptypes[COUNTER_PERCENTILE_COUNT];
     return ptypes[t];
 }
 
-dsn_perf_counter_percentile_type_t percentile_type_from_string(const char *str)
+dsn_perf_counter_percentile_type_t dsn_percentile_type_from_string(const char *str)
 {
     for (int i = 0; i < COUNTER_PERCENTILE_COUNT; ++i) {
         if (strcmp(str, ptypes[i]) == 0)

--- a/src/core/tests/perf_counter.cpp
+++ b/src/core/tests/perf_counter.cpp
@@ -83,7 +83,7 @@ static void perf_counter_add(perf_counter_ptr pc, const std::vector<int> &vec)
         add_threads[i]->join();
 }
 
-TEST(counter, perf_counter_atomic)
+TEST(perf_counter, perf_counter_atomic)
 {
     int ans = 0;
     std::vector<int> vec(10000, 0);
@@ -123,4 +123,42 @@ TEST(counter, perf_counter_atomic)
         for (int i = 0; i != COUNTER_PERCENTILE_COUNT; ++i)
             ddebug("%lf", counter->get_percentile((dsn_perf_counter_percentile_type_t)i));
     }
+}
+
+TEST(perf_counter, print_type)
+{
+    ASSERT_STREQ("NUMBER", counter_type_to_string(COUNTER_TYPE_NUMBER));
+    ASSERT_STREQ("VOLATILE_NUMBER", counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER));
+    ASSERT_STREQ("RATE", counter_type_to_string(COUNTER_TYPE_RATE));
+    ASSERT_STREQ("PERCENTILE", counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES));
+    ASSERT_STREQ("INVALID_COUNTER", counter_type_to_string(COUNTER_TYPE_INVALID));
+
+    ASSERT_EQ(COUNTER_TYPE_NUMBER,
+              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_NUMBER)));
+    ASSERT_EQ(COUNTER_TYPE_VOLATILE_NUMBER,
+              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER)));
+    ASSERT_EQ(COUNTER_TYPE_RATE,
+              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_RATE)));
+    ASSERT_EQ(COUNTER_TYPE_NUMBER_PERCENTILES,
+              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES)));
+    ASSERT_EQ(COUNTER_TYPE_INVALID, counter_type_from_string("xxxx"));
+
+    ASSERT_STREQ("P50", percentile_type_to_string(COUNTER_PERCENTILE_50));
+    ASSERT_STREQ("P90", percentile_type_to_string(COUNTER_PERCENTILE_90));
+    ASSERT_STREQ("P95", percentile_type_to_string(COUNTER_PERCENTILE_95));
+    ASSERT_STREQ("P99", percentile_type_to_string(COUNTER_PERCENTILE_99));
+    ASSERT_STREQ("P999", percentile_type_to_string(COUNTER_PERCENTILE_999));
+    ASSERT_STREQ("INVALID_PERCENTILE", percentile_type_to_string(COUNTER_PERCENTILE_INVALID));
+
+    ASSERT_EQ(COUNTER_PERCENTILE_50,
+              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_50)));
+    ASSERT_EQ(COUNTER_PERCENTILE_90,
+              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_90)));
+    ASSERT_EQ(COUNTER_PERCENTILE_95,
+              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_95)));
+    ASSERT_EQ(COUNTER_PERCENTILE_99,
+              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_99)));
+    ASSERT_EQ(COUNTER_PERCENTILE_999,
+              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_999)));
+    ASSERT_EQ(COUNTER_PERCENTILE_INVALID, percentile_type_from_string("afafda"));
 }

--- a/src/core/tests/perf_counter.cpp
+++ b/src/core/tests/perf_counter.cpp
@@ -127,38 +127,45 @@ TEST(perf_counter, perf_counter_atomic)
 
 TEST(perf_counter, print_type)
 {
-    ASSERT_STREQ("NUMBER", counter_type_to_string(COUNTER_TYPE_NUMBER));
-    ASSERT_STREQ("VOLATILE_NUMBER", counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER));
-    ASSERT_STREQ("RATE", counter_type_to_string(COUNTER_TYPE_RATE));
-    ASSERT_STREQ("PERCENTILE", counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES));
-    ASSERT_STREQ("INVALID_COUNTER", counter_type_to_string(COUNTER_TYPE_INVALID));
+    ASSERT_STREQ("NUMBER", dsn_counter_type_to_string(COUNTER_TYPE_NUMBER));
+    ASSERT_STREQ("VOLATILE_NUMBER", dsn_counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER));
+    ASSERT_STREQ("RATE", dsn_counter_type_to_string(COUNTER_TYPE_RATE));
+    ASSERT_STREQ("PERCENTILE", dsn_counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES));
+    ASSERT_STREQ("INVALID_COUNTER", dsn_counter_type_to_string(COUNTER_TYPE_INVALID));
 
     ASSERT_EQ(COUNTER_TYPE_NUMBER,
-              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_NUMBER)));
-    ASSERT_EQ(COUNTER_TYPE_VOLATILE_NUMBER,
-              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER)));
+              dsn_counter_type_from_string(dsn_counter_type_to_string(COUNTER_TYPE_NUMBER)));
+    ASSERT_EQ(
+        COUNTER_TYPE_VOLATILE_NUMBER,
+        dsn_counter_type_from_string(dsn_counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER)));
     ASSERT_EQ(COUNTER_TYPE_RATE,
-              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_RATE)));
-    ASSERT_EQ(COUNTER_TYPE_NUMBER_PERCENTILES,
-              counter_type_from_string(counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES)));
-    ASSERT_EQ(COUNTER_TYPE_INVALID, counter_type_from_string("xxxx"));
+              dsn_counter_type_from_string(dsn_counter_type_to_string(COUNTER_TYPE_RATE)));
+    ASSERT_EQ(
+        COUNTER_TYPE_NUMBER_PERCENTILES,
+        dsn_counter_type_from_string(dsn_counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES)));
+    ASSERT_EQ(COUNTER_TYPE_INVALID, dsn_counter_type_from_string("xxxx"));
 
-    ASSERT_STREQ("P50", percentile_type_to_string(COUNTER_PERCENTILE_50));
-    ASSERT_STREQ("P90", percentile_type_to_string(COUNTER_PERCENTILE_90));
-    ASSERT_STREQ("P95", percentile_type_to_string(COUNTER_PERCENTILE_95));
-    ASSERT_STREQ("P99", percentile_type_to_string(COUNTER_PERCENTILE_99));
-    ASSERT_STREQ("P999", percentile_type_to_string(COUNTER_PERCENTILE_999));
-    ASSERT_STREQ("INVALID_PERCENTILE", percentile_type_to_string(COUNTER_PERCENTILE_INVALID));
+    ASSERT_STREQ("P50", dsn_percentile_type_to_string(COUNTER_PERCENTILE_50));
+    ASSERT_STREQ("P90", dsn_percentile_type_to_string(COUNTER_PERCENTILE_90));
+    ASSERT_STREQ("P95", dsn_percentile_type_to_string(COUNTER_PERCENTILE_95));
+    ASSERT_STREQ("P99", dsn_percentile_type_to_string(COUNTER_PERCENTILE_99));
+    ASSERT_STREQ("P999", dsn_percentile_type_to_string(COUNTER_PERCENTILE_999));
+    ASSERT_STREQ("INVALID_PERCENTILE", dsn_percentile_type_to_string(COUNTER_PERCENTILE_INVALID));
 
-    ASSERT_EQ(COUNTER_PERCENTILE_50,
-              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_50)));
-    ASSERT_EQ(COUNTER_PERCENTILE_90,
-              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_90)));
-    ASSERT_EQ(COUNTER_PERCENTILE_95,
-              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_95)));
-    ASSERT_EQ(COUNTER_PERCENTILE_99,
-              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_99)));
-    ASSERT_EQ(COUNTER_PERCENTILE_999,
-              percentile_type_from_string(percentile_type_to_string(COUNTER_PERCENTILE_999)));
-    ASSERT_EQ(COUNTER_PERCENTILE_INVALID, percentile_type_from_string("afafda"));
+    ASSERT_EQ(
+        COUNTER_PERCENTILE_50,
+        dsn_percentile_type_from_string(dsn_percentile_type_to_string(COUNTER_PERCENTILE_50)));
+    ASSERT_EQ(
+        COUNTER_PERCENTILE_90,
+        dsn_percentile_type_from_string(dsn_percentile_type_to_string(COUNTER_PERCENTILE_90)));
+    ASSERT_EQ(
+        COUNTER_PERCENTILE_95,
+        dsn_percentile_type_from_string(dsn_percentile_type_to_string(COUNTER_PERCENTILE_95)));
+    ASSERT_EQ(
+        COUNTER_PERCENTILE_99,
+        dsn_percentile_type_from_string(dsn_percentile_type_to_string(COUNTER_PERCENTILE_99)));
+    ASSERT_EQ(
+        COUNTER_PERCENTILE_999,
+        dsn_percentile_type_from_string(dsn_percentile_type_to_string(COUNTER_PERCENTILE_999)));
+    ASSERT_EQ(COUNTER_PERCENTILE_INVALID, dsn_percentile_type_from_string("afafda"));
 }

--- a/src/core/tests/perf_counters.cpp
+++ b/src/core/tests/perf_counters.cpp
@@ -34,11 +34,13 @@
  */
 
 #include <dsn/perf_counter/perf_counters.h>
+#include <dsn/perf_counter/perf_counter_wrapper.h>
+#include <dsn/perf_counter/perf_counter_utils.h>
 #include <gtest/gtest.h>
 
 using namespace ::dsn;
 
-TEST(core, perf_counters)
+TEST(perf_counters, counter_create_remove)
 {
     perf_counter_ptr p;
 
@@ -100,4 +102,217 @@ TEST(core, perf_counters)
         "app", "test", "unexist_counter", COUNTER_TYPE_NUMBER, "", false);
     ASSERT_EQ(nullptr, p);
     ASSERT_FALSE(perf_counters::instance().remove_counter("app*test*unexist_counter"));
+}
+
+template <typename K, typename V>
+bool check_map_contains(const std::map<K, V> &super, const std::map<K, V> &sub)
+{
+    for (const auto &kv : sub) {
+        auto it = super.find(kv.first);
+        if (it == super.end()) {
+            return false;
+        }
+        if (it->second != kv.second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TEST(perf_counters, snapshot)
+{
+    std::map<std::string, dsn_perf_counter_type_t> expected;
+
+    std::map<std::string, dsn_perf_counter_type_t> counter_keys;
+    perf_counters::instance().take_snapshot();
+    perf_counters::snapshot_iterator iter = [&counter_keys](const dsn::perf_counter_ptr &ptr,
+                                                            double value) mutable {
+        counter_keys.emplace(ptr->full_name(), ptr->type());
+    };
+
+    counter_keys.clear();
+    expected = {
+        {"replica*server*memused.virt(MB)", COUNTER_TYPE_NUMBER},
+        {"replica*server*memused.res(MB)", COUNTER_TYPE_NUMBER},
+    };
+    perf_counters::instance().iterate_snapshot(iter);
+    // in the beginning, builtin counters are in counter_list
+    ASSERT_TRUE(check_map_contains(counter_keys, expected));
+
+    dsn::perf_counter_wrapper c1;
+    c1.init_global_counter("a", "s", "test_counter", COUNTER_TYPE_NUMBER, "");
+    dsn::perf_counter_wrapper c2;
+    c2.init_global_counter("a", "s", "test_counter", COUNTER_TYPE_NUMBER, "");
+
+    dsn::perf_counter_wrapper c3;
+    c3.init_global_counter("b", "s", "test_counter", COUNTER_TYPE_VOLATILE_NUMBER, "");
+    dsn::perf_counter_wrapper c4;
+    c4.init_global_counter("b", "s", "test_counter", COUNTER_TYPE_VOLATILE_NUMBER, "");
+
+    // snapshot will contain new counters
+    perf_counters::instance().take_snapshot();
+    counter_keys.clear();
+    expected = {
+        {"replica*server*memused.virt(MB)", COUNTER_TYPE_NUMBER},
+        {"replica*server*memused.res(MB)", COUNTER_TYPE_NUMBER},
+        {"a*s*test_counter", COUNTER_TYPE_NUMBER},
+        {"b*s*test_counter", COUNTER_TYPE_VOLATILE_NUMBER},
+    };
+    perf_counters::instance().iterate_snapshot(iter);
+    ASSERT_TRUE(check_map_contains(counter_keys, expected));
+
+    dsn::perf_counter_wrapper c5;
+    c5.init_global_counter("c", "s", "test_counter", COUNTER_TYPE_RATE, "");
+    dsn::perf_counter_wrapper c6;
+    c6.init_global_counter("c", "s", "test_counter", COUNTER_TYPE_RATE, "");
+
+    dsn::perf_counter_wrapper c7;
+    c7.init_global_counter("d", "s", "test_counter", COUNTER_TYPE_NUMBER_PERCENTILES, "");
+    dsn::perf_counter_wrapper c8;
+    c8.init_global_counter("d", "s", "test_counter", COUNTER_TYPE_NUMBER_PERCENTILES, "");
+
+    // new counters won't be contained in snapshot if you don't call "take snapshot"
+    counter_keys.clear();
+    expected = {
+        {"replica*server*memused.virt(MB)", COUNTER_TYPE_NUMBER},
+        {"replica*server*memused.res(MB)", COUNTER_TYPE_NUMBER},
+        {"a*s*test_counter", COUNTER_TYPE_NUMBER},
+        {"b*s*test_counter", COUNTER_TYPE_VOLATILE_NUMBER},
+    };
+    perf_counters::instance().iterate_snapshot(iter);
+    ASSERT_TRUE(check_map_contains(counter_keys, expected));
+    ASSERT_TRUE(counter_keys.find("c*s*test_counter") == counter_keys.end());
+    ASSERT_TRUE(counter_keys.find("d*s*test_counter") == counter_keys.end());
+
+    // after taking snapshot, new counters will be contained
+    counter_keys.clear();
+    expected = {
+        {"replica*server*memused.virt(MB)", COUNTER_TYPE_NUMBER},
+        {"replica*server*memused.res(MB)", COUNTER_TYPE_NUMBER},
+        {"a*s*test_counter", COUNTER_TYPE_NUMBER},
+        {"b*s*test_counter", COUNTER_TYPE_VOLATILE_NUMBER},
+        {"c*s*test_counter", COUNTER_TYPE_RATE},
+        {"d*s*test_counter", COUNTER_TYPE_NUMBER_PERCENTILES},
+    };
+    perf_counters::instance().take_snapshot();
+    perf_counters::instance().iterate_snapshot(iter);
+    ASSERT_TRUE(check_map_contains(counter_keys, expected));
+
+    c1.clear();
+    c2.clear();
+    c3.clear();
+    c4.clear();
+
+    // although remove counters, but snapshot won't been affected if you don't call take snapshot
+    counter_keys.clear();
+    perf_counters::instance().iterate_snapshot(iter);
+    expected = {
+        {"replica*server*memused.virt(MB)", COUNTER_TYPE_NUMBER},
+        {"replica*server*memused.res(MB)", COUNTER_TYPE_NUMBER},
+        {"a*s*test_counter", COUNTER_TYPE_NUMBER},
+        {"b*s*test_counter", COUNTER_TYPE_VOLATILE_NUMBER},
+        {"c*s*test_counter", COUNTER_TYPE_RATE},
+        {"d*s*test_counter", COUNTER_TYPE_NUMBER_PERCENTILES},
+    };
+    ASSERT_TRUE(check_map_contains(counter_keys, expected));
+
+    // after take snapshot, removed counters will be removed in snapshot
+    perf_counters::instance().take_snapshot();
+    counter_keys.clear();
+    perf_counters::instance().iterate_snapshot(iter);
+    expected = {
+        {"replica*server*memused.virt(MB)", COUNTER_TYPE_NUMBER},
+        {"replica*server*memused.res(MB)", COUNTER_TYPE_NUMBER},
+        {"c*s*test_counter", COUNTER_TYPE_RATE},
+        {"d*s*test_counter", COUNTER_TYPE_NUMBER_PERCENTILES},
+    };
+    ASSERT_TRUE(check_map_contains(counter_keys, expected));
+    ASSERT_TRUE(counter_keys.find("a*s*test_counter") == counter_keys.end());
+    ASSERT_TRUE(counter_keys.find("b*s*test_counter") == counter_keys.end());
+
+    // query snapshot
+    std::vector<std::string> target_keys = {
+        "a*s*test_counter", "c*s*test_counter", "b*s*test_counter", "d*s*test_counter"};
+    expected = {
+        {"c*s*test_counter", COUNTER_TYPE_RATE},
+        {"d*s*test_counter", COUNTER_TYPE_NUMBER_PERCENTILES},
+    };
+
+    counter_keys.clear();
+    perf_counters::instance().query_snapshot(target_keys, iter, nullptr);
+    ASSERT_EQ(2, counter_keys.size());
+    ASSERT_EQ(expected, counter_keys);
+
+    counter_keys.clear();
+    std::vector<bool> found;
+    perf_counters::instance().query_snapshot(target_keys, iter, &found);
+    ASSERT_EQ(4, found.size());
+    std::vector<bool> expected_found = {false, true, false, true};
+    ASSERT_EQ(expected_found, found);
+    ASSERT_EQ(expected, counter_keys);
+}
+
+TEST(perf_counters, query_snapshot_by_regexp)
+{
+    dsn::perf_counter_wrapper c1;
+    c1.init_global_counter("a", "s", "test_counter", COUNTER_TYPE_NUMBER, "");
+    dsn::perf_counter_wrapper c2;
+    c2.init_global_counter("a", "s", "test_counter", COUNTER_TYPE_NUMBER, "");
+
+    dsn::perf_counter_wrapper c3;
+    c3.init_global_counter("b", "s", "test_counter", COUNTER_TYPE_VOLATILE_NUMBER, "");
+    dsn::perf_counter_wrapper c4;
+    c4.init_global_counter("b", "s", "test_counter", COUNTER_TYPE_VOLATILE_NUMBER, "");
+
+    dsn::perf_counter_wrapper c5;
+    c5.init_global_counter("c", "s", "test_counter", COUNTER_TYPE_RATE, "");
+    dsn::perf_counter_wrapper c6;
+    c6.init_global_counter("c", "s", "test_counter", COUNTER_TYPE_RATE, "");
+
+    dsn::perf_counter_wrapper c7;
+    c7.init_global_counter("d", "s", "test_counter", COUNTER_TYPE_NUMBER_PERCENTILES, "");
+    dsn::perf_counter_wrapper c8;
+    c8.init_global_counter("d", "s", "test_counter", COUNTER_TYPE_NUMBER_PERCENTILES, "");
+
+    perf_counters::instance().take_snapshot();
+    std::string result = perf_counters::instance().list_snapshot_by_regexp({".*\\*s\\*.*"});
+
+    dsn::perf_counter_info info;
+    dsn::json::json_forwarder<dsn::perf_counter_info>::decode(
+        dsn::blob(result.c_str(), 0, result.size()), info);
+    ASSERT_STREQ("OK", info.result.c_str());
+    ASSERT_GT(info.timestamp, 0);
+    ASSERT_TRUE(!info.timestamp_str.empty());
+    printf("got timestamp: %s\n", info.timestamp_str.c_str());
+    ASSERT_EQ(4, info.counters.size());
+
+    std::map<std::string, std::string> expected = {
+        {"a*s*test_counter", counter_type_to_string(COUNTER_TYPE_NUMBER)},
+        {"b*s*test_counter", counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER)},
+        {"c*s*test_counter", counter_type_to_string(COUNTER_TYPE_RATE)},
+        {"d*s*test_counter", counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES)},
+    };
+    std::map<std::string, std::string> actual;
+    for (const dsn::perf_counter_metric &m : info.counters) {
+        actual.emplace(m.name, m.type);
+    }
+    ASSERT_EQ(expected, actual);
+
+    result = perf_counters::instance().list_snapshot_by_regexp({"hahaha"});
+    dsn::json::json_forwarder<dsn::perf_counter_info>::decode(
+        dsn::blob(result.c_str(), 0, result.size()), info);
+    ASSERT_STREQ("OK", info.result.c_str());
+    ASSERT_GT(info.timestamp, 0);
+    ASSERT_TRUE(!info.timestamp_str.empty());
+    printf("got timestamp: %s\n", info.timestamp_str.c_str());
+    ASSERT_TRUE(info.counters.empty());
+
+    result = perf_counters::instance().list_snapshot_by_regexp({""});
+    dsn::json::json_forwarder<dsn::perf_counter_info>::decode(
+        dsn::blob(result.c_str(), 0, result.size()), info);
+    ASSERT_STREQ("OK", info.result.c_str());
+    ASSERT_GT(info.timestamp, 0);
+    ASSERT_TRUE(!info.timestamp_str.empty());
+    printf("got timestamp: %s\n", info.timestamp_str.c_str());
+    ASSERT_TRUE(info.counters.empty());
 }

--- a/src/core/tests/perf_counters.cpp
+++ b/src/core/tests/perf_counters.cpp
@@ -287,10 +287,10 @@ TEST(perf_counters, query_snapshot_by_regexp)
     ASSERT_EQ(4, info.counters.size());
 
     std::map<std::string, std::string> expected = {
-        {"a*s*test_counter", counter_type_to_string(COUNTER_TYPE_NUMBER)},
-        {"b*s*test_counter", counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER)},
-        {"c*s*test_counter", counter_type_to_string(COUNTER_TYPE_RATE)},
-        {"d*s*test_counter", counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES)},
+        {"a*s*test_counter", dsn_counter_type_to_string(COUNTER_TYPE_NUMBER)},
+        {"b*s*test_counter", dsn_counter_type_to_string(COUNTER_TYPE_VOLATILE_NUMBER)},
+        {"c*s*test_counter", dsn_counter_type_to_string(COUNTER_TYPE_RATE)},
+        {"d*s*test_counter", dsn_counter_type_to_string(COUNTER_TYPE_NUMBER_PERCENTILES)},
     };
     std::map<std::string, std::string> actual;
     for (const dsn::perf_counter_metric &m : info.counters) {


### PR DESCRIPTION
1. change the value type of perf counters from unsigned to signed
2. move the feature take_snapshot/query_snapshot/query_counter_by_regexp
   from pegasus to rdsn, so as to support other executables to use these
   features conveniently
3. remove the useless query_counter interfaces in perf_counters
4. add some unit tests