### PR TITLE
add unit test of whitelist & fix bug

### DIFF
--- a/include/dsn/dist/failure_detector/failure_detector.h
+++ b/include/dsn/dist/failure_detector/failure_detector.h
@@ -141,6 +141,8 @@ public:
 
     void set_allow_list(const std::vector<std::string> &replica_addrs);
 
+    std::string get_allow_list(const std::vector<std::string> &args) const;
+
     int worker_count() const { return static_cast<int>(_workers.size()); }
 
     int master_count() const { return static_cast<int>(_masters.size()); }
@@ -157,8 +159,6 @@ protected:
 
 private:
     void check_all_records();
-
-    std::string get_allow_list(const std::vector<std::string> &args) const;
 
 private:
     class master_record

--- a/include/dsn/tool-api/network.h
+++ b/include/dsn/tool-api/network.h
@@ -136,7 +136,6 @@ public:
     network_header_format unknown_msg_hdr_format() const { return _unknown_msg_header_format; }
     int message_buffer_block_size() const { return _message_buffer_block_size; }
 
-protected:
     DSN_API static uint32_t get_local_ipv4();
 
 protected:

--- a/src/core/tests/gtest.filter
+++ b/src/core/tests/gtest.filter
@@ -1,3 +1,4 @@
 config-test.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*
-config-test-sim.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*
+config-test-sim.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*:tools_simulator.*
+config-test-sim.ini tools_simulator.*
 config-test-posix-aio.ini core.aio*:core.operation_failed

--- a/src/tests/dsn/CMakeLists.txt
+++ b/src/tests/dsn/CMakeLists.txt
@@ -46,6 +46,9 @@ set(MY_BINPLACES
     "${CMAKE_CURRENT_SOURCE_DIR}/clear.sh"
     "${CMAKE_CURRENT_SOURCE_DIR}/clear.cmd"
     "${CMAKE_CURRENT_SOURCE_DIR}/config-test.ini"
+    "${CMAKE_CURRENT_SOURCE_DIR}/config-whitelist-test.ini"
+    "${CMAKE_CURRENT_SOURCE_DIR}/config-whitelist-test-failed.ini"
+    "${CMAKE_CURRENT_SOURCE_DIR}/gtest.filter"
 )
 
 dsn_add_test()

--- a/src/tests/dsn/config-whitelist-test-failed.ini
+++ b/src/tests/dsn/config-whitelist-test-failed.ini
@@ -1,0 +1,123 @@
+[apps..default]
+run = true
+count = 1
+;network.client.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+;network.client.RPC_CHANNEL_UDP = dsn::tools::sim_network_provider, 65536
+;network.server.0.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+
+[apps.client]
+type = test
+arguments = localhost 20101
+run = true
+ports =
+count = 1
+delay_seconds = 1
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_DLOCK, THREAD_POOL_REPLICATION, THREAD_POOL_REPLICATION_LONG, THREAD_POOL_FDS_SERVICE
+
+[apps.server]
+type = test
+arguments =
+ports = 20101
+run = false
+count = 0
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_REPLICATION
+
+[apps.add_server]
+type = adder
+arguments =
+ports = 20201
+run = true
+count = 3
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_DLOCK
+
+[apps.test_worker]
+type = worker
+arguments =
+ports = 40001
+run = true
+count = 1
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_FD
+
+[apps.test_master]
+type = master
+#whitelist port,port,...
+arguments = whitelist 22222
+ports = 30001
+run = true
+count = 3
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_FD
+
+[core]
+;tool = simulator
+tool = nativerun
+
+;toollets = tracer, profiler
+;fault_injector
+pause_on_start = false
+
+logging_start_level = LOG_LEVEL_INFORMATION
+logging_factory_name = dsn::tools::simple_logger
+
+;io_mode = IOE_PER_NODE
+io_mode = IOE_PER_QUEUE
+io_worker_count = 1
+
+[tools.simple_logger]
+fast_flush = true
+short_header = false
+stderr_start_level = LOG_LEVEL_WARNING
+
+[tools.simulator]
+random_seed = 0
+
+[tools.screen_logger]
+short_header = false
+
+[network]
+; how many network threads for network library (used by asio)
+io_service_worker_count = 2
+
+[task..default]
+is_trace = true
+is_profile = true
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 5000
+
+[task.LPC_AIO_IMMEDIATE_CALLBACK]
+is_trace = false
+is_profile = false
+allow_inline = false
+
+[task.LPC_RPC_TIMEOUT]
+is_trace = false
+is_profile = false
+
+; specification for each thread pool
+[threadpool..default]
+worker_count = 2
+
+[threadpool.THREAD_POOL_DEFAULT]
+partitioned = false
+worker_priority = THREAD_xPRIORITY_NORMAL
+
+[threadpool.THREAD_POOL_TEST_SERVER]
+partitioned = false
+
+[threadpool.THREAD_POOL_FDS_SERVICE]
+worker_count = 8
+
+[threadpool.THREAD_POOL_DLOCK]
+partitioned = true
+
+[zookeeper]
+hosts_list = localhost:12181
+timeout_ms = 30000
+logfile = zoolog.log
+
+[fds_concurrent_test]
+total_files = 64
+min_size = 100
+max_size = 150
+

--- a/src/tests/dsn/config-whitelist-test.ini
+++ b/src/tests/dsn/config-whitelist-test.ini
@@ -1,0 +1,123 @@
+[apps..default]
+run = true
+count = 1
+;network.client.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+;network.client.RPC_CHANNEL_UDP = dsn::tools::sim_network_provider, 65536
+;network.server.0.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+
+[apps.client]
+type = test
+arguments = localhost 20101
+run = true
+ports =
+count = 1
+delay_seconds = 1
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_DLOCK, THREAD_POOL_REPLICATION, THREAD_POOL_REPLICATION_LONG, THREAD_POOL_FDS_SERVICE
+
+[apps.server]
+type = test
+arguments =
+ports = 20101
+run = false
+count = 0
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_REPLICATION
+
+[apps.add_server]
+type = adder
+arguments =
+ports = 20201
+run = true
+count = 3
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_DLOCK
+
+[apps.test_worker]
+type = worker
+arguments =
+ports = 40001
+run = true
+count = 1
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_FD
+
+[apps.test_master]
+type = master
+#whitelist port,port,...
+arguments = whitelist 40001
+ports = 30001
+run = true
+count = 3
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_FD
+
+[core]
+;tool = simulator
+tool = nativerun
+
+;toollets = tracer, profiler
+;fault_injector
+pause_on_start = false
+
+logging_start_level = LOG_LEVEL_INFORMATION
+logging_factory_name = dsn::tools::simple_logger
+
+;io_mode = IOE_PER_NODE
+io_mode = IOE_PER_QUEUE
+io_worker_count = 1
+
+[tools.simple_logger]
+fast_flush = true
+short_header = false
+stderr_start_level = LOG_LEVEL_WARNING
+
+[tools.simulator]
+random_seed = 0
+
+[tools.screen_logger]
+short_header = false
+
+[network]
+; how many network threads for network library (used by asio)
+io_service_worker_count = 2
+
+[task..default]
+is_trace = true
+is_profile = true
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 5000
+
+[task.LPC_AIO_IMMEDIATE_CALLBACK]
+is_trace = false
+is_profile = false
+allow_inline = false
+
+[task.LPC_RPC_TIMEOUT]
+is_trace = false
+is_profile = false
+
+; specification for each thread pool
+[threadpool..default]
+worker_count = 2
+
+[threadpool.THREAD_POOL_DEFAULT]
+partitioned = false
+worker_priority = THREAD_xPRIORITY_NORMAL
+
+[threadpool.THREAD_POOL_TEST_SERVER]
+partitioned = false
+
+[threadpool.THREAD_POOL_FDS_SERVICE]
+worker_count = 8
+
+[threadpool.THREAD_POOL_DLOCK]
+partitioned = true
+
+[zookeeper]
+hosts_list = localhost:12181
+timeout_ms = 30000
+logfile = zoolog.log
+
+[fds_concurrent_test]
+total_files = 64
+min_size = 100
+max_size = 150
+

--- a/src/tests/dsn/gtest.filter
+++ b/src/tests/dsn/gtest.filter
@@ -1,0 +1,4 @@
+config-test.ini distributed_lock_service_zookeeper.simple_lock_unlock
+config-test.ini -distributed_lock_service_zookeeper.simple_lock_unlock:fd.not_in_whitelist
+config-whitelist-test.ini -distributed_lock_service_zookeeper.simple_lock_unlock:fd.not_in_whitelist
+config-whitelist-test-failed.ini fd.not_in_whitelist

--- a/src/tests/dsn/main.cpp
+++ b/src/tests/dsn/main.cpp
@@ -88,7 +88,11 @@ GTEST_API_ int main(int argc, char **argv)
     fd_test_init();
 
     // specify what services and tools will run in config file, then run
-    dsn_run_config("config-test.ini", false);
+    if (argc < 2)
+        dsn_run_config("config-test.ini", false);
+    else
+        dsn_run_config(argv[1], false);
+
     while (g_test_count == 0) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }


### PR DESCRIPTION
1. whitelist单测：为了白名单里的ip地址和worker的ip地址的获取方式统一，把network::get_local_ipv4()改为public
2.set_allow_list bug修复
3.dsn.core.tests单独提出tools_simulator，因为有些机器的dsn.core.tests顺序不一样，tools_simulator会影响perf_counters的query_snapshot_by_regexp测试