### PR TITLE
replica-server: support remote command useless-dir-reserve-seconds

### DIFF
--- a/include/dsn/tool-api/command_manager.h
+++ b/include/dsn/tool-api/command_manager.h
@@ -82,7 +82,7 @@ private:
 #define HANDLE_CLI_FLAGS(flag, args)                                                               \
     do {                                                                                           \
         std::string ret_msg("OK");                                                                 \
-        if (args.size() <= 0) {                                                                    \
+        if (args.empty()) {                                                                        \
             ret_msg = flag ? "true" : "false";                                                     \
         } else {                                                                                   \
             if (strcmp(args[0].c_str(), "true") == 0) {                                            \

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -243,7 +243,7 @@ private:
     dsn_handle_t _trigger_chkpt_command;
     dsn_handle_t _query_compact_command;
     dsn_handle_t _query_app_envs_command;
-    dsn_handle_t _garbage_dir_reserve_seconds_command;
+    dsn_handle_t _useless_dir_reserve_seconds_command;
 
     bool _deny_client;
     bool _verbose_client_log;

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -243,10 +243,13 @@ private:
     dsn_handle_t _trigger_chkpt_command;
     dsn_handle_t _query_compact_command;
     dsn_handle_t _query_app_envs_command;
+    dsn_handle_t _garbage_dir_reserve_seconds_command;
 
     bool _deny_client;
     bool _verbose_client_log;
     bool _verbose_commit_log;
+    int32_t _gc_disk_error_replica_interval_seconds;
+    int32_t _gc_disk_garbage_replica_interval_seconds;
 
     // we limit LT_APP max concurrent count, because nfs service implementation is
     // too simple, it do not support priority.

--- a/src/dist/replication/meta_server/server_load_balancer.cpp
+++ b/src/dist/replication/meta_server/server_load_balancer.cpp
@@ -1,5 +1,6 @@
 #include "server_load_balancer.h"
 #include <dsn/utility/extensible_object.h>
+#include <dsn/utility/string_conv.h>
 #include <dsn/tool-api/command_manager.h>
 #include <boost/lexical_cast.hpp>
 
@@ -877,15 +878,15 @@ void simple_load_balancer::unregister_ctrl_commands()
 std::string simple_load_balancer::ctrl_assign_delay_ms(const std::vector<std::string> &args)
 {
     std::string result("OK");
-    if (args.size() <= 0) {
+    if (args.empty()) {
         result = std::to_string(_replica_assign_delay_ms_for_dropouts);
     } else {
         if (args[0] == "DEFAULT") {
             _replica_assign_delay_ms_for_dropouts =
                 _svc->get_meta_options()._lb_opts.replica_assign_delay_ms_for_dropouts;
         } else {
-            int v = atoi(args[0].c_str());
-            if (v <= 0) {
+            int32_t v = 0;
+            if (!dsn::buf2int32(args[0], v) || v <= 0) {
                 result = std::string("ERR: invalid arguments");
             } else {
                 _replica_assign_delay_ms_for_dropouts = v;
@@ -900,7 +901,7 @@ simple_load_balancer::ctrl_assign_secondary_black_list(const std::vector<std::st
 {
     std::string invalid_arguments("invalid arguments");
     std::stringstream oss;
-    if (args.size() <= 0) {
+    if (args.empty()) {
         dsn::zauto_read_lock l(_black_list_lock);
         oss << "get ok: ";
         for (auto iter = _assign_secondary_black_list.begin();

--- a/src/dist/replication/meta_server/server_state.cpp
+++ b/src/dist/replication/meta_server/server_state.cpp
@@ -35,6 +35,7 @@
  */
 
 #include <dsn/utility/factory_store.h>
+#include <dsn/utility/string_conv.h>
 #include <dsn/tool-api/task.h>
 #include <dsn/tool-api/command_manager.h>
 #include <dsn/tool-api/async_calls.h>
@@ -128,15 +129,15 @@ void server_state::register_cli_commands()
             "control the max count to add secondary for one node",
             [this](const std::vector<std::string> &args) {
                 std::string result("OK");
-                if (args.size() <= 0) {
+                if (args.empty()) {
                     result = std::to_string(_add_secondary_max_count_for_one_node);
                 } else {
                     if (args[0] == "DEFAULT") {
                         _add_secondary_max_count_for_one_node =
                             _meta_svc->get_meta_options().add_secondary_max_count_for_one_node;
                     } else {
-                        int v = atoi(args[0].c_str());
-                        if (v < 0) {
+                        int32_t v = 0;
+                        if (!dsn::buf2int32(args[0], v) || v < 0) {
                             result = std::string("ERR: invalid arguments");
                         } else {
                             _add_secondary_max_count_for_one_node = v;


### PR DESCRIPTION
to dynamically change `gc_disk_error_replica_interval_seconds` and `gc_disk_garbage_replica_interval_seconds`.

for the reason, please refer to: [垃圾文件夹管理](https://github.com/XiaoMi/pegasus/wiki/%E8%B5%84%E6%BA%90%E7%AE%A1%E7%90%86#%E5%9E%83%E5%9C%BE%E6%96%87%E4%BB%B6%E5%A4%B9%E7%AE%A1%E7%90%86)