### PR TITLE
meta: support white list of replica-servers & add remote cmd to ctrl live_percentage

### DIFF
--- a/include/dsn/dist/failure_detector/failure_detector.h
+++ b/include/dsn/dist/failure_detector/failure_detector.h
@@ -64,7 +64,6 @@
 #include <dsn/dist/failure_detector/fd.client.h>
 #include <dsn/dist/failure_detector/fd.server.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
-#include <dsn/tool-api/command_manager.h>
 #include <dsn/tool-api/zlocks.h>
 
 namespace dsn {
@@ -101,7 +100,7 @@ public:
     virtual void end_ping(::dsn::error_code err, const beacon_ack &ack, void *context);
 
     virtual void register_ctrl_commands();
-    virtual void unregister_ctrl_commands() { UNREGISTER_VALID_HANDLER(_get_allow_list); }
+    virtual void unregister_ctrl_commands();
 
 public:
     error_code start(uint32_t check_interval_seconds,
@@ -159,7 +158,7 @@ protected:
 private:
     void check_all_records();
 
-    std::string get_allow_list(const std::vector<std::string> &args);
+    std::string get_allow_list(const std::vector<std::string> &args) const;
 
 private:
     class master_record

--- a/include/dsn/dist/failure_detector/failure_detector.h
+++ b/include/dsn/dist/failure_detector/failure_detector.h
@@ -64,8 +64,8 @@
 #include <dsn/dist/failure_detector/fd.client.h>
 #include <dsn/dist/failure_detector/fd.server.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
-#include <dsn/tool-api/zlocks.h>
 #include <dsn/tool-api/command_manager.h>
+#include <dsn/tool-api/zlocks.h>
 
 namespace dsn {
 namespace fd {
@@ -140,14 +140,7 @@ public:
 
     bool remove_from_allow_list(::dsn::rpc_address node);
 
-    void set_allow_list(const std::vector<std::string> &replica_addrs)
-    {
-        for (auto &addr : replica_addrs) {
-            dsn::rpc_address node;
-            if (node.from_string_ipv4(addr.c_str()))
-                add_allow_list(node);
-        }
-    }
+    void set_allow_list(const std::vector<std::string> &replica_addrs);
 
     int worker_count() const { return static_cast<int>(_workers.size()); }
 

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -316,6 +316,20 @@ bool failure_detector::remove_from_allow_list(::dsn::rpc_address node)
     return _allow_list.erase(node) > 0;
 }
 
+void failure_detector::set_allow_list(const std::vector<std::string> &replica_addrs)
+{
+    if(_is_started){
+        dwarn("FD is already started, the allow list should really not be modified");
+        return;
+    }
+    
+    for (auto &addr : replica_addrs) {
+        dsn::rpc_address node;
+        if (node.from_string_ipv4(addr.c_str()))
+            add_allow_list(node);
+    }
+}
+
 void failure_detector::on_ping_internal(const beacon_msg &beacon, /*out*/ beacon_ack &ack)
 {
     ack.time = beacon.time;

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -318,11 +318,11 @@ bool failure_detector::remove_from_allow_list(::dsn::rpc_address node)
 
 void failure_detector::set_allow_list(const std::vector<std::string> &replica_addrs)
 {
-    if(_is_started){
+    if (_is_started) {
         dwarn("FD is already started, the allow list should really not be modified");
         return;
     }
-    
+
     for (auto &addr : replica_addrs) {
         dsn::rpc_address node;
         if (node.from_string_ipv4(addr.c_str()))

--- a/src/dist/replication/meta_server/meta_options.cpp
+++ b/src/dist/replication/meta_server/meta_options.cpp
@@ -171,7 +171,7 @@ void meta_options::initialize()
                                   "whether to enable white list of replica servers");
 
     const char *replica_white_list_raw = dsn_config_get_value_string(
-        "meta_server", "replica_white_list", "", "distributed_lock_service provider parameters");
+        "meta_server", "replica_white_list", "", "white list of replica-servers in meta-server");
     utils::split_args(replica_white_list_raw, replica_white_list, ',');
 }
 }

--- a/src/dist/replication/meta_server/meta_options.cpp
+++ b/src/dist/replication/meta_server/meta_options.cpp
@@ -164,8 +164,11 @@ void meta_options::initialize()
     cold_backup_disabled = dsn_config_get_value_bool(
         "meta_server", "cold_backup_disabled", true, "whether to disable cold backup");
 
-    enable_white_list = dsn_config_get_value_bool(
-        "meta_server", "enable_white_list", false, "whether to enable white list of replica servers");
+    enable_white_list =
+        dsn_config_get_value_bool("meta_server",
+                                  "enable_white_list",
+                                  false,
+                                  "whether to enable white list of replica servers");
 
     const char *replica_white_list_raw = dsn_config_get_value_string(
         "meta_server", "replica_white_list", "", "distributed_lock_service provider parameters");

--- a/src/dist/replication/meta_server/meta_options.cpp
+++ b/src/dist/replication/meta_server/meta_options.cpp
@@ -163,6 +163,13 @@ void meta_options::initialize()
 
     cold_backup_disabled = dsn_config_get_value_bool(
         "meta_server", "cold_backup_disabled", true, "whether to disable cold backup");
+
+    enable_white_list = dsn_config_get_value_bool(
+        "meta_server", "enable_white_list", false, "whether to enable white list of replica servers");
+
+    const char *replica_white_list_raw = dsn_config_get_value_string(
+        "meta_server", "replica_white_list", "", "distributed_lock_service provider parameters");
+    utils::split_args(replica_white_list_raw, replica_white_list, ',');
 }
 }
 }

--- a/src/dist/replication/meta_server/meta_options.h
+++ b/src/dist/replication/meta_server/meta_options.h
@@ -83,6 +83,9 @@ public:
 
     bool cold_backup_disabled;
 
+    bool enable_white_list;
+    std::vector<std::string> replica_white_list;
+
 public:
     void initialize();
 

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -38,6 +38,8 @@
 #include <fmt/format.h>
 
 #include <dsn/utility/factory_store.h>
+#include <dsn/utility/extensible_object.h>
+#include <dsn/utility/string_conv.h>
 #include <dsn/dist/meta_state_service.h>
 #include <dsn/tool-api/command_manager.h>
 #include <algorithm> // for std::remove_if
@@ -56,6 +58,8 @@ meta_service::meta_service()
 {
     _opts.initialize();
     _meta_opts.initialize();
+    _node_live_percentage_threshold_for_update =
+        _meta_opts.node_live_percentage_threshold_for_update;
     _state.reset(new server_state());
     _function_level.store(_meta_opts.meta_function_level_on_start);
     if (_meta_opts.recover_from_replica_server) {
@@ -76,7 +80,11 @@ meta_service::meta_service()
         "eon.meta_service", "unalive_nodes", COUNTER_TYPE_NUMBER, "current count of unalive nodes");
 }
 
-meta_service::~meta_service() { _tracker.cancel_outstanding_tasks(); }
+meta_service::~meta_service()
+{
+    _tracker.cancel_outstanding_tasks();
+    unregister_ctrl_commands();
+}
 
 bool meta_service::check_freeze() const
 {
@@ -84,7 +92,7 @@ bool meta_service::check_freeze() const
     if (_alive_set.size() < _meta_opts.min_live_node_count_for_unfreeze)
         return true;
     int total = _alive_set.size() + _dead_set.size();
-    return _alive_set.size() * 100 < _meta_opts.node_live_percentage_threshold_for_update * total;
+    return _alive_set.size() * 100 < _node_live_percentage_threshold_for_update * total;
 }
 
 error_code meta_service::remote_storage_initialize()
@@ -159,6 +167,39 @@ void meta_service::get_node_state(/*out*/ std::map<rpc_address, bool> &all_nodes
 
 void meta_service::balancer_run() { _state->check_all_partitions(); }
 
+void meta_service::register_ctrl_commands()
+{
+    _ctrl_node_live_percentage_threshold_for_update =
+        dsn::command_manager::instance().register_app_command(
+            {"live_percentage"},
+            "live_percentage [num | DEFAULT]",
+            "node live percentage threshold for update",
+            [this](const std::vector<std::string> &args) {
+                std::string result("OK");
+                if (args.empty()) {
+                    result = std::to_string(_node_live_percentage_threshold_for_update);
+                } else {
+                    if (args[0] == "DEFAULT") {
+                        _node_live_percentage_threshold_for_update =
+                            _meta_opts.node_live_percentage_threshold_for_update;
+                    } else {
+                        int32_t v = 0;
+                        if (!dsn::buf2int32(args[0], v) || v < 0) {
+                            result = std::string("ERR: invalid arguments");
+                        } else {
+                            _node_live_percentage_threshold_for_update = v;
+                        }
+                    }
+                }
+                return result;
+            });
+}
+
+void meta_service::unregister_ctrl_commands()
+{
+    UNREGISTER_VALID_HANDLER(_ctrl_node_live_percentage_threshold_for_update);
+}
+
 void meta_service::start_service()
 {
     zauto_lock l(_failure_detector->_lock);
@@ -208,6 +249,8 @@ void meta_service::start_service()
 error_code meta_service::start()
 {
     dassert(!_started, "meta service is already started");
+    register_ctrl_commands();
+
     error_code err;
 
     err = remote_storage_initialize();

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -216,7 +216,7 @@ error_code meta_service::start()
 
     // start failure detector, and try to acquire the leader lock
     _failure_detector.reset(new meta_server_failure_detector(this));
-    if (_meta_opts.enable_white_list && !_meta_opts.replica_white_list.empty())
+    if (_meta_opts.enable_white_list)
         _failure_detector->set_allow_list(_meta_opts.replica_white_list);
     _failure_detector->register_ctrl_commands();
 

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -130,7 +130,7 @@ private:
     void register_rpc_handlers();
     void register_ctrl_commands();
     void unregister_ctrl_commands();
-    
+
     // client => meta server
     // query partition configuration
     void on_query_configuration_by_node(dsn::message_ex *req);

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -128,7 +128,9 @@ public:
 
 private:
     void register_rpc_handlers();
-
+    void register_ctrl_commands();
+    void unregister_ctrl_commands();
+    
     // client => meta server
     // query partition configuration
     void on_query_configuration_by_node(dsn::message_ex *req);
@@ -184,6 +186,8 @@ private:
 
     replication_options _opts;
     meta_options _meta_opts;
+    uint64_t _node_live_percentage_threshold_for_update;
+    dsn_handle_t _ctrl_node_live_percentage_threshold_for_update;
 
     std::shared_ptr<server_state> _state;
     std::shared_ptr<meta_server_failure_detector> _failure_detector;

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -187,7 +187,7 @@ private:
     replication_options _opts;
     meta_options _meta_opts;
     uint64_t _node_live_percentage_threshold_for_update;
-    dsn_handle_t _ctrl_node_live_percentage_threshold_for_update;
+    dsn_handle_t _ctrl_node_live_percentage_threshold_for_update = nullptr;
 
     std::shared_ptr<server_state> _state;
     std::shared_ptr<meta_server_failure_detector> _failure_detector;


### PR DESCRIPTION
### White List
**Implementation Notes**
[https://github.com/XiaoMi/pegasus/issues/238](url)
white list feature is implemented by using allow_list in failure detector.

**Assistant Tool**
we can use remote_command “meta.fd.allow_list” to query the replica white list in meta-server.
```
>>> remote_command -t meta meta.fd.allow_list
COMMAND: meta.fd.allow_list

CALL [meta-server] [xxx] succeed: get ok: allow list disabled.
```
or
```
>>> remote_command -t meta meta.fd.allow_list
COMMAND: meta.fd.allow_list

CALL [meta-server] [xxx] succeed: get ok: allow list enabled. list: x.x.x.x:xx, x.x.x.x:xx
```
### live_percentage
we can control node_live_percentage_threshold_for_update by
` remote_command -t meta meta.live_percentage  [num | DEFAULT]`