### PR TITLE
bugfix: link tcmalloc by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
     - ulimit -c unlimited -S
 
 script:
-    - ./run.sh test --skip_thirdparty --check
+    - ./run.sh test --skip_thirdparty --check --disable_gperf
 
 after_script:
     - ./run.sh stop_zk

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -212,9 +212,7 @@ function(dsn_setup_compiler_flags)
     # -fno-omit-frame-pointer
     #   use frame pointers to allow simple stack frame walking for backtraces.
     #   This has a small perf hit but worth it for the ability to profile in production
-    add_definitions(-fno-omit-frame-pointer)
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-omit-frame-pointer" CACHE STRING "" FORCE)
 
     #  -Wall: Enable all warnings.
     add_compile_options(-Wall)

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -82,9 +82,10 @@ fi
 # valgrind can not work together with gpertools
 # you may want to use this option when you want to run valgrind
 if [ "$DISABLE_GPERF" == "YES" ]
+then
     echo "DISABLE_GPERF=YES"
     CMAKE_OPTIONS="$CMAKE_OPTIONS -DENABLE_GPERF=Off"
-then
+else
     echo "DISABLE_GPERF=NO"
 fi
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -76,7 +76,7 @@ fi
 # gperftools
 if [ ! -f $TP_OUTPUT/lib/libtcmalloc.so ]; then
     cd $TP_SRC/gperftools-2.7
-    ./configure --prefix=$TP_OUTPUT --enable-static=no
+    ./configure --prefix=$TP_OUTPUT --enable-static=no --enable-frame-pointers=yes
     make -j8 && make install
     res=$?
     cd $TP_DIR


### PR DESCRIPTION
Previously:

![image](https://user-images.githubusercontent.com/6970676/53314095-a18d9980-38f7-11e9-8c48-a2442fe00868.png)

Now:
![image](https://user-images.githubusercontent.com/6970676/53314055-55425980-38f7-11e9-818c-b6809e252849.png)

There's one problem that travis doesn't have libunwind built in, and gperftools requires it as necessary. Therefore as a work round we disable gperf on travis. 

> For that reason, if you use a 64-bit system, we strongly recommend you                                                                                                                                      
install libunwind before trying to configure or install gperftools.                                                                                                                                         
libunwind can be found at    

> If you cannot or do not wish to install libunwind, you can still try
to use the built-in stack unwinder.  The built-in stack unwinder
requires that your application, the tcmalloc library, and system
libraries like libc, all be compiled with a frame pointer.  This is
*not* the default for x86-64.

> If you are on x86-64 system, know that you have a set of system
libraries with frame-pointers enabled, and compile all your
applications with -fno-omit-frame-pointer, then you can enable the
built-in perftools stack unwinder by passing the
--enable-frame-pointers flag to configure.

> Even with the use of libunwind, there are still known problems with
stack unwinding on 64-bit systems, particularly x86-64.  See the
"64-BIT ISSUES" section in README.

> If you encounter problems, try compiling perftools with './configure
--enable-frame-pointers'.  Note you will need to compile your
application with frame pointers (via 'gcc -fno-omit-frame-pointer
...') in this case.
