### PR TITLE
lint: files under include/dsn/utility/ pass cpplint (Part 1)

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,20 @@
+# Stop searching for additional config files.
+set noparent
+
+# rDSN uses `#pragma once`, not the `#ifndef FOO_H` guard.
+filter=-build/header_guard
+filter=+build/pragma_once
+
+# Disable a warning about C++ features that were not in the original
+# C++11 specification (and so might not be well-supported).
+filter=-build/c++11
+
+# Limit line length.
+linelength=100
+
+filter=-whitespace/comments
+filter=-whitespace/braces
+filter=-whitespace/indent
+
+# TODO(wutao1): use pointer instead of mutable references.
+filter=-runtime/references

--- a/include/dsn/utility/apply.h
+++ b/include/dsn/utility/apply.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <dsn/utility/absl/utility/utility.h>
+#include "dsn/utility/absl/utility/utility.h"
 
 namespace dsn {
 

--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
 #include <atomic>
@@ -83,11 +74,11 @@ public:
         }
     }
 
-    long get_count() const { return _counter.load(); }
+    int32_t get_count() const { return _counter.load(); }
 
 protected:
     unsigned int _magic;
-    std::atomic<long> _counter;
+    std::atomic<int32_t> _counter;
 
 public:
     ref_counter(const ref_counter &) = delete;
@@ -100,14 +91,14 @@ class ref_ptr
 public:
     ref_ptr() : _obj(nullptr) {}
 
-    ref_ptr(T *obj) : _obj(obj)
+    ref_ptr(T *obj) : _obj(obj) // NOLINT(runtime/explicit)
     {
         if (nullptr != _obj)
             _obj->add_ref();
     }
 
     template <typename U>
-    ref_ptr(U *obj) : _obj(obj)
+    ref_ptr(U *obj) : _obj(obj) // NOLINT(runtime/explicit)
     {
         if (nullptr != _obj)
             _obj->add_ref();
@@ -229,4 +220,4 @@ private:
     friend class ref_ptr;
 };
 
-} // end namespace dsn
+} // namespace dsn

--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -92,7 +92,7 @@ template <typename T>
 inline int binary_reader::read_pod(/*out*/ T &val)
 {
     if (sizeof(T) <= get_remaining_size()) {
-        memcpy(reinterpret_cast<void *>(&val), _ptr, sizeof(T));
+        memcpy(&val, _ptr, sizeof(T));
         _ptr += sizeof(T);
         _remaining_size -= sizeof(T);
         return static_cast<int>(sizeof(T));

--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -1,15 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #pragma once
 
 #include <cstring>
-#include <dsn/utility/blob.h>
+#include <string>
+
+#include "dsn/utility/blob.h"
 
 namespace dsn {
 class binary_reader
 {
 public:
     // given bb on ctor
-    binary_reader(const blob &blob);
-    binary_reader(blob &&blob);
+    explicit binary_reader(const blob &blob);
+    explicit binary_reader(blob &&blob);
 
     // or delayed init
     binary_reader() {}
@@ -64,7 +92,7 @@ template <typename T>
 inline int binary_reader::read_pod(/*out*/ T &val)
 {
     if (sizeof(T) <= get_remaining_size()) {
-        memcpy((void *)&val, _ptr, sizeof(T));
+        memcpy(reinterpret_cast<void *>(&val), _ptr, sizeof(T));
         _ptr += sizeof(T);
         _remaining_size -= sizeof(T);
         return static_cast<int>(sizeof(T));
@@ -74,4 +102,5 @@ inline int binary_reader::read_pod(/*out*/ T &val)
         return 0;
     }
 }
-}
+
+} // namespace dsn

--- a/include/dsn/utility/binary_writer.h
+++ b/include/dsn/utility/binary_writer.h
@@ -1,15 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #pragma once
 
-#include <dsn/utility/blob.h>
 #include <cstring>
+#include <string>
+#include <vector>
+
+#include "dsn/utility/blob.h"
 
 namespace dsn {
 
 class binary_writer
 {
 public:
-    binary_writer(int reserved_buffer_size = 0);
-    binary_writer(blob &buffer);
+    explicit binary_writer(int reserved_buffer_size = 0);
+    explicit binary_writer(blob &buffer);
     virtual ~binary_writer();
 
     virtual void flush();
@@ -40,11 +69,8 @@ public:
     bool next(void **data, int *size);
     bool backup(int count);
 
-    void get_buffers(/*out*/ std::vector<blob> &buffers);
-    int get_buffer_count() const { return static_cast<int>(_buffers.size()); }
     blob get_buffer();
     blob get_current_buffer(); // without commit, write can be continued on the last buffer
-    blob get_first_buffer() const;
 
     int total_size() const { return _total_size; }
 
@@ -70,31 +96,24 @@ private:
 template <typename T>
 inline void binary_writer::write_pod(const T &val)
 {
-    write((char *)&val, static_cast<int>(sizeof(T)));
+    write(reinterpret_cast<const char *>(&val), static_cast<int>(sizeof(T)));
 }
-
-inline void binary_writer::get_buffers(/*out*/ std::vector<blob> &buffers)
-{
-    commit();
-    buffers = _buffers;
-}
-
-inline blob binary_writer::get_first_buffer() const { return _buffers[0]; }
 
 inline void binary_writer::write(const std::string &val)
 {
     int len = static_cast<int>(val.length());
     write((const char *)&len, sizeof(int));
     if (len > 0)
-        write((const char *)&val[0], len);
+        write(&val[0], len);
 }
 
 inline void binary_writer::write(const blob &val)
 {
-    // TODO: optimization by not memcpy
+    // TODO(wutao1): optimization by not memcpy
     int len = val.length();
     write((const char *)&len, sizeof(int));
     if (len > 0)
-        write((const char *)val.data(), len);
+        write(val.data(), len);
 }
-}
+
+} // namespace dsn

--- a/include/dsn/utility/binary_writer.h
+++ b/include/dsn/utility/binary_writer.h
@@ -69,8 +69,11 @@ public:
     bool next(void **data, int *size);
     bool backup(int count);
 
+    void get_buffers(/*out*/ std::vector<blob> &buffers);
+    int get_buffer_count() const { return static_cast<int>(_buffers.size()); }
     blob get_buffer();
     blob get_current_buffer(); // without commit, write can be continued on the last buffer
+    blob get_first_buffer() const;
 
     int total_size() const { return _total_size; }
 
@@ -99,13 +102,13 @@ inline void binary_writer::write_pod(const T &val)
     write(reinterpret_cast<const char *>(&val), static_cast<int>(sizeof(T)));
 }
 
-inline void binary_writer::write(const std::string &val)
+inline void binary_writer::get_buffers(/*out*/ std::vector<blob> &buffers)
 {
-    int len = static_cast<int>(val.length());
-    write((const char *)&len, sizeof(int));
-    if (len > 0)
-        write(&val[0], len);
+    commit();
+    buffers = _buffers;
 }
+
+inline blob binary_writer::get_first_buffer() const { return _buffers[0]; }
 
 inline void binary_writer::write(const blob &val)
 {

--- a/include/dsn/utility/binary_writer.h
+++ b/include/dsn/utility/binary_writer.h
@@ -110,6 +110,14 @@ inline void binary_writer::get_buffers(/*out*/ std::vector<blob> &buffers)
 
 inline blob binary_writer::get_first_buffer() const { return _buffers[0]; }
 
+inline void binary_writer::write(const std::string &val)
+{
+    int len = static_cast<int>(val.length());
+    write(reinterpret_cast<const char *>(&len), sizeof(int));
+    if (len > 0)
+        write(&val[0], len);
+}
+
 inline void binary_writer::write(const blob &val)
 {
     // TODO(wutao1): optimization by not memcpy

--- a/include/dsn/utility/blob.h
+++ b/include/dsn/utility/blob.h
@@ -26,8 +26,9 @@
 
 #pragma once
 
-#include <memory>
-#include <thrift/protocol/TProtocol.h>
+#include <string>
+
+#include "thrift/protocol/TProtocol.h"
 
 namespace dsn {
 

--- a/include/dsn/utility/callocator.h
+++ b/include/dsn/utility/callocator.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <dsn/utility/transient_memory.h>
+#include "dsn/utility/transient_memory.h"
 
 namespace dsn {
 
@@ -53,4 +53,5 @@ public:
 /// are derived from transient_objects,
 /// so that their memory can be mamanged by trans_memory_allocator
 typedef callocator_object<tls_trans_malloc, tls_trans_free> transient_object;
-}
+
+} // namespace dsn

--- a/include/dsn/utility/chrono_literals.h
+++ b/include/dsn/utility/chrono_literals.h
@@ -45,34 +45,35 @@ namespace dsn {
 
 inline namespace literals {
 inline namespace chrono_literals {
+constexpr std::chrono::hours operator"" _h(unsigned long long v) // NOLINT(runtime/int)
+{
+    return std::chrono::hours{v};
+}
 
-constexpr std::chrono::hours operator"" _h(unsigned long long v) { return std::chrono::hours{v}; }
-
-constexpr std::chrono::minutes operator"" _min(unsigned long long v)
+constexpr std::chrono::minutes operator"" _min(unsigned long long v) // NOLINT(runtime/int)
 {
     return std::chrono::minutes{v};
 }
 
-constexpr std::chrono::seconds operator"" _s(unsigned long long v)
+constexpr std::chrono::seconds operator"" _s(unsigned long long v) // NOLINT(runtime/int)
 {
     return std::chrono::seconds{v};
 }
 
-constexpr std::chrono::milliseconds operator"" _ms(unsigned long long v)
+constexpr std::chrono::milliseconds operator"" _ms(unsigned long long v) // NOLINT(runtime/int)
 {
     return std::chrono::milliseconds{v};
 }
 
-constexpr std::chrono::microseconds operator"" _us(unsigned long long v)
+constexpr std::chrono::microseconds operator"" _us(unsigned long long v) // NOLINT(runtime/int)
 {
     return std::chrono::microseconds{v};
 }
 
-constexpr std::chrono::nanoseconds operator"" _ns(unsigned long long v)
+constexpr std::chrono::nanoseconds operator"" _ns(unsigned long long v) // NOLINT(runtime/int)
 {
     return std::chrono::nanoseconds{v};
 }
-
 } // inline namespace chrono_literals
 } // inline namespace literals
 } // namespace dsn

--- a/include/dsn/utility/chrono_literals.h
+++ b/include/dsn/utility/chrono_literals.h
@@ -74,6 +74,6 @@ constexpr std::chrono::nanoseconds operator"" _ns(unsigned long long v) // NOLIN
 {
     return std::chrono::nanoseconds{v};
 }
-} // inline namespace chrono_literals
-} // inline namespace literals
+} // namespace chrono_literals
+} // namespace literals
 } // namespace dsn

--- a/include/dsn/utility/config_helper.h
+++ b/include/dsn/utility/config_helper.h
@@ -26,8 +26,11 @@
 
 #pragma once
 
-#include <dsn/utility/config_api.h>
-#include <dsn/utility/strings.h>
+#include <list>
+#include <string>
+
+#include "dsn/utility/config_api.h"
+#include "dsn/utility/strings.h"
 
 /// you can use following macros to implement a function called "read_config"
 /// to initialize a structure from the configuration file quickly
@@ -38,7 +41,6 @@
     inline bool read_config(                                                                       \
         const char *section, /*out*/ t_struct &val, t_struct *default_value = nullptr)             \
     {
-
 #define CONFIG_END                                                                                 \
     return true;                                                                                   \
     }
@@ -72,8 +74,9 @@
             if (!type::is_exist(v.c_str())) {                                                      \
                 printf("invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str());   \
                 return false;                                                                      \
-            } else                                                                                 \
+            } else {                                                                               \
                 val.fld = type(v.c_str());                                                         \
+            }                                                                                      \
         }                                                                                          \
     }
 
@@ -94,8 +97,9 @@
             if (v2 == invalid_enum) {                                                              \
                 printf("invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str());   \
                 return false;                                                                      \
-            } else                                                                                 \
+            } else {                                                                               \
                 val.fld = v2;                                                                      \
+            }                                                                                      \
         }                                                                                          \
     }
 
@@ -110,8 +114,9 @@
             if (!type::is_exist(v.c_str())) {                                                      \
                 printf("invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str());   \
                 return false;                                                                      \
-            } else                                                                                 \
+            } else {                                                                               \
                 val.fld.push_back(type(v.c_str()));                                                \
+            }                                                                                      \
         }                                                                                          \
         if (val.fld.size() == 0 && default_value)                                                  \
             val.fld = default_value->fld;                                                          \
@@ -132,9 +137,9 @@
         std::string vv = dsn_config_get_value_string(section, #fld, "", dsptr);                    \
         std::list<std::string> lv;                                                                 \
         ::dsn::utils::split_args(vv.c_str(), lv, ',');                                             \
-        if (lv.size() == 0 && default_value)                                                       \
+        if (lv.size() == 0 && default_value) {                                                     \
             val.fld = default_value->fld;                                                          \
-        else {                                                                                     \
+        } else {                                                                                   \
             for (auto &s : lv) {                                                                   \
                 val.fld.push_back(atoi(s.c_str()));                                                \
             }                                                                                      \

--- a/include/dsn/utility/configuration.h
+++ b/include/dsn/utility/configuration.h
@@ -35,7 +35,8 @@
 #include <string>
 #include <list>
 #include <mutex>
-#include <dsn/utility/string_conv.h>
+
+#include "dsn/utility/string_conv.h"
 
 namespace dsn {
 
@@ -134,7 +135,7 @@ inline double configuration::get_value<double>(const char *section,
 {
     const char *value;
     char defaultstr[32];
-    sprintf(defaultstr, "%lf", default_value);
+    snprintf(defaultstr, sizeof(defaultstr), "%lf", default_value);
 
     if (!get_string_value_internal(section, key, defaultstr, &value, dsptr)) {
         if (_warning) {
@@ -158,7 +159,7 @@ inline int64_t configuration::get_value<int64_t>(const char *section,
 {
     const char *value;
     char defaultstr[32];
-    sprintf(defaultstr, "%" PRId64, default_value);
+    snprintf(defaultstr, sizeof(defaultstr), "%" PRId64, default_value);
 
     if (!get_string_value_internal(section, key, defaultstr, &value, dsptr)) {
         if (_warning) {
@@ -186,7 +187,7 @@ inline uint64_t configuration::get_value<uint64_t>(const char *section,
 {
     const char *value;
     char defaultstr[32];
-    sprintf(defaultstr, "%" PRIu64, default_value);
+    snprintf(defaultstr, sizeof(defaultstr), "%" PRIu64, default_value);
 
     if (!get_string_value_internal(section, key, defaultstr, &value, dsptr)) {
         if (_warning) {

--- a/include/dsn/utility/crc.h
+++ b/include/dsn/utility/crc.h
@@ -1,3 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #pragma once
 
 #include <cstdint>
@@ -45,5 +71,5 @@ uint64_t crc64_concat(uint32_t xy_init,
                       uint64_t y_init,
                       uint64_t y_final,
                       size_t y_size);
-}
-}
+} // namespace utils
+} // namespace dsn

--- a/include/dsn/utility/customizable_id.h
+++ b/include/dsn/utility/customizable_id.h
@@ -36,11 +36,12 @@
 
 #pragma once
 
-#include <dsn/utility/singleton.h>
-#include <dsn/utility/ports.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "dsn/utility/singleton.h"
+#include "dsn/utility/ports.h"
 
 namespace dsn {
 namespace utils {
@@ -73,7 +74,7 @@ private:
 template <typename T>
 struct customized_id
 {
-    customized_id(const char *name);
+    explicit customized_id(const char *name);
     customized_id(const customized_id &source);
     operator int() const;
     operator T() const { return T(_internal_code); }
@@ -87,7 +88,7 @@ struct customized_id
 
 protected:
     static int assign(const char *xxx);
-    customized_id(int code);
+    explicit customized_id(int code);
 
 protected:
     int _internal_code;
@@ -208,5 +209,5 @@ int customized_id_mgr<T>::register_id(const char *name)
     _names2.push_back(std::string(name));
     return code;
 }
-}
-} // end namespace dsn::utils
+} // namespace utils
+} // namespace dsn

--- a/include/dsn/utility/endians.h
+++ b/include/dsn/utility/endians.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <endian.h>
 #include <cstdint>
 #include <cassert>
-#include <endian.h>
-#include <dsn/utility/string_view.h>
+#include <string>
+
+#include "dsn/utility/string_view.h"
 
 namespace dsn {
 

--- a/include/dsn/utility/enum_helper.h
+++ b/include/dsn/utility/enum_helper.h
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
 #include <map>
@@ -76,7 +67,7 @@ private:
     };
 
 public:
-    enum_helper_xxx(TEnum invalid) : _invalid(invalid) {}
+    explicit enum_helper_xxx(TEnum invalid) : _invalid(invalid) {}
 
     void register_enum(const char *name, TEnum v)
     {

--- a/include/dsn/utility/error_code.h
+++ b/include/dsn/utility/error_code.h
@@ -1,7 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #pragma once
 
-#include <dsn/utility/customizable_id.h>
-#include <thrift/protocol/TProtocol.h>
+#include <string>
+
+#include "thrift/protocol/TProtocol.h"
+
+#include "dsn/utility/customizable_id.h"
 
 namespace dsn {
 

--- a/include/dsn/utility/errors.h
+++ b/include/dsn/utility/errors.h
@@ -26,11 +26,13 @@
 
 #pragma once
 
-#include <dsn/utility/error_code.h>
-#include <dsn/utility/smart_pointers.h>
-#include <dsn/utility/string_view.h>
-
 #include <sstream>
+#include <string>
+#include <algorithm>
+
+#include "dsn/utility/error_code.h"
+#include "dsn/utility/smart_pointers.h"
+#include "dsn/utility/string_view.h"
 
 namespace dsn {
 
@@ -178,12 +180,18 @@ class error_with
 {
 public:
     // for ok case
-    error_with(const T &value) : _value(new T(value)) {}
-    error_with(T &&value) : _value(new T(std::move(value))) {}
+    error_with(const T &value) : _value(new T(value)) {}       // NOLINT(runtime/explicit)
+    error_with(T &&value) : _value(new T(std::move(value))) {} // NOLINT(runtime/explicit)
 
     // for error case
-    error_with(error_s &&err) : _err(std::move(err)) { assert(!_err.is_ok()); }
-    error_with(const error_s &status) : _err(status) { assert(!_err.is_ok()); }
+    error_with(error_s &&err) : _err(std::move(err)) // NOLINT(runtime/explicit)
+    {
+        assert(!_err.is_ok());
+    }
+    error_with(const error_s &status) : _err(status) // NOLINT(runtime/explicit)
+    {
+        assert(!_err.is_ok());
+    }
 
     const T &get_value() const
     {

--- a/include/dsn/utility/exp_delay.h
+++ b/include/dsn/utility/exp_delay.h
@@ -59,7 +59,7 @@ public:
 
     void initialize(const std::vector<int> &delays, int threshold)
     {
-        assert(static_cast<int>(delays.size()) == DELAY_COUNT);
+        assert(delays.size() == DELAY_COUNT);
 
         int i = 0;
         for (auto &d : delays) {
@@ -97,16 +97,11 @@ private:
 class shared_exp_delay
 {
 public:
-    shared_exp_delay()
-    {
-        memcpy(reinterpret_cast<void *>(_delay),
-               reinterpret_cast<const void *>(s_default_delay),
-               sizeof(_delay));
-    }
+    shared_exp_delay() { memcpy(_delay, s_default_delay, sizeof(_delay)); }
 
     void initialize(const std::vector<int> &delays)
     {
-        assert(static_cast<int>(delays.size()) == DELAY_COUNT);
+        assert(delays.size() == DELAY_COUNT);
 
         int i = 0;
         for (auto &d : delays) {

--- a/include/dsn/utility/exp_delay.h
+++ b/include/dsn/utility/exp_delay.h
@@ -51,9 +51,7 @@ class exp_delay
 public:
     exp_delay()
     {
-        memcpy(reinterpret_cast<void *>(_delay),
-               reinterpret_cast<const void *>(s_default_delay),
-               sizeof(_delay));
+        memcpy(_delay, s_default_delay, sizeof(_delay));
         _threshold = 0x0fffffff;
     }
 

--- a/include/dsn/utility/exp_delay.h
+++ b/include/dsn/utility/exp_delay.h
@@ -35,27 +35,31 @@
 
 #pragma once
 
-#include <dsn/utility/singleton.h>
 #include <vector>
 #include <cassert>
+
+#include "dsn/utility/singleton.h"
 
 namespace dsn {
 #define DELAY_COUNT 6
 const double s_default_delay_points[DELAY_COUNT] = {1.0, 1.2, 1.4, 1.6, 1.8, 2.0};
 const int s_default_delay[DELAY_COUNT] = {0, 0, 1, 2, 5, 10}; // millieseconds
 
+// TODO(wutao1): remove this class
 class exp_delay
 {
 public:
     exp_delay()
     {
-        memcpy((void *)_delay, (const void *)s_default_delay, sizeof(_delay));
+        memcpy(reinterpret_cast<void *>(_delay),
+               reinterpret_cast<const void *>(s_default_delay),
+               sizeof(_delay));
         _threshold = 0x0fffffff;
     }
 
     void initialize(const std::vector<int> &delays, int threshold)
     {
-        assert((int)delays.size() == DELAY_COUNT);
+        assert(static_cast<int>(delays.size()) == DELAY_COUNT);
 
         int i = 0;
         for (auto &d : delays) {
@@ -69,7 +73,7 @@ public:
     inline int delay(int value)
     {
         if (value >= _threshold) {
-            double f = (double)value / (double)_threshold;
+            double f = static_cast<double>(value) / static_cast<double>(_threshold);
             int delay_milliseconds;
 
             if (f < s_default_delay_points[DELAY_COUNT - 1]) {
@@ -93,11 +97,16 @@ private:
 class shared_exp_delay
 {
 public:
-    shared_exp_delay() { memcpy((void *)_delay, (const void *)s_default_delay, sizeof(_delay)); }
+    shared_exp_delay()
+    {
+        memcpy(reinterpret_cast<void *>(_delay),
+               reinterpret_cast<const void *>(s_default_delay),
+               sizeof(_delay));
+    }
 
     void initialize(const std::vector<int> &delays)
     {
-        assert((int)delays.size() == DELAY_COUNT);
+        assert(static_cast<int>(delays.size()) == DELAY_COUNT);
 
         int i = 0;
         for (auto &d : delays) {
@@ -108,7 +117,7 @@ public:
     inline int delay(int value, int threshold)
     {
         if (value >= threshold) {
-            double f = (double)value / (double)threshold;
+            double f = static_cast<double>(value) / static_cast<double>(threshold);
             int delay_milliseconds;
 
             if (f < s_default_delay_points[DELAY_COUNT - 1]) {
@@ -127,4 +136,5 @@ public:
 private:
     int _delay[DELAY_COUNT];
 };
-}
+
+} // namespace dsn

--- a/include/dsn/utility/extensible_object.h
+++ b/include/dsn/utility/extensible_object.h
@@ -35,11 +35,12 @@
 
 #pragma once
 
-#include <dsn/utility/utils.h>
 #include <vector>
 #include <atomic>
 #include <cstring>
 #include <cassert>
+
+#include "dsn/utility/utils.h"
 
 namespace dsn {
 /*!
@@ -85,7 +86,7 @@ public:
 public:
     extensible_object() : extensible(_extensions, MAX_EXTENSION_COUNT)
     {
-        memset((void *)_extensions, 0, sizeof(_extensions));
+        memset(reinterpret_cast<void *>(_extensions), 0, sizeof(_extensions));
     }
 
     ~extensible_object()
@@ -95,7 +96,7 @@ public:
         for (int i = 0; i < maxId; i++) {
             if (_extensions[i] != extensible_object::INVALID_VALUE &&
                 s_extensionDeletors[i] != nullptr) {
-                s_extensionDeletors[i]((void *)_extensions[i]);
+                s_extensionDeletors[i](reinterpret_cast<void *>(_extensions[i]));
             }
         }
     }
@@ -183,7 +184,7 @@ public:
     static TExtension *get(TExtensibleObject *ctx)
     {
         uint64_t &val = ctx->get_extension(s_slotIdx);
-        return (TExtension *)val;
+        return reinterpret_cast<TExtension *>(val);
     }
 
     static void set(TExtensibleObject *ctx, TExtension *ext)
@@ -195,7 +196,7 @@ public:
     {
         uint64_t &val = ctx->get_extension(s_slotIdx);
         if (val != TExtensibleObject::INVALID_VALUE)
-            return (TExtension *)val;
+            return reinterpret_cast<TExtension *>(val);
 
         if (s_creator == nullptr) {
             TExtension *obj = new TExtension();
@@ -204,14 +205,14 @@ public:
             val = (uint64_t)s_creator(ctx);
         }
 
-        return (TExtension *)val;
+        return reinterpret_cast<TExtension *>(val);
     }
 
     static void clear(TExtensibleObject *ctx)
     {
         uint64_t &val = ctx->get_extension(s_slotIdx);
         if (val != TExtensibleObject::INVALID_VALUE) {
-            s_deletor((TExtension *)val);
+            s_deletor(reinterpret_cast<TExtension *>(val));
             val = TExtensibleObject::INVALID_VALUE;
         }
     }
@@ -239,4 +240,4 @@ extension_deletor object_extension_helper<TExtension, TExtensibleObject>::s_dele
 template <typename TExtension, typename TExtensibleObject>
 extension_creator object_extension_helper<TExtension, TExtensibleObject>::s_creator = nullptr;
 /*@}*/
-} // end namespace dsn
+} // namespace dsn

--- a/include/dsn/utility/extensible_object.h
+++ b/include/dsn/utility/extensible_object.h
@@ -86,7 +86,7 @@ public:
 public:
     extensible_object() : extensible(_extensions, MAX_EXTENSION_COUNT)
     {
-        memset(reinterpret_cast<void *>(_extensions), 0, sizeof(_extensions));
+        memset(_extensions, 0, sizeof(_extensions));
     }
 
     ~extensible_object()
@@ -96,7 +96,7 @@ public:
         for (int i = 0; i < maxId; i++) {
             if (_extensions[i] != extensible_object::INVALID_VALUE &&
                 s_extensionDeletors[i] != nullptr) {
-                s_extensionDeletors[i](reinterpret_cast<void *>(_extensions[i]));
+                s_extensionDeletors[i] = reinterpret_cast<extension_deletor *>(_extensions[i]);
             }
         }
     }

--- a/include/dsn/utility/extensible_object.h
+++ b/include/dsn/utility/extensible_object.h
@@ -96,7 +96,7 @@ public:
         for (int i = 0; i < maxId; i++) {
             if (_extensions[i] != extensible_object::INVALID_VALUE &&
                 s_extensionDeletors[i] != nullptr) {
-                s_extensionDeletors[i] = reinterpret_cast<extension_deletor *>(_extensions[i]);
+                s_extensionDeletors[i] = reinterpret_cast<extension_deletor>(_extensions[i]);
             }
         }
     }

--- a/include/dsn/utility/factory_store.h
+++ b/include/dsn/utility/factory_store.h
@@ -35,7 +35,10 @@
 
 #pragma once
 
-#include <dsn/utility/singleton_store.h>
+#include <vector>
+#include <string>
+
+#include "dsn/utility/singleton_store.h"
 
 namespace dsn {
 
@@ -56,7 +59,7 @@ public:
     {
         factory_entry entry;
         entry.dummy = nullptr;
-        entry.factory = (void *)factory;
+        entry.factory = reinterpret_cast<void *>(factory);
         entry.type = type;
         return singleton_store<std::string, factory_entry>::instance().put(std::string(name),
                                                                            entry);
@@ -72,7 +75,7 @@ public:
                 return nullptr;
             } else {
                 TFactory f;
-                f = *(TFactory *)&entry.factory;
+                f = *reinterpret_cast<TFactory *>(&entry.factory);
                 return f;
             }
         } else {
@@ -165,5 +168,6 @@ private:
         }
     };
 };
-}
-} // end namespace dsn::utils
+
+} // namespace utils
+} // namespace dsn

--- a/include/dsn/utility/fail_point.h
+++ b/include/dsn/utility/fail_point.h
@@ -20,7 +20,9 @@
 /// A fail point implementation in C++.
 /// This lib is ported from https://github.com/pingcap/fail-rs.
 
-#include <dsn/utility/string_view.h>
+#include <string>
+
+#include "dsn/utility/string_view.h"
 
 /// The only entry to define a fail point.
 /// Add following line to cmake to compile target with fault injection.


### PR DESCRIPTION
This PR fixes the warnings from cpplint for our wrong coding practice against google cpp code style, some of the warnings are listed as follows:

- Use int16/int64/etc, rather than the C type long  [runtime/int] 
```c
--    long get_count() const { return _counter.load(); }
++    int32_t get_count() const { return _counter.load(); }
```

- Namespace should be terminated with "// namespace dsn" [readability/namespace]
```c
-- }
++ } // namespace dsn
```

- Single-parameter constructors should be marked explicit.  [runtime/explicit]
```c
--    customized_id(const char *name);
++    explicit customized_id(const char *name);
```

- No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright]
```
++ /*
++ * The MIT License (MIT)
++ *
++ * Copyright (c) 2015 Microsoft Corporation
++ *
```

- Using C-style cast.  Use reinterpret_cast<void *>(...) instead  [readability/casting] 

```c
--    write((char *)&val, static_cast<int>(sizeof(T)));
++    write(reinterpret_cast<const char *>(&val), static_cast<int>(sizeof(T)));
```

- If an else has a brace on one side, it should have it on both  [readability/braces]
```c
              if (v2 == invalid_enum) {                                                              \
                  printf("invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str());   \
                  return false;                                                                      \
--            } else                                                                                 \
++            } else {                                                                               \
                  val.fld = v2;                                                                      \
++            }     
```