### PR TITLE
cold_backup: some bug fix to support hdfs-fuse as storage media

### DIFF
--- a/include/dsn/tool-api/rpc_address.h
+++ b/include/dsn/tool-api/rpc_address.h
@@ -107,6 +107,9 @@ public:
 
     const char *to_string() const;
 
+    // return a.b.c.d if address is ipv4
+    const char *ipv4_str() const;
+
     std::string to_std_string() const { return std::string(to_string()); }
 
     bool from_string_ipv4(const char *s)

--- a/include/dsn/utility/strings.h
+++ b/include/dsn/utility/strings.h
@@ -46,5 +46,8 @@ replace_string(std::string subject, const std::string &search, const std::string
 std::string get_last_component(const std::string &input, const char splitters[]);
 
 char *trim_string(char *s);
+
+// calculate the md5 checksum of buffer
+std::string string_md5(const char *buffer, unsigned int length);
 }
 }

--- a/src/core/core/rpc_address.cpp
+++ b/src/core/core/rpc_address.cpp
@@ -191,6 +191,22 @@ void rpc_address::set_invalid()
 }
 
 static __thread fixed_size_buffer_pool<8, 256> bf;
+
+const char *rpc_address::ipv4_str() const
+{
+    char *p = bf.next();
+    auto sz = bf.get_chunk_size();
+    struct in_addr net_addr;
+
+    if (_addr.v4.type == HOST_TYPE_IPV4) {
+        net_addr.s_addr = htonl(ip());
+        inet_ntop(AF_INET, &net_addr, p, sz);
+    } else {
+        p = (char *)"invalid_ipv4";
+    }
+    return p;
+}
+
 const char *rpc_address::to_string() const
 {
     char *p = bf.next();

--- a/src/core/core/strings.cpp
+++ b/src/core/core/strings.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <sstream>
+#include <openssl/md5.h>
 #include <dsn/utility/strings.h>
 
 namespace dsn {
@@ -154,6 +155,33 @@ char *trim_string(char *s)
         s--;
     }
     return r;
+}
+
+std::string string_md5(const char *buffer, unsigned length)
+{
+    unsigned char out[MD5_DIGEST_LENGTH];
+    MD5_CTX c;
+    MD5_Init(&c);
+
+    int offset = 0;
+    while (offset < length) {
+        int block = length - offset;
+        if (block > 4096)
+            block = 4096;
+        MD5_Update(&c, buffer, block);
+        offset += block;
+    }
+    MD5_Final(out, &c);
+
+    char str[MD5_DIGEST_LENGTH * 2 + 1];
+    str[MD5_DIGEST_LENGTH * 2] = 0;
+    for (int n = 0; n < MD5_DIGEST_LENGTH; n++)
+        sprintf(str + n + n, "%02x", out[n]);
+
+    std::string result;
+    result.assign(str);
+
+    return result;
 }
 }
 }

--- a/src/dist/block_service/local/local_service.cpp
+++ b/src/dist/block_service/local/local_service.cpp
@@ -2,6 +2,11 @@
 
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/error_code.h>
+#include <dsn/utility/defer.h>
+#include <dsn/utility/utils.h>
+#include <dsn/utility/strings.h>
+
+#include <dsn/cpp/json_helper.h>
 #include <dsn/tool-api/task_tracker.h>
 #include "local_service.h"
 
@@ -14,17 +19,32 @@ namespace block_service {
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_LOCAL_SERVICE)
 DEFINE_TASK_CODE(LPC_LOCAL_SERVICE_CALL, TASK_PRIORITY_COMMON, THREAD_POOL_LOCAL_SERVICE)
 
+struct file_metadata
+{
+    uint64_t size;
+    std::string md5;
+    DEFINE_JSON_SERIALIZATION(size, md5)
+};
+
+std::string local_service::get_metafile(const std::string &filepath)
+{
+    std::string dir_part = utils::filesystem::remove_file_name(filepath);
+    std::string base_part = utils::filesystem::get_file_name(filepath);
+
+    return utils::filesystem::path_combine(dir_part, std::string(".") + base_part + ".meta");
+}
+
 local_service::local_service() {}
 
 local_service::local_service(const std::string &root) : _root(root) {}
 
-local_service::~local_service()
-{
-    // do nothing
-}
+local_service::~local_service() {}
 
 error_code local_service::initialize(const std::vector<std::string> &args)
 {
+    if (args.size() > 0 && _root.empty())
+        _root = args[0];
+
     if (_root.empty()) {
         ddebug("initialize local block service succeed with empty root");
     } else {
@@ -36,8 +56,8 @@ error_code local_service::initialize(const std::vector<std::string> &args)
                 return ERR_FS_INTERNAL;
             }
         }
+        ddebug("local block service initialize succeed with root(%s)", _root.c_str());
     }
-    ddebug("local block service initialize succeed");
     return ERR_OK;
 }
 
@@ -72,9 +92,15 @@ dsn::task_ptr local_service::list_dir(const ls_request &req,
                 ls_entry tentry;
                 tentry.is_directory = false;
 
-                for (const auto &file : children) {
-                    tentry.entry_name = ::dsn::utils::filesystem::get_file_name(file);
-                    resp.entries->emplace_back(tentry);
+                std::set<std::string> file_matcher;
+                for (const std::string &file : children) {
+                    file_matcher.insert(utils::filesystem::get_file_name(file));
+                }
+                for (const auto &file : file_matcher) {
+                    if (file_matcher.find(get_metafile(file)) != file_matcher.end()) {
+                        tentry.entry_name = file;
+                        resp.entries->emplace_back(tentry);
+                    }
                 }
             }
 
@@ -118,23 +144,25 @@ dsn::task_ptr local_service::create_file(const create_file_request &req,
     }
 
     auto create_file_background = [this, req, tsk]() {
-        std::string file_path = ::dsn::utils::filesystem::path_combine(_root, req.file_name);
+        std::string file_path = utils::filesystem::path_combine(_root, req.file_name);
+        std::string meta_file_path =
+            utils::filesystem::path_combine(_root, get_metafile(req.file_name));
         create_file_response resp;
         resp.err = ERR_OK;
 
-        if (::dsn::utils::filesystem::file_exists(file_path)) {
-            ddebug("file: %s already exist", file_path.c_str());
-            resp.file_handle = new local_file_object(file_path);
+        dsn::ref_ptr<local_file_object> f = new local_file_object(file_path);
+        if (utils::filesystem::file_exists(file_path) &&
+            utils::filesystem::file_exists(meta_file_path)) {
+
+            dinfo("file(%s) already exist", file_path.c_str());
+            resp.err = f->load_metadata();
         } else {
-            ddebug("start create file, file = %s", file_path.c_str());
-            if (!::dsn::utils::filesystem::create_file(file_path)) {
-                derror("create file: %s fail", file_path.c_str());
-                resp.err = ERR_FS_INTERNAL;
-            } else {
-                resp.file_handle = new local_file_object(file_path);
-                ddebug("create file succeed, file = %s", resp.file_handle->file_name().c_str());
-            }
+            resp.file_handle = new local_file_object(file_path);
+            dinfo("create file(%s) succeed, ", f->file_name().c_str());
         }
+
+        if (ERR_OK == resp.err)
+            resp.file_handle = f;
 
         tsk->enqueue_with(resp);
     };
@@ -154,9 +182,14 @@ dsn::task_ptr local_service::delete_file(const delete_file_request &req,
     auto delete_file_background = [this, req, tsk]() {
         delete_file_response resp;
         resp.err = ERR_OK;
-        ddebug("delete file(%s)", req.file_name.c_str());
-        std::string file = ::dsn::utils::filesystem::path_combine(_root, req.file_name);
+        dinfo("delete file(%s)", req.file_name.c_str());
 
+        // delete the meta data file.
+        // skip to check the result for simplicity
+        std::string meta_file = utils::filesystem::path_combine(_root, get_metafile(req.file_name));
+        utils::filesystem::remove_path(meta_file);
+
+        std::string file = utils::filesystem::path_combine(_root, req.file_name);
         if (::dsn::utils::filesystem::file_exists(file)) {
             if (!::dsn::utils::filesystem::remove_path(file)) {
                 resp.err = ERR_FS_INTERNAL;
@@ -179,9 +212,10 @@ dsn::task_ptr local_service::exist(const exist_request &req,
 {
     exist_future_ptr tsk(new exist_future(code, cb, 0));
     tsk->set_tracker(tracker);
-    auto exist_background = [req, tsk]() {
+    auto exist_background = [this, req, tsk]() {
         exist_response resp;
-        if (utils::filesystem::path_exists(req.path)) {
+        std::string meta_file = utils::filesystem::path_combine(_root, get_metafile(req.path));
+        if (utils::filesystem::path_exists(meta_file)) {
             resp.err = ERR_OK;
         } else {
             resp.err = ERR_OBJECT_NOT_FOUND;
@@ -201,31 +235,32 @@ dsn::task_ptr local_service::remove_path(const remove_path_request &req,
     remove_path_future_ptr tsk(new remove_path_future(code, cb, 0));
     tsk->set_tracker(tracker);
 
-    auto remove_path_background = [req, tsk]() {
+    auto remove_path_background = [this, req, tsk]() {
         remove_path_response resp;
         resp.err = ERR_OK;
 
-        bool is_need_truly_remove = true;
+        bool do_remove = true;
 
-        if (utils::filesystem::directory_exists(req.path)) {
-            auto res = utils::filesystem::is_directory_empty(req.path);
+        std::string full_path = utils::filesystem::path_combine(_root, req.path);
+        if (utils::filesystem::directory_exists(full_path)) {
+            auto res = utils::filesystem::is_directory_empty(full_path);
             if (res.first == ERR_OK) {
                 // directory is not empty & recursive = false
                 if (!res.second && !req.recursive) {
                     resp.err = ERR_DIR_NOT_EMPTY;
-                    is_need_truly_remove = false;
+                    do_remove = false;
                 }
             } else {
                 resp.err = ERR_FS_INTERNAL;
-                is_need_truly_remove = false;
+                do_remove = false;
             }
-        } else if (!utils::filesystem::file_exists(req.path)) {
+        } else if (!utils::filesystem::file_exists(full_path)) {
             resp.err = ERR_OBJECT_NOT_FOUND;
-            is_need_truly_remove = false;
+            do_remove = false;
         }
 
-        if (is_need_truly_remove) {
-            if (!utils::filesystem::remove_path(req.path)) {
+        if (do_remove) {
+            if (!utils::filesystem::remove_path(full_path)) {
                 resp.err = ERR_FS_INTERNAL;
             }
         }
@@ -238,24 +273,64 @@ dsn::task_ptr local_service::remove_path(const remove_path_request &req,
 }
 
 // local_file_object
-local_file_object::local_file_object(const std::string &name) : block_file(name)
+local_file_object::local_file_object(const std::string &name)
+    : block_file(name), _size(0), _md5_value(""), _has_meta_synced(false)
 {
-    _md5_value = compute_md5();
 }
 
 local_file_object::~local_file_object() {}
 
 const std::string &local_file_object::get_md5sum() { return _md5_value; }
 
-uint64_t local_file_object::get_size()
+uint64_t local_file_object::get_size() { return _size; }
+
+error_code local_file_object::load_metadata()
 {
-    if (!::dsn::utils::filesystem::file_exists(file_name())) {
-        return 0;
-    } else {
-        int64_t size = 0;
-        ::dsn::utils::filesystem::file_size(file_name(), size);
-        return static_cast<uint64_t>(size);
+    if (_has_meta_synced)
+        return ERR_OK;
+
+    std::string metadata_path = local_service::get_metafile(file_name());
+    std::ifstream is(metadata_path, std::ios::in);
+    if (!is.is_open()) {
+        dwarn("load meta data from %s failed, err = %s", utils::safe_strerror(errno));
+        return ERR_FS_INTERNAL;
     }
+    auto cleanup = dsn::defer([&is]() { is.close(); });
+
+    std::string data;
+    is >> data;
+
+    file_metadata meta;
+    bool ans = dsn::json::json_forwarder<file_metadata>::decode(
+        dsn::blob(data.c_str(), 0, data.size()), meta);
+    if (!ans) {
+        dwarn("decode meta data from json(%s) failed", data.c_str());
+        return ERR_FS_INTERNAL;
+    }
+    _size = meta.size;
+    _md5_value = meta.md5;
+    _has_meta_synced = true;
+    return ERR_OK;
+}
+
+error_code local_file_object::store_metadata()
+{
+    file_metadata meta;
+    meta.md5 = _md5_value;
+    meta.size = _size;
+
+    std::string metadata_path = local_service::get_metafile(file_name());
+    std::ofstream os(metadata_path, std::ios::out | std::ios::trunc);
+    if (!os.is_open()) {
+        dwarn("store to metadata file %s failed, err=%s",
+              metadata_path.c_str(),
+              utils::safe_strerror(errno));
+        return ERR_FS_INTERNAL;
+    }
+    auto cleanup = dsn::defer([&os]() { os.close(); });
+    dsn::json::json_forwarder<file_metadata>::encode(os, meta);
+
+    return ERR_OK;
 }
 
 dsn::task_ptr local_file_object::write(const write_request &req,
@@ -287,7 +362,14 @@ dsn::task_ptr local_file_object::write(const write_request &req,
                 fout.write(req.buffer.data(), req.buffer.length());
                 resp.written_size = req.buffer.length();
                 fout.close();
-                _md5_value = compute_md5();
+
+                // Currently we calc the meta data from source data, which save the io bandwidth
+                // a lot, but it is somewhat not correct.
+                _size = resp.written_size;
+                _md5_value = utils::string_md5(req.buffer.data(), req.buffer.length());
+                _has_meta_synced = true;
+
+                store_metadata();
             }
         }
         tsk->enqueue_with(resp);
@@ -310,42 +392,41 @@ dsn::task_ptr local_file_object::read(const read_request &req,
     auto read_func = [this, req, tsk]() {
         read_response resp;
         resp.err = ERR_OK;
-        if (!::dsn::utils::filesystem::file_exists(file_name())) {
+        if (!utils::filesystem::file_exists(file_name()) ||
+            !utils::filesystem::file_exists(local_service::get_metafile(file_name()))) {
             resp.err = ERR_OBJECT_NOT_FOUND;
         } else {
-            ddebug("start read file, file = %s", file_name().c_str());
-            // just read the whole file
-            int64_t file_sz = 0;
-            if (!::dsn::utils::filesystem::file_size(file_name(), file_sz)) {
-                dassert(false, "get file size failed, file = %s", file_name().c_str());
-                resp.err = ERR_FILE_OPERATION_FAILED;
-            }
-            int64_t total_sz = 0;
-            if (req.remote_length == -1 || req.remote_length > file_sz) {
-                total_sz = file_sz;
+            if ((resp.err = load_metadata()) != ERR_OK) {
+                dwarn("load meta data of %s failed", file_name().c_str());
             } else {
-                total_sz = req.remote_length;
-            }
+                int64_t file_sz = _size;
+                int64_t total_sz = 0;
+                if (req.remote_length == -1 || req.remote_length + req.remote_pos > file_sz) {
+                    total_sz = file_sz - req.remote_pos;
+                } else {
+                    total_sz = req.remote_length;
+                }
 
-            ddebug("read file(%s), size = %ld", file_name().c_str(), total_sz);
-            std::shared_ptr<char> buf = std::shared_ptr<char>(new char[total_sz + 1]);
-            std::ifstream fin(file_name(), std::ifstream::in);
-            if (!fin.is_open()) {
-                resp.err = ERR_FS_INTERNAL;
-            } else {
-                fin.seekg(static_cast<int64_t>(req.remote_pos), fin.beg);
-                fin.read(buf.get(), total_sz);
-                buf.get()[fin.gcount()] = '\0';
-                ddebug("read func, read value = %s", buf.get());
-                resp.buffer.assign(std::move(buf), 0, fin.gcount());
+                dinfo("read file(%s), size = %ld", file_name().c_str(), total_sz);
+                std::shared_ptr<char> buf = std::shared_ptr<char>(new char[total_sz + 1]);
+                std::ifstream fin(file_name(), std::ifstream::in);
+                if (!fin.is_open()) {
+                    resp.err = ERR_FS_INTERNAL;
+                } else {
+                    fin.seekg(static_cast<int64_t>(req.remote_pos), fin.beg);
+                    fin.read(buf.get(), total_sz);
+                    buf.get()[fin.gcount()] = '\0';
+                    resp.buffer.assign(std::move(buf), 0, fin.gcount());
+                }
+                fin.close();
             }
-            fin.close();
         }
 
         tsk->enqueue_with(resp);
         release_ref();
     };
-    ::dsn::tasking::enqueue(LPC_LOCAL_SERVICE_CALL, nullptr, std::move(read_func));
+
+    dsn::tasking::enqueue(LPC_LOCAL_SERVICE_CALL, nullptr, std::move(read_func));
     return tsk;
 }
 
@@ -360,52 +441,59 @@ dsn::task_ptr local_file_object::upload(const upload_request &req,
     auto upload_file_func = [this, req, tsk]() {
         upload_response resp;
         resp.err = ERR_OK;
-        if (!::dsn::utils::filesystem::file_exists(file_name())) {
-            if (!::dsn::utils::filesystem::create_file(file_name())) {
+        std::ifstream fin(req.input_local_name, std::ios_base::in);
+        if (!fin.is_open()) {
+            dwarn("open %s for read faied, err(%s)",
+                  req.input_local_name.c_str(),
+                  utils::safe_strerror(errno));
+            resp.err = ERR_FS_INTERNAL;
+        }
+
+        utils::filesystem::create_file(file_name());
+        std::ofstream fout(file_name(),
+                           std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+        if (!fout.is_open()) {
+            dwarn("open %s for write faied, err(%s)",
+                  file_name().c_str(),
+                  utils::safe_strerror(errno));
+            resp.err = ERR_FILE_OPERATION_FAILED;
+        }
+
+        if (resp.err == ERR_OK) {
+            dinfo("start to transfer the file, src_file = %s, des_file = %s",
+                  req.input_local_name.c_str(),
+                  file_name().c_str());
+            int64_t total_sz = 0;
+            char buf[max_length] = {'\0'};
+            while (!fin.eof()) {
+                fin.read(buf, max_length);
+                total_sz += fin.gcount();
+                fout.write(buf, fin.gcount());
+            }
+            dinfo("finish upload file, file = %s, total_size = %d", file_name().c_str(), total_sz);
+            fout.close();
+            fin.close();
+
+            resp.uploaded_size = static_cast<uint64_t>(total_sz);
+
+            _size = total_sz;
+            error_code res = utils::filesystem::md5sum(req.input_local_name, _md5_value);
+            if (res == dsn::ERR_OK) {
+                _has_meta_synced = true;
+                store_metadata();
+            } else {
                 resp.err = ERR_FS_INTERNAL;
             }
-        }
-        if (resp.err == ERR_OK) {
-            ddebug("start upload file, src = %s, des = %s",
-                   req.input_local_name.c_str(),
-                   file_name().c_str());
-            std::ifstream fin(req.input_local_name, std::ifstream::in);
-            std::ofstream fout(file_name(), std::ifstream::out | std::ifstream::trunc);
-            if (!fin.is_open() || !fout.is_open()) {
-                if (fin) {
-                    resp.err = ERR_FS_INTERNAL;
-                    fin.close();
-                }
-                if (fout) {
-                    resp.err = ERR_FILE_OPERATION_FAILED;
-                    fout.close();
-                }
-            }
-            if (resp.err == ERR_OK) {
-                ddebug("start to transfer the file, src_file = %s, des_file = %s",
-                       req.input_local_name.c_str(),
-                       file_name().c_str());
-                int64_t total_sz = 0;
-                char buf[max_length] = {'\0'};
-                while (!fin.eof()) {
-                    fin.read(buf, max_length);
-                    total_sz += fin.gcount();
-                    fout.write(buf, fin.gcount());
-                }
-                ddebug("finish upload file, file = %s, total_size = %d",
-                       file_name().c_str(),
-                       total_sz);
-                fout.close();
+        } else {
+            if (fin.is_open())
                 fin.close();
-                resp.uploaded_size = static_cast<uint64_t>(total_sz);
-                _md5_value = compute_md5();
-            }
+            if (fout.is_open())
+                fout.close();
         }
+
         tsk->enqueue_with(resp);
-        ddebug("%s: start to release_ref in upload file", file_name().c_str());
         release_ref();
     };
-    // push this task to thread_pool, make it work
     ::dsn::tasking::enqueue(LPC_LOCAL_SERVICE_CALL, nullptr, std::move(upload_file_func));
 
     return tsk;
@@ -429,34 +517,52 @@ dsn::task_ptr local_file_object::download(const download_request &req,
             resp.err = ERR_INVALID_PARAMETERS;
         }
 
-        std::ifstream fin(file_name(), std::ifstream::in);
-        std::ofstream fout(target_file, std::ifstream::out | std::ifstream::trunc);
-        if (!fin.is_open() || !fout.is_open()) {
-            if (fin) {
-                resp.err = ERR_FILE_OPERATION_FAILED;
-                fin.close();
-            }
-            if (fout) {
-                resp.err = ERR_FS_INTERNAL;
-                fout.close();
+        if (!_has_meta_synced) {
+            if (!utils::filesystem::file_exists(file_name()) ||
+                !utils::filesystem::file_exists(local_service::get_metafile(file_name()))) {
+                resp.err = ERR_OBJECT_NOT_FOUND;
             }
         }
+
         if (resp.err == ERR_OK) {
-            ddebug("start to transfer the file, src_file = %s, des_file = %s",
-                   file_name().c_str(),
-                   target_file.c_str());
-            int64_t total_sz = 0;
-            char buf[max_length] = {'\0'};
-            while (!fin.eof()) {
-                fin.read(buf, max_length);
-                total_sz += fin.gcount();
-                fout.write(buf, fin.gcount());
+            std::ifstream fin(file_name(), std::ifstream::in);
+            std::ofstream fout(target_file,
+                               std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+            if (!fin.is_open() || !fout.is_open()) {
+                if (fin) {
+                    resp.err = ERR_FILE_OPERATION_FAILED;
+                    fin.close();
+                }
+                if (fout) {
+                    resp.err = ERR_FS_INTERNAL;
+                    fout.close();
+                }
             }
-            ddebug(
-                "finish download file, file = %s, total_size = %d", target_file.c_str(), total_sz);
-            fout.close();
-            fin.close();
-            resp.downloaded_size = static_cast<uint64_t>(total_sz);
+            if (resp.err == ERR_OK) {
+                dinfo("start to transfer, src_file(%s), des_file(%s)",
+                      file_name().c_str(),
+                      target_file.c_str());
+                int64_t total_sz = 0;
+                char buf[max_length] = {'\0'};
+                while (!fin.eof()) {
+                    fin.read(buf, max_length);
+                    total_sz += fin.gcount();
+                    fout.write(buf, fin.gcount());
+                }
+                dinfo("finish download file(%s), total_size = %d", target_file.c_str(), total_sz);
+                fout.close();
+                fin.close();
+                resp.downloaded_size = static_cast<uint64_t>(total_sz);
+
+                _size = total_sz;
+                if ((resp.err = utils::filesystem::md5sum(target_file, _md5_value)) != ERR_OK) {
+                    dwarn("download %s failed when calculate the md5sum of %s",
+                          file_name().c_str(),
+                          target_file.c_str());
+                } else {
+                    _has_meta_synced = true;
+                }
+            }
         }
 
         tsk->enqueue_with(resp);
@@ -465,16 +571,6 @@ dsn::task_ptr local_file_object::download(const download_request &req,
     ::dsn::tasking::enqueue(LPC_LOCAL_SERVICE_CALL, nullptr, std::move(download_file_func));
 
     return tsk;
-}
-
-std::string local_file_object::compute_md5()
-{
-    std::string result;
-    if (::dsn::utils::filesystem::file_exists(file_name())) {
-        auto err = ::dsn::utils::filesystem::md5sum(file_name(), result);
-        dassert(err == ERR_OK, "local file object calculate md5 failed");
-    }
-    return result;
 }
 }
 }

--- a/src/dist/block_service/local/local_service.cpp
+++ b/src/dist/block_service/local/local_service.cpp
@@ -5,6 +5,7 @@
 #include <dsn/utility/defer.h>
 #include <dsn/utility/utils.h>
 #include <dsn/utility/strings.h>
+#include <dsn/utility/safe_strerror_posix.h>
 
 #include <dsn/cpp/json_helper.h>
 #include <dsn/tool-api/task_tracker.h>
@@ -292,7 +293,7 @@ error_code local_file_object::load_metadata()
     std::string metadata_path = local_service::get_metafile(file_name());
     std::ifstream is(metadata_path, std::ios::in);
     if (!is.is_open()) {
-        dwarn("load meta data from %s failed, err = %s", utils::safe_strerror(errno));
+        dwarn("load meta data from %s failed, err = %s", utils::safe_strerror(errno).c_str());
         return ERR_FS_INTERNAL;
     }
     auto cleanup = dsn::defer([&is]() { is.close(); });
@@ -324,7 +325,7 @@ error_code local_file_object::store_metadata()
     if (!os.is_open()) {
         dwarn("store to metadata file %s failed, err=%s",
               metadata_path.c_str(),
-              utils::safe_strerror(errno));
+              utils::safe_strerror(errno).c_str());
         return ERR_FS_INTERNAL;
     }
     auto cleanup = dsn::defer([&os]() { os.close(); });
@@ -445,7 +446,7 @@ dsn::task_ptr local_file_object::upload(const upload_request &req,
         if (!fin.is_open()) {
             dwarn("open %s for read faied, err(%s)",
                   req.input_local_name.c_str(),
-                  utils::safe_strerror(errno));
+                  utils::safe_strerror(errno).c_str());
             resp.err = ERR_FS_INTERNAL;
         }
 
@@ -455,7 +456,7 @@ dsn::task_ptr local_file_object::upload(const upload_request &req,
         if (!fout.is_open()) {
             dwarn("open %s for write faied, err(%s)",
                   file_name().c_str(),
-                  utils::safe_strerror(errno));
+                  utils::safe_strerror(errno).c_str());
             resp.err = ERR_FILE_OPERATION_FAILED;
         }
 

--- a/src/dist/block_service/local/local_service.h
+++ b/src/dist/block_service/local/local_service.h
@@ -41,6 +41,8 @@ public:
 
     virtual ~local_service();
 
+    static std::string get_metafile(const std::string &filepath);
+
 private:
     std::string _root;
 };
@@ -75,11 +77,16 @@ public:
                                    const download_callback &cb,
                                    dsn::task_tracker *tracker = nullptr) override;
 
+    error_code load_metadata();
+    error_code store_metadata();
+
 private:
     std::string compute_md5();
 
 private:
+    uint64_t _size;
     std::string _md5_value;
+    bool _has_meta_synced;
 };
 }
 }

--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -648,7 +648,7 @@ std::string get_remote_chkpt_dirname()
     // here using server address as suffix of remote_chkpt_dirname
     rpc_address local_address = dsn_primary_address();
     std::stringstream ss;
-    ss << "checkpoint@" << local_address.to_string();
+    ss << "chkpt_" << local_address.ipv4_str() << "_" << local_address.port();
     return ss.str();
 }
 


### PR DESCRIPTION
1. modify the cold backup path from checkpoint@a.b.c.d:port to chkpt_a.b.c.d_port, as old format not valid in hdfs
2. implement meta_data's query interface for local block service. in order to support meta-data querying, a small metadata file is added for each real file.