### PR TITLE
meta-server: re-implement returning forward address in configuration_query_b…

### DIFF
--- a/include/dsn/cpp/serialization_helper/dsn.layer2_types.h
+++ b/include/dsn/cpp/serialization_helper/dsn.layer2_types.h
@@ -203,12 +203,7 @@ inline std::ostream &operator<<(std::ostream &out, const configuration_query_by_
 typedef struct _configuration_query_by_index_response__isset
 {
     _configuration_query_by_index_response__isset()
-        : err(false),
-          app_id(false),
-          partition_count(false),
-          is_stateful(false),
-          partitions(false),
-          forward_address(false)
+        : err(false), app_id(false), partition_count(false), is_stateful(false), partitions(false)
     {
     }
     bool err : 1;
@@ -216,7 +211,6 @@ typedef struct _configuration_query_by_index_response__isset
     bool partition_count : 1;
     bool is_stateful : 1;
     bool partitions : 1;
-    bool forward_address : 1;
 } _configuration_query_by_index_response__isset;
 
 class configuration_query_by_index_response
@@ -234,7 +228,6 @@ public:
     int32_t partition_count;
     bool is_stateful;
     std::vector<partition_configuration> partitions;
-    ::dsn::rpc_address forward_address;
 
     _configuration_query_by_index_response__isset __isset;
 
@@ -248,8 +241,6 @@ public:
 
     void __set_partitions(const std::vector<partition_configuration> &val);
 
-    void __set_forward_address(const ::dsn::rpc_address &val);
-
     bool operator==(const configuration_query_by_index_response &rhs) const
     {
         if (!(err == rhs.err))
@@ -261,8 +252,6 @@ public:
         if (!(is_stateful == rhs.is_stateful))
             return false;
         if (!(partitions == rhs.partitions))
-            return false;
-        if (!(forward_address == rhs.forward_address))
             return false;
         return true;
     }

--- a/src/core/core/dsn.layer2_types.cpp
+++ b/src/core/core/dsn.layer2_types.cpp
@@ -500,11 +500,6 @@ void configuration_query_by_index_response::__set_partitions(
     this->partitions = val;
 }
 
-void configuration_query_by_index_response::__set_forward_address(const ::dsn::rpc_address &val)
-{
-    this->forward_address = val;
-}
-
 uint32_t configuration_query_by_index_response::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -575,14 +570,6 @@ uint32_t configuration_query_by_index_response::read(::apache::thrift::protocol:
                 xfer += iprot->skip(ftype);
             }
             break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->forward_address.read(iprot);
-                this->__isset.forward_address = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -630,10 +617,6 @@ configuration_query_by_index_response::write(::apache::thrift::protocol::TProtoc
     }
     xfer += oprot->writeFieldEnd();
 
-    xfer += oprot->writeFieldBegin("forward_address", ::apache::thrift::protocol::T_STRUCT, 6);
-    xfer += this->forward_address.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -647,7 +630,6 @@ void swap(configuration_query_by_index_response &a, configuration_query_by_index
     swap(a.partition_count, b.partition_count);
     swap(a.is_stateful, b.is_stateful);
     swap(a.partitions, b.partitions);
-    swap(a.forward_address, b.forward_address);
     swap(a.__isset, b.__isset);
 }
 
@@ -659,7 +641,6 @@ configuration_query_by_index_response::configuration_query_by_index_response(
     partition_count = other32.partition_count;
     is_stateful = other32.is_stateful;
     partitions = other32.partitions;
-    forward_address = other32.forward_address;
     __isset = other32.__isset;
 }
 configuration_query_by_index_response::configuration_query_by_index_response(
@@ -670,7 +651,6 @@ configuration_query_by_index_response::configuration_query_by_index_response(
     partition_count = std::move(other33.partition_count);
     is_stateful = std::move(other33.is_stateful);
     partitions = std::move(other33.partitions);
-    forward_address = std::move(other33.forward_address);
     __isset = std::move(other33.__isset);
 }
 configuration_query_by_index_response &configuration_query_by_index_response::
@@ -681,7 +661,6 @@ operator=(const configuration_query_by_index_response &other34)
     partition_count = other34.partition_count;
     is_stateful = other34.is_stateful;
     partitions = other34.partitions;
-    forward_address = other34.forward_address;
     __isset = other34.__isset;
     return *this;
 }
@@ -693,7 +672,6 @@ operator=(configuration_query_by_index_response &&other35)
     partition_count = std::move(other35.partition_count);
     is_stateful = std::move(other35.is_stateful);
     partitions = std::move(other35.partitions);
-    forward_address = std::move(other35.forward_address);
     __isset = std::move(other35.__isset);
     return *this;
 }
@@ -710,8 +688,6 @@ void configuration_query_by_index_response::printTo(std::ostream &out) const
         << "is_stateful=" << to_string(is_stateful);
     out << ", "
         << "partitions=" << to_string(partitions);
-    out << ", "
-        << "forward_address=" << to_string(forward_address);
     out << ")";
 }
 

--- a/src/dsn.layer2.thrift
+++ b/src/dsn.layer2.thrift
@@ -22,6 +22,8 @@ struct configuration_query_by_index_request
     2:list<i32>        partition_indices;
 }
 
+// for server version > 1.11.2, if err == ERR_FORWARD_TO_OTHERS,
+// then the forward address will be put in partitions[0].primary if exist.
 struct configuration_query_by_index_response
 {
     1:dsn.error_code                err;
@@ -29,7 +31,6 @@ struct configuration_query_by_index_response
     3:i32                           partition_count;
     4:bool                          is_stateful;
     5:list<partition_configuration> partitions;    
-    6:dsn.rpc_address               forward_address;
 }
 
 enum app_status


### PR DESCRIPTION
…y_index_response

we re-implement it in other way to fix compatibility problem of #212 

because rpc_address is customized serialized in thrift binary (refer to rpc_address::write), which do not follow the thrift protocal, so the rpc_address cannot be used as extend field.