### PR TITLE
shell: refactor table data output method

### DIFF
--- a/include/dsn/dist/replication/replication_ddl_client.h
+++ b/include/dsn/dist/replication/replication_ddl_client.h
@@ -172,12 +172,6 @@ public:
     dsn::error_code
     clear_app_envs(const std::string &app_name, bool clear_all, const std::string &prefix);
 
-    // print table to format columns as the same width.
-    // return false if column count is not the same for all rows.
-    bool print_table(const std::vector<std::vector<std::string>> &table,
-                     std::ostream &output,
-                     const std::string &column_delimiter = "   ");
-
     dsn::error_code ddd_diagnose(gpid pid, std::vector<ddd_partition_info> &ddd_partitions);
 
 private:

--- a/include/dsn/utility/absl/utility/utility.h
+++ b/include/dsn/utility/absl/utility/utility.h
@@ -205,4 +205,3 @@ auto apply(Functor &&functor, Tuple &&t) -> decltype(utility_internal::apply_hel
 } // namespace dsn
 
 #endif // ABSL_UTILITY_UTILITY_H_
-

--- a/include/dsn/utility/absl/utility/utility.h
+++ b/include/dsn/utility/absl/utility/utility.h
@@ -205,3 +205,4 @@ auto apply(Functor &&functor, Tuple &&t) -> decltype(utility_internal::apply_hel
 } // namespace dsn
 
 #endif // ABSL_UTILITY_UTILITY_H_
+

--- a/include/dsn/utility/output_utils.h
+++ b/include/dsn/utility/output_utils.h
@@ -26,33 +26,15 @@
 
 #pragma once
 
+#include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
 namespace dsn {
 namespace utils {
-
-namespace output_utils {
-template <typename T>
-std::string to_string(T data)
-{
-    return std::to_string(data);
-}
-
-template <>
-std::string to_string<bool>(bool data);
-
-template <>
-std::string to_string<double>(double data);
-
-template <>
-std::string to_string<std::string>(std::string data);
-
-template <>
-std::string to_string<const char *>(const char *data);
-} // namespace output_utils
 
 /// A tool used to print data in a table form.
 ///
@@ -117,7 +99,7 @@ public:
     void append_data(const T &data)
     {
         check_mode(data_mode::KMultiColumns);
-        append_string_data(output_utils::to_string(data));
+        append_string_data(to_string(data));
     }
 
     // KSingleColumn
@@ -125,12 +107,18 @@ public:
     void add_row_name_and_data(const std::string &row_name, const T &data)
     {
         check_mode(data_mode::KSingleColumn);
-        add_row_name_and_string_data(row_name, output_utils::to_string(data));
+        add_row_name_and_string_data(row_name, to_string(data));
     }
 
     void output(std::ostream &out, const std::string &separator = "") const;
 
 private:
+    template <typename T>
+    std::string to_string(T data)
+    {
+        return std::to_string(data);
+    }
+
     void check_mode(data_mode mode);
     void append_string_data(const std::string &data);
     void add_row_name_and_string_data(const std::string &row_name, const std::string &data);
@@ -142,6 +130,36 @@ private:
     std::vector<int> max_col_width_;
     std::vector<std::vector<std::string>> matrix_data_;
 };
+
+template <>
+inline std::string table_printer::to_string<bool>(bool data)
+{
+    return data ? "true" : "false";
+}
+
+template <>
+inline std::string table_printer::to_string<double>(double data)
+{
+    if (std::abs(data) < 1e-6) {
+        return "0.00";
+    } else {
+        std::stringstream s;
+        s << std::fixed << std::setprecision(precision_) << data;
+        return s.str();
+    }
+}
+
+template <>
+inline std::string table_printer::to_string<std::string>(std::string data)
+{
+    return data;
+}
+
+template <>
+inline std::string table_printer::to_string<const char *>(const char *data)
+{
+    return std::string(data);
+}
 
 } // namespace utils
 } // namespace dsn

--- a/src/core/core/output_utils.cpp
+++ b/src/core/core/output_utils.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include "dsn/utility/output_utils.h"
+
+#include <dsn/c/api_utilities.h>
+
+namespace dsn {
+namespace utils {
+
+template <>
+std::string to_string<bool>(bool data)
+{
+    return data ? "true" : "false";
+}
+
+template <>
+std::string to_string<double>(double data)   // TODO size数据加','
+{
+    if (std::abs(data) < 1e-6) {
+        return "0.00";
+    } else {
+        std::stringstream s;
+        s << std::fixed << std::setprecision(/*precision_*/ 2) << data;
+        return s.str();
+    }
+}
+
+template <>
+std::string to_string<std::string>(std::string data)
+{
+    return data;
+}
+
+template <>
+std::string to_string<char *>(char *data)
+{
+    return std::string(data);
+}
+
+template <>
+std::string to_string<const char *>(const char *data)
+{
+    return std::string(data);
+}
+
+void table_printer::add_title(const std::string &title)
+{
+    check_mode(data_mode::MULTI_COLUMNS);
+    dassert(matrix_data_.empty() && max_col_width_.empty(), "`add_title` must be called only once");
+    max_col_width_.push_back(title.length());
+    add_row(title);
+}
+
+void table_printer::add_column(const std::string &col_name)
+{
+    check_mode(data_mode::MULTI_COLUMNS);
+    dassert(matrix_data_.size() == 1, "`add_column` must be called before real data appendding");
+    max_col_width_.emplace_back(col_name.length());
+    append_data(col_name);
+}
+
+void table_printer::add_row_name_and_string_data(const std::string &row_name,
+                                                 const std::string &data)
+{
+    check_mode(data_mode::SINGLE_COLUMN);
+    max_col_width_.push_back(row_name.length());
+    max_col_width_.push_back(data.length());
+    add_row(row_name);
+    append_data(data);
+}
+
+void table_printer::output(std::ostream &out, const std::string &separator) const
+{
+    if (max_col_width_.empty()) {
+        return;
+    }
+
+    for (const auto &row : matrix_data_) {
+        //        dassert(!row.empty(), "Row name must be exist at least");
+        //        out << std::setw(max_col_width_[0] + space_width_) << std::left << row[0];
+        for (size_t i = 0; i < row.size(); ++i) {
+            auto data = (i == 0 ? "" : separator) + row[i];
+            out << std::setw(max_col_width_[i] + space_width_) << std::left << data;
+        }
+        out << std::endl;
+    }
+}
+
+void table_printer::append_string_data(const std::string &data)
+{
+    matrix_data_.rbegin()->emplace_back(data);
+
+    // update column max length
+    int &cur_len = max_col_width_[matrix_data_.rbegin()->size() - 1];
+    if (cur_len < data.size()) {
+        cur_len = data.size();
+    }
+}
+
+void table_printer::check_mode(data_mode mode)
+{
+    if (mode_ == data_mode::UNINITIALIZED) {
+        mode_ = mode;
+        return;
+    }
+    dassert(mode_ == mode, "");
+}
+
+} // namespace utils
+} // namespace dsn

--- a/src/core/core/output_utils.cpp
+++ b/src/core/core/output_utils.cpp
@@ -4,6 +4,8 @@
 
 #include "dsn/utility/output_utils.h"
 
+#include <sstream>
+
 #include <dsn/c/api_utilities.h>
 
 namespace dsn {

--- a/src/core/core/output_utils.cpp
+++ b/src/core/core/output_utils.cpp
@@ -63,8 +63,10 @@ void table_printer::add_row_name_and_string_data(const std::string &row_name,
 {
     max_col_width_.push_back(row_name.length());
     max_col_width_.push_back(data.length());
-    add_row(row_name);
-    append_data(data);
+
+    matrix_data_.emplace_back(std::vector<std::string>());
+    append_string_data(row_name);
+    append_string_data(data);
 }
 
 void table_printer::output(std::ostream &out, const std::string &separator) const
@@ -74,8 +76,6 @@ void table_printer::output(std::ostream &out, const std::string &separator) cons
     }
 
     for (const auto &row : matrix_data_) {
-        //        dassert(!row.empty(), "Row name must be exist at least");
-        //        out << std::setw(max_col_width_[0] + space_width_) << std::left << row[0];
         for (size_t i = 0; i < row.size(); ++i) {
             auto data = (i == 0 ? "" : separator) + row[i];
             out << std::setw(max_col_width_[i] + space_width_) << std::left << data;

--- a/src/core/core/output_utils.cpp
+++ b/src/core/core/output_utils.cpp
@@ -9,6 +9,7 @@
 namespace dsn {
 namespace utils {
 
+namespace output_utils {
 template <>
 std::string to_string<bool>(bool data)
 {
@@ -16,7 +17,7 @@ std::string to_string<bool>(bool data)
 }
 
 template <>
-std::string to_string<double>(double data)   // TODO size数据加','
+std::string to_string<double>(double data)
 {
     if (std::abs(data) < 1e-6) {
         return "0.00";
@@ -34,20 +35,16 @@ std::string to_string<std::string>(std::string data)
 }
 
 template <>
-std::string to_string<char *>(char *data)
-{
-    return std::string(data);
-}
-
-template <>
 std::string to_string<const char *>(const char *data)
 {
     return std::string(data);
 }
 
+} // namespace output_utils
+
 void table_printer::add_title(const std::string &title)
 {
-    check_mode(data_mode::MULTI_COLUMNS);
+    check_mode(data_mode::KMultiColumns);
     dassert(matrix_data_.empty() && max_col_width_.empty(), "`add_title` must be called only once");
     max_col_width_.push_back(title.length());
     add_row(title);
@@ -55,7 +52,7 @@ void table_printer::add_title(const std::string &title)
 
 void table_printer::add_column(const std::string &col_name)
 {
-    check_mode(data_mode::MULTI_COLUMNS);
+    check_mode(data_mode::KMultiColumns);
     dassert(matrix_data_.size() == 1, "`add_column` must be called before real data appendding");
     max_col_width_.emplace_back(col_name.length());
     append_data(col_name);
@@ -64,7 +61,6 @@ void table_printer::add_column(const std::string &col_name)
 void table_printer::add_row_name_and_string_data(const std::string &row_name,
                                                  const std::string &data)
 {
-    check_mode(data_mode::SINGLE_COLUMN);
     max_col_width_.push_back(row_name.length());
     max_col_width_.push_back(data.length());
     add_row(row_name);
@@ -101,7 +97,7 @@ void table_printer::append_string_data(const std::string &data)
 
 void table_printer::check_mode(data_mode mode)
 {
-    if (mode_ == data_mode::UNINITIALIZED) {
+    if (mode_ == data_mode::kUninitialized) {
         mode_ = mode;
         return;
     }

--- a/src/core/core/output_utils.cpp
+++ b/src/core/core/output_utils.cpp
@@ -1,48 +1,35 @@
-// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
-// This source code is licensed under the Apache License Version 2.0, which
-// can be found in the LICENSE file in the root directory of this source tree.
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #include "dsn/utility/output_utils.h"
-
-#include <sstream>
 
 #include <dsn/c/api_utilities.h>
 
 namespace dsn {
 namespace utils {
-
-namespace output_utils {
-template <>
-std::string to_string<bool>(bool data)
-{
-    return data ? "true" : "false";
-}
-
-template <>
-std::string to_string<double>(double data)
-{
-    if (std::abs(data) < 1e-6) {
-        return "0.00";
-    } else {
-        std::stringstream s;
-        s << std::fixed << std::setprecision(/*precision_*/ 2) << data;
-        return s.str();
-    }
-}
-
-template <>
-std::string to_string<std::string>(std::string data)
-{
-    return data;
-}
-
-template <>
-std::string to_string<const char *>(const char *data)
-{
-    return std::string(data);
-}
-
-} // namespace output_utils
 
 void table_printer::add_title(const std::string &title)
 {


### PR DESCRIPTION
```
 A tool used to print data in a table form.

 Example usage 1:
    table_printer tp;
    tp.add_title("table_title");
    tp.add_column("column_name1");
    tp.add_column("column_name2");
    for (...) {
        tp.add_row("row_name_i");
        tp.append_data(int_data);
        tp.append_data(double_data);
    }

    std::ostream out(...);
    tp.output(out);

 Output looks like:
    table_title  column_name1  column_name2
    row_name_1   123           45.67
    row_name_2   456           45.68

 Example usage 2:
    table_printer tp;
    tp.add_row_name_and_data("row_name_1", int_value);
    tp.add_row_name_and_data("row_name_2", string_value);

    std::ostream out(...);
    tp.output(out, ": ");

 Output looks like:
    row_name_1 :  4567
    row_name_2 :  hello
```