### PR TITLE
server: support to disable write on table

### DIFF
--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -556,6 +556,8 @@ const std::string backup_restore_constant::APP_ID("restore.app_id");
 const std::string backup_restore_constant::BACKUP_ID("restore.backup_id");
 const std::string backup_restore_constant::SKIP_BAD_PARTITION("restore.skip_bad_partition");
 
+const std::string replica_envs::DENY_CLIENT_WRITE("replica.deny_client_write");
+
 namespace cold_backup {
 std::string get_policy_path(const std::string &root, const std::string &policy_name)
 {

--- a/src/dist/replication/common/replication_common.h
+++ b/src/dist/replication/common/replication_common.h
@@ -149,6 +149,12 @@ public:
     static const std::string SKIP_BAD_PARTITION;
 };
 
+class replica_envs
+{
+public:
+    static const std::string DENY_CLIENT_WRITE;
+};
+
 namespace cold_backup {
 //
 //  Attention: when compose the path on block service, we use appname_appid, because appname_appid

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -236,6 +236,7 @@ private:
 
     // return false when update fails or replica is going to be closed
     bool update_app_envs(const std::map<std::string, std::string> &envs);
+    void update_app_envs_internal(const std::map<std::string, std::string> &envs);
     bool query_app_envs(/*out*/ std::map<std::string, std::string> &envs);
     bool update_configuration(const partition_configuration &config);
     bool update_local_configuration(const replica_configuration &config, bool same_ballot = false);
@@ -376,6 +377,7 @@ private:
 
     bool _inactive_is_transient; // upgrade to P/S is allowed only iff true
     bool _is_initializing;       // when initializing, switching to primary need to update ballot
+    volatile bool _deny_client_write = false;
 
     // perf counters
     perf_counter_wrapper _counter_private_log_size;

--- a/src/dist/replication/lib/replica_2pc.cpp
+++ b/src/dist/replication/lib/replica_2pc.cpp
@@ -46,6 +46,13 @@ void replica::on_client_write(task_code code, dsn::message_ex *request)
 {
     _checker.only_one_thread_access();
 
+    if (_deny_client_write) {
+        // Do not relay any message to the peer client to let it timeout, it's OK coz some users
+        // may retry immediately when they got a not success code which will make the server side
+        // pressure more and more heavy.
+        return;
+    }
+
     task_spec *spec = task_spec::get(code);
     if (!_options->allow_non_idempotent_write && !spec->rpc_request_is_write_idempotent) {
         response_client_message(false, request, ERR_OPERATION_DISABLED);

--- a/src/dist/replication/lib/replica_config.cpp
+++ b/src/dist/replication/lib/replica_config.cpp
@@ -38,7 +38,9 @@
 #include "mutation.h"
 #include "mutation_log.h"
 #include "replica_stub.h"
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/dist/replication/replication_app_base.h>
+#include <dsn/utility/string_conv.h>
 
 namespace dsn {
 namespace replication {
@@ -532,10 +534,23 @@ void replica::on_update_configuration_on_meta_server_reply(
 bool replica::update_app_envs(const std::map<std::string, std::string> &envs)
 {
     if (_app) {
+        update_app_envs_internal(envs);
         _app->update_app_envs(envs);
         return true;
     } else {
         return false;
+    }
+}
+
+void replica::update_app_envs_internal(const std::map<std::string, std::string> &envs)
+{
+    bool deny_client_write = false;
+    auto find = envs.find(replica_envs::DENY_CLIENT_WRITE);
+    if (find != envs.end() && buf2bool(find->second, deny_client_write)) {
+        if (deny_client_write != _deny_client_write) {
+            _deny_client_write = deny_client_write;
+            ddebug_replica("switch _deny_client_write to {}", _deny_client_write);
+        }
     }
 }
 


### PR DESCRIPTION
support to disable write on table by set environment variable on table:
```
>>> use temp
OK
>>> set_app_envs replica.deny_client_write true               // disable write
set app envs succeed
>>> set_app_envs replica.deny_client_write false              // enable write
set app envs succeed
>>> 
```