### PR TITLE
utils: test format utilities

### DIFF
--- a/include/dsn/dist/fmt_logging.h
+++ b/include/dsn/dist/fmt_logging.h
@@ -26,9 +26,7 @@
 
 #pragma once
 
-#include <dsn/tool-api/auto_codes.h>
-#include <dsn/utility/errors.h>
-#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 // The macros below no longer use the default snprintf method for log message formatting,
 // instead we use fmt::format.
@@ -62,36 +60,3 @@
 #define dcheck_le_replica(var1, var2) dassert_replica(var1 <= var2, "{} vs {}", var1, var2)
 #define dcheck_gt_replica(var1, var2) dassert_replica(var1 > var2, "{} vs {}", var1, var2)
 #define dcheck_lt_replica(var1, var2) dassert_replica(var1 < var2, "{} vs {}", var1, var2)
-
-// Customized formatter for rDSN basic types, on which
-// users can easily call fmt::format("{}", xxx), without the effort
-// of converting them into string.
-
-namespace fmt {
-
-inline void format_arg(fmt::BasicFormatter<char> &f, const char *format_str, dsn::gpid p)
-{
-    f.writer().write("{}.{}", p.get_app_id(), p.get_partition_index());
-}
-
-inline void format_arg(fmt::BasicFormatter<char> &f, const char *format_str, const dsn::error_s &p)
-{
-    f.writer().write(p.description());
-}
-
-inline void format_arg(fmt::BasicFormatter<char> &f, const char *format_str, dsn::error_code p)
-{
-    f.writer().write(p.to_string());
-}
-
-inline void format_arg(fmt::BasicFormatter<char> &f, const char *format_str, dsn::task_code p)
-{
-    f.writer().write(p.to_string());
-}
-
-inline void format_arg(fmt::BasicFormatter<char> &f, const char *format_str, dsn::string_view p)
-{
-    f.writer().write(std::string(p));
-}
-
-} // namespace fmt

--- a/include/dsn/tool-api/gpid.h
+++ b/include/dsn/tool-api/gpid.h
@@ -71,6 +71,11 @@ public:
 
     int thread_hash() const { return _value.u.app_id * 7919 + _value.u.partition_index; }
 
+    friend std::ostream &operator<<(std::ostream &os, gpid id)
+    {
+        return os << std::string(id.to_string());
+    }
+
 private:
     union
     {

--- a/include/dsn/tool-api/task_code.h
+++ b/include/dsn/tool-api/task_code.h
@@ -121,6 +121,11 @@ public:
     static task_code try_get(const char *name, task_code default_value);
     static task_code try_get(const std::string &name, task_code default_value);
 
+    friend std::ostream &operator<<(std::ostream &os, const task_code &tc)
+    {
+        return os << std::string(tc.to_string());
+    }
+
 private:
     task_code(const char *name);
     int _internal_code{0};

--- a/include/dsn/utility/error_code.h
+++ b/include/dsn/utility/error_code.h
@@ -31,6 +31,11 @@ public:
     static error_code try_get(const char *name, error_code default_value);
     static error_code try_get(const std::string &name, error_code default_value);
 
+    friend std::ostream &operator<<(std::ostream &os, const error_code &ec)
+    {
+        return os << std::string(ec.to_string());
+    }
+
 private:
     int _internal_code{0};
 };

--- a/src/core/core/string_view.cpp
+++ b/src/core/core/string_view.cpp
@@ -14,10 +14,48 @@
 // limitations under the License.
 
 #include <dsn/utility/string_view.h>
+#include <ostream>
 
 #include "memutil.h"
 
 namespace dsn {
+
+namespace {
+void WritePadding(std::ostream &o, size_t pad)
+{
+    char fill_buf[32];
+    memset(fill_buf, o.fill(), sizeof(fill_buf));
+    while (pad) {
+        size_t n = std::min(pad, sizeof(fill_buf));
+        o.write(fill_buf, n);
+        pad -= n;
+    }
+}
+} // namespace
+
+std::ostream &operator<<(std::ostream &o, string_view piece)
+{
+    std::ostream::sentry sentry(o);
+    if (sentry) {
+        size_t lpad = 0;
+        size_t rpad = 0;
+        if (static_cast<size_t>(o.width()) > piece.size()) {
+            size_t pad = o.width() - piece.size();
+            if ((o.flags() & o.adjustfield) == o.left) {
+                rpad = pad;
+            } else {
+                lpad = pad;
+            }
+        }
+        if (lpad)
+            WritePadding(o, lpad);
+        o.write(piece.data(), piece.size());
+        if (rpad)
+            WritePadding(o, rpad);
+        o.width(0);
+    }
+    return o;
+}
 
 namespace strings_internal {
 

--- a/src/dist/replication/common/CMakeLists.txt
+++ b/src/dist/replication/common/CMakeLists.txt
@@ -19,3 +19,5 @@ set(MY_PROJ_LIB_PATH "")
 set(MY_BINPLACES "")
 
 dsn_add_static_library()
+
+add_subdirectory(test)

--- a/src/dist/replication/common/test/CMakeLists.txt
+++ b/src/dist/replication/common/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(MY_PROJ_NAME dsn_replication_common_test)
+
+set(MY_SRC_SEARCH_MODE "GLOB")
+
+set(MY_BOOST_PACKAGES system filesystem)
+
+set(MY_PROJ_LIBS
+        dsn_replication_common
+        gtest
+        fmt
+        )
+
+set(MY_BINPLACES
+        config-test.ini
+        run.sh
+        )
+
+dsn_add_test()

--- a/src/dist/replication/common/test/config-test.ini
+++ b/src/dist/replication/common/test/config-test.ini
@@ -1,0 +1,81 @@
+[apps..default]
+run = true
+count = 1
+;network.client.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+;network.client.RPC_CHANNEL_UDP = dsn::tools::sim_network_provider, 65536
+;network.server.0.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+
+[apps.replica]
+type = replica
+run = true
+count = 1
+ports = 54321
+pools = THREAD_POOL_DEFAULT
+
+[core]
+;tool = simulator
+tool = nativerun
+
+;toollets = tracer, profiler
+;fault_injector
+pause_on_start = false
+cli_local = false
+cli_remote = false
+
+logging_start_level = LOG_LEVEL_DEBUG
+logging_factory_name = dsn::tools::simple_logger
+
+;io_mode = IOE_PER_NODE
+io_mode = IOE_PER_QUEUE
+io_worker_count = 1
+
+[tools.simple_logger]
+fast_flush = true
+short_header = false
+stderr_start_level = LOG_LEVEL_WARNING
+
+[tools.simulator]
+random_seed = 1465902258
+
+[tools.screen_logger]
+short_header = false
+
+[network]
+; how many network threads for network library (used by asio)
+io_service_worker_count = 2
+
+; specification for each thread pool
+[threadpool..default]
+worker_count = 4
+
+[threadpool.THREAD_POOL_DEFAULT]
+name = default
+partitioned = false
+max_input_queue_length = 1024
+worker_priority = THREAD_xPRIORITY_NORMAL
+worker_count = 2
+
+[threadpool.THREAD_POOL_REPLICATION]
+name = replica
+partitioned = true
+max_input_queue_length = 2560
+worker_priority = THREAD_xPRIORITY_NORMAL
+worker_count = 3
+
+[threadpool.THREAD_POOL_REPLICATION_LONG]
+name = replica_long
+
+[task..default]
+is_trace = true
+is_profile = true
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 5000
+
+[replication]
+cluster_name = master-cluster
+
+[duplication-group]
+master-cluster = 1
+slave-cluster  = 2

--- a/src/dist/replication/common/test/fmt_logging_test.cpp
+++ b/src/dist/replication/common/test/fmt_logging_test.cpp
@@ -41,6 +41,7 @@ TEST(fmt_logging, basic)
     ASSERT_EQ(fmt::format("{}", ERR_OK), "ERR_OK");
     ASSERT_EQ(fmt::format("{}", LPC_REPLICATION_LOW), "LPC_REPLICATION_LOW");
     ASSERT_EQ(string_view("yes"), "yes");
+    ASSERT_EQ(fmt::format("{}", string_view("yes\0yes")), "yes\0yes");
 }
 
 } // namespace replication

--- a/src/dist/replication/common/test/fmt_logging_test.cpp
+++ b/src/dist/replication/common/test/fmt_logging_test.cpp
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <dsn/utility/string_view.h>
+#include <dsn/utility/errors.h>
+#include <dsn/dist/fmt_logging.h>
+#include <gtest/gtest.h>
+#include <dsn/dist/replication/replication.codes.h>
+
+namespace dsn {
+namespace replication {
+
+TEST(fmt_logging, basic)
+{
+    ASSERT_EQ(fmt::format("{}", gpid(1, 1)), "1.1");
+    ASSERT_EQ(fmt::format("{}", error_s::ok()), "ERR_OK");
+    ASSERT_EQ(fmt::format("{}", error_s::make(ERR_TIMEOUT, "yes")), "ERR_TIMEOUT: yes");
+    ASSERT_EQ(fmt::format("{}", ERR_OK), "ERR_OK");
+    ASSERT_EQ(fmt::format("{}", LPC_REPLICATION_LOW), "LPC_REPLICATION_LOW");
+    ASSERT_EQ(string_view("yes"), "yes");
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/common/test/main.cpp
+++ b/src/dist/replication/common/test/main.cpp
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <dsn/service_api_cpp.h>
+
+int g_test_count = 0;
+int g_test_ret = 0;
+
+class gtest_app : public dsn::service_app
+{
+public:
+    explicit gtest_app(const dsn::service_app_info *info) : ::dsn::service_app(info) {}
+
+    dsn::error_code start(const std::vector<std::string> &args) override
+    {
+        g_test_ret = RUN_ALL_TESTS();
+        g_test_count = 1;
+        return dsn::ERR_OK;
+    }
+
+    dsn::error_code stop(bool) override { return dsn::ERR_OK; }
+};
+
+GTEST_API_ int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+
+    dsn::service_app::register_factory<gtest_app>("replica");
+
+    dsn_run_config("config-test.ini", false);
+    while (g_test_count == 0) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    dsn_exit(g_test_ret);
+}

--- a/src/dist/replication/common/test/run.sh
+++ b/src/dist/replication/common/test/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+exit_if_fail() {
+    if [ $1 != 0 ]; then
+        echo $2
+        exit 1
+    fi
+}
+
+./dsn_replication_common_test
+
+exit_if_fail $? "run unit test failed"


### PR DESCRIPTION
补充了 

```cpp
std::ostream &operator<<(std::ostream &o, string_view piece)
```

的实现（拷贝于 abseil），之前 string_view 是不支持 operator<< 的