### PR TITLE
scripts: revert "shift" on some options in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -111,19 +111,15 @@ function run_build()
             --enable_gcov)
                 ENABLE_GCOV=YES
                 BUILD_TYPE="debug"
-                shift
                 ;;
             -v|--verbose)
                 RUN_VERBOSE=YES
-                shift
                 ;;
             --notest)
                 NO_TEST=YES
-                shift
                 ;;
             --disable_gperf)
                 DISABLE_GPERF=YES
-                shift
                 ;;
             -m|--test_module)
                 if [ "$ONLY_BUILD" == "YES" ]; then


### PR DESCRIPTION
This PR is to fix the mistakes I made on #170 that adds `shift` after parsing some options. I'm sorry for that.