### PR TITLE
misc: reduce build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 2.8.8)
 
-#set(DSN_DEBUG_CMAKE TRUE)
-
 include(bin/dsn.cmake)
-#cmake_policy(SET CMP0048 NEW)
-#project(dsn VERSION 1.0 LANGUAGES C CXX)
+
 project(dsn C CXX)
 set(DSN_BUILD_RUNTIME TRUE)
 add_definitions(-DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=0)

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -378,6 +378,13 @@ function(dsn_add_object)
     dsn_add_project()
 endfunction(dsn_add_object)
 
+option(BUILD_TEST "build unit test" ON)
+function(dsn_add_test)
+    if(${BUILD_TEST})
+        dsn_add_executable()
+    endif()
+endfunction()
+
 function(dsn_setup_compiler_flags)
     ms_replace_compiler_flags("STATIC_LINK")
 

--- a/run.sh
+++ b/run.sh
@@ -61,6 +61,7 @@ function usage_build()
     echo "   -w|--warning_all      open all warnings when build, default no"
     echo "   --enable_gcov         generate gcov code coverage report, default no"
     echo "   -v|--verbose          build in verbose mode, default no"
+    echo "   --notest              build without building unit tests, default no"
     if [ "$ONLY_BUILD" == "NO" ]; then
         echo "   -m|--test_module      specify modules to test, split by ',',"
         echo "                         e.g., \"dsn.core.tests,dsn.tests\","
@@ -79,6 +80,7 @@ function run_build()
     WARNING_ALL=NO
     ENABLE_GCOV=NO
     RUN_VERBOSE=NO
+    NO_TEST=NO
     TEST_MODULE=""
     while [[ $# > 0 ]]; do
         key="$1"
@@ -124,6 +126,9 @@ function run_build()
                 ;;
             -v|--verbose)
                 RUN_VERBOSE=YES
+                ;;
+            --notest)
+                NO_TEST=YES
                 ;;
             -m|--test_module)
                 if [ "$ONLY_BUILD" == "YES" ]; then
@@ -175,7 +180,7 @@ function run_build()
     C_COMPILER="$C_COMPILER" CXX_COMPILER="$CXX_COMPILER" BUILD_TYPE="$BUILD_TYPE" \
         ONLY_BUILD="$ONLY_BUILD" CLEAR="$CLEAR" JOB_NUM="$JOB_NUM" \
         BOOST_DIR="$BOOST_DIR" WARNING_ALL="$WARNING_ALL" ENABLE_GCOV="$ENABLE_GCOV" \
-        RUN_VERBOSE="$RUN_VERBOSE" TEST_MODULE="$TEST_MODULE" $scripts_dir/build.sh
+        RUN_VERBOSE="$RUN_VERBOSE" TEST_MODULE="$TEST_MODULE" NO_TEST="$NO_TEST" $scripts_dir/build.sh
 }
 
 #####################

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -90,6 +90,14 @@ else
     echo "ENABLE_GCOV=NO"
 fi
 
+if [ "$NO_TEST" == "YES" ]
+then
+    echo "NO_TEST=YES"
+    CMAKE_OPTIONS="$CMAKE_OPTIONS -DBUILD_TEST=OFF"
+else
+    echo "NO_TEST=NO"
+fi
+
 # You can specify customized boost by defining BOOST_DIR.
 # Install boost like this:
 #   wget http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.zip?r=&ts=1442891144&use_mirror=jaist

--- a/src/apps/skv/CMakeLists.txt
+++ b/src/apps/skv/CMakeLists.txt
@@ -28,4 +28,4 @@ file(GLOB
 # Extra files that will be installed
 set(MY_BINPLACES ${RES_FILES})
 
-dsn_add_executable()
+dsn_add_test()

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -42,4 +42,4 @@ set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config-bad-section.ini"
 )
 add_definitions(-Wno-dangling-else)
 add_definitions(-DENABLE_FAIL)
-dsn_add_executable()
+dsn_add_test()

--- a/src/dist/nfs/test/CMakeLists.txt
+++ b/src/dist/nfs/test/CMakeLists.txt
@@ -26,4 +26,4 @@ set(MY_BINPLACES
     "${CMAKE_CURRENT_SOURCE_DIR}/run.sh"
 )
 
-dsn_add_executable()
+dsn_add_test()

--- a/src/dist/replication/test/meta_test/balancer_simulator/CMakeLists.txt
+++ b/src/dist/replication/test/meta_test/balancer_simulator/CMakeLists.txt
@@ -25,4 +25,4 @@ set(MY_BOOST_PACKAGES system filesystem)
 # Extra files that will be installed
 set(MY_BINPLACES "")
 
-dsn_add_executable()
+dsn_add_test()

--- a/src/dist/replication/test/meta_test/unit_test/CMakeLists.txt
+++ b/src/dist/replication/test/meta_test/unit_test/CMakeLists.txt
@@ -36,4 +36,4 @@ set(MY_BOOST_PACKAGES system filesystem)
 set(MY_BINPLACES clear.sh run.sh config-ddl-test.ini config-test.ini suite1 suite2)
 
 add_definitions(-DDSN_MOCK_TEST)
-dsn_add_executable()
+dsn_add_test()

--- a/src/dist/replication/test/replica_test/unit_test/CMakeLists.txt
+++ b/src/dist/replication/test/replica_test/unit_test/CMakeLists.txt
@@ -34,4 +34,4 @@ set(MY_BOOST_PACKAGES system filesystem)
 set(MY_BINPLACES clear.sh run.sh config-test.ini)
 
 add_definitions(-DDSN_MOCK_TEST)
-dsn_add_executable()
+dsn_add_test()

--- a/src/dist/replication/test/simple_kv/CMakeLists.txt
+++ b/src/dist/replication/test/simple_kv/CMakeLists.txt
@@ -47,8 +47,4 @@ set(MY_BINPLACES
     "${CASE_FILES}"
 )
 
-if(WIN32)
-    SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /ignore:4049 /ignore:4217")
-endif()
-
-dsn_add_executable()
+dsn_add_test()

--- a/src/tests/dsn/CMakeLists.txt
+++ b/src/tests/dsn/CMakeLists.txt
@@ -48,4 +48,4 @@ set(MY_BINPLACES
     "${CMAKE_CURRENT_SOURCE_DIR}/config-test.ini"
 )
 
-dsn_add_executable()
+dsn_add_test()


### PR DESCRIPTION
Support build without building unit test. By default rDSN always builds everything.

```
./run.sh build --notest
```

With this feature the total build time of rDSN was reduced from "3m 44s" to "2m 16s" on my PC.
It will be beneficial for low-end machine (eg. laptop or vm on travis-ci), and building unit test of rdsn in pegasus's CI can be avoided.
