### PR TITLE
scripts: improve build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ cache:
 
 before_install:
     - wget https://raw.githubusercontent.com/xiaomi/pegasus-common/master/build-depends.tar.gz
-    - tar xf build-depends.tar.gz
+    - tar xfz build-depends.tar.gz
+    - rm -f build-depends.tar.gz
     - cd packages
     - ls | xargs sudo dpkg -i --force-depends
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,8 @@ install:
 before_script:
     - cd thirdparty
     - wget https://raw.githubusercontent.com/xiaomi/pegasus-common/master/pegasus-thirdparty-prebuild.tar.gz
-    - tar xf pegasus-thirdparty-prebuild.tar.gz
-    - rm -rf pegasus-thirdparty-prebuild.tar.gz
-    - wget https://raw.githubusercontent.com/xiaomi/pegasus-common/master/zookeeper-3.4.10.tar.gz
-    - mkdir src/
-    - tar xf zookeeper-3.4.10.tar.gz -C src
-    - rm -rf zookeeper-3.4.10.tar.gz
+    - tar xfz pegasus-thirdparty-prebuild.tar.gz
+    - rm -f pegasus-thirdparty-prebuild.tar.gz
     - cd ..
     - ulimit -c unlimited -S
 

--- a/compile_thrift.py
+++ b/compile_thrift.py
@@ -102,7 +102,7 @@ print "root_dir = " + root_dir
 
 if not os.path.isfile(thrift_exe):
     os.system("wget --no-check-certificate "
-              "https://github.com/imzhenyu/thrift/raw/master/pre-built/ubuntu14.04/thrift "
+              "https://github.com/xiaomi/pegasus-common/raw/master/pre-built/ubuntu14.04/thrift "
               "&& chmod u+x thrift "
               "&& mv thrift "+thrift_exe)
 

--- a/compile_thrift.py
+++ b/compile_thrift.py
@@ -100,6 +100,11 @@ root_dir = os.getcwd()
 print "thrift_exe = " + thrift_exe
 print "root_dir = " + root_dir
 
+if not os.path.isfile(thrift_exe):
+    os.system("wget --no-check-certificate "
+              "https://github.com/imzhenyu/thrift/raw/master/pre-built/ubuntu14.04/thrift "
+              "&& chmod u+x thrift "
+              "&& mv thrift "+thrift_exe)
 
 class CompileError(Exception):
     """ Raised when dealing with thrift idl have errors"""

--- a/run.sh
+++ b/run.sh
@@ -240,7 +240,7 @@ function usage_start_zk()
     echo "   -d|--install_dir <dir>"
     echo "                     zookeeper install directory,"
     echo "                     if not set, then default is './.zk_install'"
-    echo "   -p|--port <port>  listen port of zookeeper, default is 22181"
+    echo "   -p|--port <port>  listen port of zookeeper, default is 12181"
 }
 
 function run_start_zk()
@@ -253,7 +253,7 @@ function run_start_zk()
     type nc >/dev/null 2>&1 || { echo >&2 "start zk failed, need install netcat command..."; exit 1;}
 
     INSTALL_DIR=`pwd`/.zk_install
-    PORT=22181
+    PORT=12181
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in

--- a/run.sh
+++ b/run.sh
@@ -70,9 +70,10 @@ function run_build()
     JOB_NUM=8
     BOOST_DIR=""
     ENABLE_GCOV=NO
-    SKIP_THIRDPARTY=NO
     RUN_VERBOSE=NO
     NO_TEST=NO
+    DISABLE_GPERF=NO
+    SKIP_THIRDPARTY=NO
     TEST_MODULE=""
     while [[ $# > 0 ]]; do
         key="$1"
@@ -125,7 +126,6 @@ function run_build()
                 ;;
             --skip_thirdparty)
                 SKIP_THIRDPARTY=YES
-                echo "run.sh build: skip building third-parties"
                 ;;
             -m|--test_module)
                 if [ "$ONLY_BUILD" == "YES" ]; then
@@ -147,7 +147,9 @@ function run_build()
         shift
     done
 
-    if [[ ${SKIP_THIRDPARTY} != "YES" ]]; then
+    if [[ ${SKIP_THIRDPARTY} == "YES" ]]; then
+        echo "Skip building thirdparty..."
+    else
         # build thirdparty first
         cd thirdparty
         if [[ "$CLEAR_THIRDPARTY" == "YES" ]]; then
@@ -155,6 +157,7 @@ function run_build()
             rm -rf src build output &>/dev/null
             CLEAR=YES
         fi
+        echo "Start building thirdparty..."
         ./download-thirdparty.sh
         exit_if_fail $?
         if [[ "x"$BOOST_DIR != "x" ]]; then

--- a/run.sh
+++ b/run.sh
@@ -233,27 +233,33 @@ function usage_start_zk()
 {
     echo "Options for subcommand 'start_zk':"
     echo "   -h|--help         print the help info"
-    echo "   -p|--port <port>  listen port of zookeeper, default is 12181"
+    echo "   -d|--install_dir <dir>"
+    echo "                     zookeeper install directory,"
+    echo "                     if not set, then default is './.zk_install'"
+    echo "   -p|--port <port>  listen port of zookeeper, default is 22181"
 }
+
 function run_start_zk()
 {
-    if [[ ! -d `pwd`/thirdparty/src/zookeeper-3.4.10/bin ]]; then
-        # download zk before starting zk service
-        # here we simply download all the third-parties
-        `pwd`/thirdparty/download-thirdparty.sh
-    else
-        echo "skip download zookeeper"
-    fi
-    exit_if_fail $?
+    # first we check the environment that zk need: java and nc command
+    # check java
+    type java >/dev/null 2>&1 || { echo >&2 "start zk failed, need install jre..."; exit 1;}
 
-    DOWNLOADED_DIR=`pwd`/thirdparty/src
-    PORT=12181
+    # check nc command
+    type nc >/dev/null 2>&1 || { echo >&2 "start zk failed, need install netcat command..."; exit 1;}
+
+    INSTALL_DIR=`pwd`/.zk_install
+    PORT=22181
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
             -h|--help)
                 usage_start_zk
                 exit 0
+                ;;
+            -d|--install_dir)
+                INSTALL_DIR=$2
+                shift
                 ;;
             -p|--port)
                 PORT=$2
@@ -268,7 +274,7 @@ function run_start_zk()
         esac
         shift
     done
-    DOWNLOADED_DIR="$DOWNLOADED_DIR" PORT="$PORT" $scripts_dir/start_zk.sh
+    INSTALL_DIR="$INSTALL_DIR" PORT="$PORT" ./scripts/start_zk.sh
 }
 
 #####################
@@ -278,16 +284,23 @@ function usage_stop_zk()
 {
     echo "Options for subcommand 'stop_zk':"
     echo "   -h|--help         print the help info"
+    echo "   -d|--install_dir <dir>"
+    echo "                     zookeeper install directory,"
+    echo "                     if not set, then default is './.zk_install'"
 }
 function run_stop_zk()
 {
-    DOWNLOADED_DIR=`pwd`/thirdparty/src
+    INSTALL_DIR=`pwd`/.zk_install
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
             -h|--help)
                 usage_stop_zk
                 exit 0
+                ;;
+            -d|--install_dir)
+                INSTALL_DIR=$2
+                shift
                 ;;
             *)
                 echo "ERROR: unknown option \"$key\""
@@ -298,7 +311,7 @@ function run_stop_zk()
         esac
         shift
     done
-    DOWNLOADED_DIR="$DOWNLOADED_DIR" $scripts_dir/stop_zk.sh
+    INSTALL_DIR="$INSTALL_DIR" ./scripts/stop_zk.sh
 }
 
 #####################
@@ -308,16 +321,23 @@ function usage_clear_zk()
 {
     echo "Options for subcommand 'clear_zk':"
     echo "   -h|--help         print the help info"
+    echo "   -d|--install_dir <dir>"
+    echo "                     zookeeper install directory,"
+    echo "                     if not set, then default is './.zk_install'"
 }
 function run_clear_zk()
 {
-    DOWNLOADED_DIR=`pwd`/thirdparty/src
+    INSTALL_DIR=`pwd`/.zk_install
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
             -h|--help)
                 usage_clear_zk
                 exit 0
+                ;;
+            -d|--install_dir)
+                INSTALL_DIR=$2
+                shift
                 ;;
             *)
                 echo "ERROR: unknown option \"$key\""
@@ -328,7 +348,7 @@ function run_clear_zk()
         esac
         shift
     done
-    DOWNLOADED_DIR="$DOWNLOADED_DIR" $scripts_dir/clear_zk.sh
+    INSTALL_DIR="$INSTALL_DIR" ./scripts/clear_zk.sh
 }
 
 ####################################################################

--- a/run.sh
+++ b/run.sh
@@ -274,7 +274,7 @@ function run_start_zk()
         esac
         shift
     done
-    INSTALL_DIR="$INSTALL_DIR" PORT="$PORT" ./scripts/start_zk.sh
+    INSTALL_DIR="$INSTALL_DIR" PORT="$PORT" ./scripts/linux/start_zk.sh
 }
 
 #####################
@@ -311,7 +311,7 @@ function run_stop_zk()
         esac
         shift
     done
-    INSTALL_DIR="$INSTALL_DIR" ./scripts/stop_zk.sh
+    INSTALL_DIR="$INSTALL_DIR" ./scripts/linux/stop_zk.sh
 }
 
 #####################
@@ -348,7 +348,7 @@ function run_clear_zk()
         esac
         shift
     done
-    INSTALL_DIR="$INSTALL_DIR" ./scripts/clear_zk.sh
+    INSTALL_DIR="$INSTALL_DIR" ./scripts/linux/clear_zk.sh
 }
 
 ####################################################################

--- a/run.sh
+++ b/run.sh
@@ -178,6 +178,10 @@ function run_build()
     fi
     if [ "$ONLY_BUILD" == "NO" ]; then
         run_start_zk
+        if [ $? -ne 0 ]; then
+            echo "ERROR: start zk failed"
+            exit 1
+        fi
     fi
     C_COMPILER="$C_COMPILER" CXX_COMPILER="$CXX_COMPILER" BUILD_TYPE="$BUILD_TYPE" \
         ONLY_BUILD="$ONLY_BUILD" CLEAR="$CLEAR" JOB_NUM="$JOB_NUM" \

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -127,14 +127,6 @@ then
     rm -rf $BUILD_DIR
 fi
 
-if [ ! -f "$ROOT/bin/Linux/thrift" ]
-then
-    echo "Downloading thrift..."
-    wget --no-check-certificate https://github.com/imzhenyu/thrift/raw/master/pre-built/ubuntu14.04/thrift
-    chmod u+x thrift
-    mv thrift $ROOT/bin/Linux
-fi
-
 if [ ! -d "$BUILD_DIR" ]
 then
     echo "Running cmake..."

--- a/scripts/linux/clear_zk.sh
+++ b/scripts/linux/clear_zk.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 #
 # Options:
-#    DOWNLOADED_DIR    <dir>
+#    INSTALL_DIR    <dir>
 
-if [ -z "$DOWNLOADED_DIR" ]
+if [ -z "$INSTALL_DIR" ]
 then
-    echo "ERROR: no DOWNLOADED_DIR specified"
+    echo "ERROR: no INSTALL_DIR specified"
     exit 1
 fi
 
-cd $DOWNLOADED_DIR
+cd $INSTALL_DIR
 
-ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.6
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then
@@ -19,4 +19,3 @@ then
     rm -rf $ZOOKEEPER_HOME/data &>/dev/null
     echo "Clearing zookeeper ... CLEARED"
 fi
-

--- a/scripts/linux/start_zk.sh
+++ b/scripts/linux/start_zk.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 # Options:
-#    DOWNLOADED_DIR    <dir>
+#    INSTALL_DIR    <dir>
 #    PORT           <port>
 
-if [ -z "$DOWNLOADED_DIR" ]
+if [ -z "$INSTALL_DIR" ]
 then
     echo "ERROR: no INSTALL_DIR specified"
     exit 1
@@ -16,9 +16,39 @@ then
     exit 1
 fi
 
-cd $DOWNLOADED_DIR
+mkdir -p $INSTALL_DIR
+if [ $? -ne 0 ]
+then
+    echo "ERROR: mkdir $PREFIX failed"
+    exit 1
+fi
 
-ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
+cd $INSTALL_DIR
+
+if [ ! -f zookeeper-3.4.6.tar.gz ]; then
+    echo "Downloading zookeeper..."
+    download_url="http://git.n.xiaomi.com/pegasus/packages/raw/master/zookeeper-3.4.6.tar.gz"
+    wget -T 5 -t 1 $download_url
+    if [ $? -ne 0 ]; then
+        download_url="https://github.com/xiaomi/pegasus-common/raw/master/zookeeper-3.4.6.tar.gz"
+        wget -T 5 -t 1 $download_url
+        if [ $? -ne 0 ]; then
+            echo "ERROR: download zookeeper failed"
+            exit 1
+        fi
+    fi
+fi
+
+if [ ! -d zookeeper-3.4.6 ]; then
+    echo "Decompressing zookeeper..."
+    tar xfz zookeeper-3.4.6.tar.gz
+    if [ $? -ne 0 ]; then
+        echo "ERROR: decompress zookeeper failed"
+        exit 1
+    fi
+fi
+
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.6
 ZOOKEEPER_PORT=$PORT
 
 cp $ZOOKEEPER_HOME/conf/zoo_sample.cfg $ZOOKEEPER_HOME/conf/zoo.cfg
@@ -27,8 +57,8 @@ sed -i "s@clientPort=2181@clientPort=$ZOOKEEPER_PORT@" $ZOOKEEPER_HOME/conf/zoo.
 
 mkdir -p $ZOOKEEPER_HOME/data
 $ZOOKEEPER_HOME/bin/zkServer.sh start
+sleep 0.1
 
-sleep 2
 if echo ruok | nc localhost $ZOOKEEPER_PORT | grep -q imok; then
     echo "Zookeeper started at port $ZOOKEEPER_PORT"
     exit 0

--- a/scripts/linux/start_zk.sh
+++ b/scripts/linux/start_zk.sh
@@ -57,7 +57,7 @@ sed -i "s@clientPort=2181@clientPort=$ZOOKEEPER_PORT@" $ZOOKEEPER_HOME/conf/zoo.
 
 mkdir -p $ZOOKEEPER_HOME/data
 $ZOOKEEPER_HOME/bin/zkServer.sh start
-sleep 0.1
+sleep 1
 
 if echo ruok | nc localhost $ZOOKEEPER_PORT | grep -q imok; then
     echo "Zookeeper started at port $ZOOKEEPER_PORT"

--- a/scripts/linux/stop_zk.sh
+++ b/scripts/linux/stop_zk.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 #
 # Options:
-#    DOWNLOADED_DIR    <dir>
+#    INSTALL_DIR    <dir>
 
-if [ -z "$DOWNLOADED_DIR" ]
+if [ -z "$INSTALL_DIR" ]
 then
-    echo "ERROR: no DOWNLOADED_DIR specified"
+    echo "ERROR: no INSTALL_DIR specified"
     exit 1
 fi
 
-cd $DOWNLOADED_DIR
+cd $INSTALL_DIR
 
-ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.6
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then
     $ZOOKEEPER_HOME/bin/zkServer.sh stop
 fi
-

--- a/src/core/core/rpc_address.cpp
+++ b/src/core/core/rpc_address.cpp
@@ -105,7 +105,9 @@ uint32_t rpc_address::ipv4_from_network_interface(const char *network_interface)
                     ret = (uint32_t)ntohl(ip_val);
                     break;
                 } else {
-                    ddebug("skip interface(%s), address(%08X)", i->ifa_name, ip_val);
+                    dinfo("skip interface(%s), address(%s)",
+                          i->ifa_name,
+                          rpc_address(ip_val, 0).ipv4_str());
                 }
             }
             i = i->ifa_next;
@@ -115,9 +117,9 @@ uint32_t rpc_address::ipv4_from_network_interface(const char *network_interface)
             derror("get local ip from network interfaces failed, network_interface = %s",
                    network_interface);
         } else {
-            ddebug("get ip address from network interface(%s), addr(%08X), input interface(%s)",
+            ddebug("get ip address from network interface(%s), addr(%s), input interface(\"%s\")",
                    i->ifa_name,
-                   ret,
+                   rpc_address(ret, 0).ipv4_str(),
                    network_interface);
         }
 

--- a/src/core/tests/run.sh
+++ b/src/core/tests/run.sh
@@ -26,7 +26,8 @@ while read -r -a line; do
         fi
         exit 1
     fi
+    echo "============ done dsn.core.tests ${test_case} with gtest_filter ${gtest_filter} ============"
 done <gtest.filter
 
-echo "============ done ============"
+echo "============ done dsn.core.tests ============"
 

--- a/src/tests/dsn/distributed_lock_zookeeper.cpp
+++ b/src/tests/dsn/distributed_lock_zookeeper.cpp
@@ -37,7 +37,8 @@ public:
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
         _dlock_service = new distributed_lock_service_zookeeper();
-        dassert(_dlock_service->initialize({"/dsn/tests/simple_adder_server"}) == ERR_OK, "");
+        auto err = _dlock_service->initialize({"/dsn/tests/simple_adder_server"});
+        dassert(err == ERR_OK, "err = %s", err.to_string());
 
         distributed_lock_service::lock_options opt = {true, true};
         while (!ss_finish) {

--- a/src/tests/dsn/restart_zookeeper.sh
+++ b/src/tests/dsn/restart_zookeeper.sh
@@ -4,6 +4,5 @@ pushd ../../../
 while [ 0 -lt 1 ]; do
     ./run.sh stop_zk
     ./run.sh start_zk
-    sleep 3
 done
 popd

--- a/src/tests/dsn/restart_zookeeper.sh
+++ b/src/tests/dsn/restart_zookeeper.sh
@@ -4,5 +4,6 @@ pushd ../../../
 while [ 0 -lt 1 ]; do
     ./run.sh stop_zk
     ./run.sh start_zk
+    sleep 3
 done
 popd

--- a/src/tests/dsn/run.sh
+++ b/src/tests/dsn/run.sh
@@ -2,7 +2,7 @@
 
 function prepare_environment()
 {
-    if [ $1 = "distributed_lock_service_zookeeper.simple_lock_unlock" ]; then
+    if [ $1 == "distributed_lock_service_zookeeper.simple_lock_unlock" ]; then
         echo "test $1, try to restart to zookeeper service periodically"
         ./restart_zookeeper.sh >output.log 2>&1 &
     fi
@@ -10,7 +10,7 @@ function prepare_environment()
 
 function destroy_environment()
 {
-    if [ $1 = "distributed_lock_service_zookeeper.simple_lock_unlock" ]; then
+    if [ $1 == "distributed_lock_service_zookeeper.simple_lock_unlock" ]; then
         echo "stop restart-zookeeper process"
         ps aux | grep restart_zookeeper | grep -v "grep" | awk '{print $2}' | xargs kill -9
         echo "make sure the zookeeper is started"
@@ -26,8 +26,9 @@ fi
 filters="distributed_lock_service_zookeeper.simple_lock_unlock -distributed_lock_service_zookeeper.simple_lock_unlock"
 
 for filter in $filters; do
+    echo "============ run dsn.tests with gtest_filter ${filter} ============"
     output_xml="${REPORT_DIR}/dsn.tests.xml"
-    prepare_environment $filter
+    #prepare_environment $filter
 
     GTEST_OUTPUT="xml:${output_xml}" GTEST_FILTER=$filter ./dsn.tests config-test.ini
     if [ $? -ne 0 ]; then
@@ -42,9 +43,10 @@ for filter in $filters; do
             echo "---- gdb ./dsn.tests core ----"
             gdb ./dsn.tests core -ex "thread apply all bt" -ex "set pagination 0" -batch
         fi
-        destroy_environment $filter
+        #destroy_environment $filter
         exit 1
     fi
 
-    destroy_environment $filter
+    #destroy_environment $filter
+    echo "============ done dsn.tests with gtest_filter ${filter} ============"
 done

--- a/src/tests/dsn/run.sh
+++ b/src/tests/dsn/run.sh
@@ -27,7 +27,7 @@ filters="distributed_lock_service_zookeeper.simple_lock_unlock -distributed_lock
 
 for filter in $filters; do
     output_xml="${REPORT_DIR}/dsn.tests.xml"
-    #prepare_environment $filter
+    prepare_environment $filter
 
     GTEST_OUTPUT="xml:${output_xml}" GTEST_FILTER=$filter ./dsn.tests config-test.ini
     if [ $? -ne 0 ]; then
@@ -45,5 +45,6 @@ for filter in $filters; do
         destroy_environment $filter
         exit 1
     fi
-    #destroy_environment $filter
+
+    destroy_environment $filter
 done


### PR DESCRIPTION
主要改动点：
* 改进pegasus-thirdparty-prebuild，包含完整的依赖，譬如gflags
* 改进start_zk.sh，不再依赖thirdparty/src，避免在travis里面额外下载zookeeper
* 编译时不再下载bin/Linux/thrift，只在调用compile_thrift.py时按需要下载