### PR TITLE
core: remove useless code

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -24,16 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     Service API  in rDSN
- *
- * Revision history:
- *     Mar., 2015, @imzhenyu (Zhenyu Guo), first version
- *     Feb., 2016, @imzhenyu (Zhenyu Guo), add comments for V1 release
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
 #include <dsn/c/api_common.h>
@@ -267,11 +257,6 @@ extern DSN_API dsn::message_ex *dsn_rpc_call_wait(dsn::rpc_address server,
 /*! one-way RPC from client, no rpc response is expected */
 extern DSN_API void dsn_rpc_call_one_way(dsn::rpc_address server, dsn::message_ex *request);
 
-/*! this is to mimic a response is received when no real rpc is called */
-extern DSN_API void dsn_rpc_enqueue_response(dsn::rpc_response_task *rpc_call,
-                                             dsn::error_code err,
-                                             dsn::message_ex *response);
-
 /*@}*/
 
 /*@}*/
@@ -291,14 +276,6 @@ typedef struct
     int size;
 } dsn_file_buffer_t;
 
-/*! the following ctrl code are used by \ref dsn_file_ctrl. */
-typedef enum dsn_ctrl_code_t {
-    CTL_BATCH_INVALID = 0,
-    CTL_BATCH_WRITE = 1,            ///< (batch) set write batch size
-    CTL_MAX_CON_READ_OP_COUNT = 2,  ///< (throttling) maximum concurrent read ops
-    CTL_MAX_CON_WRITE_OP_COUNT = 3, ///< (throttling) maximum concurrent write ops
-} dsn_ctrl_code_t;
-
 /*!
  open file
 
@@ -315,9 +292,6 @@ extern DSN_API dsn::error_code dsn_file_close(dsn_handle_t file);
 
 /*! flush the buffer of the given file */
 extern DSN_API dsn::error_code dsn_file_flush(dsn_handle_t file);
-
-/*! get native handle: HANDLE for windows, int for non-windows */
-extern DSN_API void *dsn_file_native_handle(dsn_handle_t file);
 
 /*!
  read file asynchronously

--- a/src/core/core/disk_engine.cpp
+++ b/src/core/core/disk_engine.cpp
@@ -24,20 +24,7 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #include "disk_engine.h"
-#include <dsn/perf_counter/perf_counter.h>
-#include <dsn/tool-api/aio_provider.h>
-#include <dsn/utility/utils.h>
-#include <dsn/utility/transient_memory.h>
 
 using namespace dsn::utils;
 
@@ -88,12 +75,6 @@ aio_task *disk_write_queue::unlink_next_workload(void *plength)
 }
 
 disk_file::disk_file(dsn_handle_t handle) : _handle(handle) {}
-
-void disk_file::ctrl(dsn_ctrl_code_t code, int param)
-{
-    // TODO:
-    dassert(false, "NOT IMPLEMENTED");
-}
 
 aio_task *disk_file::read(aio_task *tsk)
 {
@@ -168,15 +149,6 @@ void disk_engine::start(aio_provider *provider)
     _provider = provider;
     _provider->start();
     _is_running = true;
-}
-
-void disk_engine::ctrl(dsn_handle_t fh, dsn_ctrl_code_t code, int param)
-{
-    if (nullptr == fh)
-        return;
-
-    auto df = (disk_file *)fh;
-    df->ctrl(code, param);
 }
 
 dsn_handle_t disk_engine::open(const char *file_name, int flag, int pmode)
@@ -365,4 +337,4 @@ void disk_engine::complete_io(aio_task *aio, error_code err, uint32_t bytes, int
     }
 }
 
-} // end namespace
+} // namespace dsn

--- a/src/core/core/disk_engine.h
+++ b/src/core/core/disk_engine.h
@@ -24,18 +24,10 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
 #include "service_engine.h"
+
 #include <dsn/utility/synchronize.h>
 #include <dsn/tool-api/aio_provider.h>
 #include <dsn/utility/work_queue.h>
@@ -61,7 +53,6 @@ class disk_file
 {
 public:
     disk_file(dsn_handle_t handle);
-    void ctrl(dsn_ctrl_code_t code, int param);
     aio_task *read(aio_task *tsk);
     aio_task *write(aio_task *tsk, void *ctx);
 
@@ -91,7 +82,6 @@ public:
     void read(aio_task *aio);
     void write(aio_task *aio);
 
-    void ctrl(dsn_handle_t fh, dsn_ctrl_code_t code, int param);
     disk_aio *prepare_aio_context(aio_task *tsk) { return _provider->prepare_aio_context(tsk); }
     service_node *node() const { return _node; }
 
@@ -107,4 +97,4 @@ private:
     service_node *_node;
 };
 
-} // end namespace
+} // namespace dsn

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -24,45 +24,18 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #include <dsn/service_api_c.h>
 #include <dsn/tool_api.h>
-#include <dsn/utility/enum_helper.h>
-#include <dsn/tool-api/auto_codes.h>
 #include <dsn/cpp/serialization.h>
-#include <dsn/tool-api/task_spec.h>
-#include <dsn/tool-api/zlock_provider.h>
-#include <dsn/tool-api/env_provider.h>
-#include <dsn/utility/factory_store.h>
-#include <dsn/tool-api/task.h>
-#include <dsn/utility/singleton_store.h>
-#include <dsn/utility/utils.h>
-
-#include <dsn/utility/config_api.h>
 #include <dsn/utility/filesystem.h>
-#include <dsn/utility/transient_memory.h>
 #include <dsn/tool-api/command_manager.h>
+#include <fstream>
+
 #include "service_engine.h"
 #include "rpc_engine.h"
 #include "disk_engine.h"
 #include "task_engine.h"
 #include "coredump.h"
-#include <fstream>
-
-#ifndef _WIN32
-#include <signal.h>
-#include <unistd.h>
-#else
-#include <TlHelp32.h>
-#endif
 
 //
 // global state
@@ -328,17 +301,6 @@ DSN_API void dsn_rpc_forward(dsn::message_ex *request, dsn::rpc_address addr)
                                             ::dsn::rpc_address(addr));
 }
 
-DSN_API void dsn_rpc_enqueue_response(dsn::rpc_response_task *rpc_call,
-                                      dsn::error_code err,
-                                      dsn::message_ex *response)
-{
-    dassert(rpc_call->spec().type == TASK_TYPE_RPC_RESPONSE,
-            "invalid task_type, type = %s",
-            enum_to_string(rpc_call->spec().type));
-    auto resp = ((::dsn::message_ex *)response);
-    rpc_call->enqueue(err, resp);
-}
-
 //------------------------------------------------------------------------------
 //
 // file operations
@@ -358,13 +320,6 @@ DSN_API dsn::error_code dsn_file_close(dsn_handle_t file)
 DSN_API dsn::error_code dsn_file_flush(dsn_handle_t file)
 {
     return ::dsn::task::get_current_disk()->flush(file);
-}
-
-// native HANDLE: HANDLE for windows, int for non-windows
-DSN_API void *dsn_file_native_handle(dsn_handle_t file)
-{
-    auto dfile = (::dsn::disk_file *)file;
-    return dfile->native_handle();
 }
 
 DSN_API void
@@ -451,74 +406,13 @@ DSN_API bool dsn_run_config(const char *config, bool sleep_after_init)
     return run(config, nullptr, sleep_after_init, name);
 }
 
-#ifdef _WIN32
-static BOOL SuspendAllThreads()
-{
-    std::map<uint32_t, HANDLE> threads;
-    uint32_t dwCurrentThreadId = ::GetCurrentThreadId();
-    uint32_t dwCurrentProcessId = ::GetCurrentProcessId();
-    HANDLE hSnapshot;
-    bool bChange = TRUE;
-
-    while (bChange) {
-        hSnapshot = ::CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-        if (hSnapshot == INVALID_HANDLE_VALUE) {
-            derror("CreateToolhelp32Snapshot failed, err = %d", ::GetLastError());
-            return FALSE;
-        }
-
-        THREADENTRY32 ti;
-        ZeroMemory(&ti, sizeof(ti));
-        ti.dwSize = sizeof(ti);
-        bChange = FALSE;
-
-        if (FALSE == ::Thread32First(hSnapshot, &ti)) {
-            derror("Thread32First failed, err = %d", ::GetLastError());
-            goto err;
-        }
-
-        do {
-            if (ti.th32OwnerProcessID == dwCurrentProcessId &&
-                ti.th32ThreadID != dwCurrentThreadId &&
-                threads.find(ti.th32ThreadID) == threads.end()) {
-                HANDLE hThread = ::OpenThread(THREAD_ALL_ACCESS, FALSE, ti.th32ThreadID);
-                if (hThread == NULL) {
-                    derror("OpenThread failed, err = %d", ::GetLastError());
-                    goto err;
-                }
-                ::SuspendThread(hThread);
-                ddebug("thread %d find and suspended ...", ti.th32ThreadID);
-                threads.insert(std::make_pair(ti.th32ThreadID, hThread));
-                bChange = TRUE;
-            }
-        } while (::Thread32Next(hSnapshot, &ti));
-
-        ::CloseHandle(hSnapshot);
-    }
-
-    return TRUE;
-
-err:
-    ::CloseHandle(hSnapshot);
-    return FALSE;
-}
-#endif
-
 NORETURN DSN_API void dsn_exit(int code)
 {
     printf("dsn exit with code %d\n", code);
     fflush(stdout);
     ::dsn::tools::sys_exit.execute(::dsn::SYS_EXIT_NORMAL);
 
-#if defined(_WIN32)
-    // TODO: do not use std::map above, coz when suspend the other threads, they may stop
-    // inside certain locks which causes deadlock
-    // SuspendAllThreads();
-    ::TerminateProcess(::GetCurrentProcess(), code);
-#else
     _exit(code);
-// kill(getpid(), SIGKILL);
-#endif
 }
 
 DSN_API bool dsn_mimic_app(const char *app_role, int index)
@@ -611,11 +505,13 @@ DSN_API void dsn_run(int argc, char **argv, bool sleep_after_init)
 
 namespace dsn {
 namespace tools {
+
 bool is_engine_ready() { return dsn_all.is_engine_ready(); }
 
 tool_app *get_current_tool() { return dsn_all.tool; }
-}
-}
+
+} // namespace tools
+} // namespace dsn
 
 extern void dsn_log_init();
 extern void dsn_core_init();
@@ -653,11 +549,7 @@ bool run(const char *config_file,
                                   "pause_on_start",
                                   false,
                                   "whether to pause at startup time for easier debugging")) {
-#if defined(_WIN32)
-        printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(::GetCurrentProcessId()));
-#else
         printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(getpid()));
-#endif
         getchar();
     }
 
@@ -724,12 +616,10 @@ bool run(const char *config_file,
     // init logging
     dsn_log_init();
 
-#ifndef _WIN32
     ddebug("init rdsn runtime, pid = %d, dsn_runtime_init_time_ms = %" PRIu64 " (%s)",
            (int)getpid(),
            dsn_runtime_init_time_ms(),
            init_time_buf);
-#endif
 
     // init toollets
     for (auto it = spec.toollets.begin(); it != spec.toollets.end(); ++it) {
@@ -859,4 +749,5 @@ void service_app::get_all_service_apps(std::vector<service_app *> *apps)
         apps->push_back(const_cast<service_app *>(node->get_service_app()));
     }
 }
-}
+
+} // namespace dsn


### PR DESCRIPTION
- remove the windows specific code
- remove `dsn_rpc_enqueue_response` since i don't find any places using it
- remove `disk_file::ctrl` and `disk_engine::ctrl` since they are not even implemented completely. We may reimplement this function when we need.
