### PR TITLE
*:fix Semaphore bug & Compile warnings

### DIFF
--- a/include/dsn/utility/hpc_locks/sema.h
+++ b/include/dsn/utility/hpc_locks/sema.h
@@ -209,7 +209,7 @@ public:
             waitWithPartialSpinning();
     }
 
-    // Be careful! Should check the return value, and can consume if the return value is true.
+    // Be careful! Should check the return value, and can consume iff the return value is true.
     bool wait(int timeout_milliseconds)
     {
         int oldCount = m_count.fetch_sub(1, std::memory_order_acquire);

--- a/include/dsn/utility/hpc_locks/sema.h
+++ b/include/dsn/utility/hpc_locks/sema.h
@@ -132,6 +132,12 @@ public:
         clock_gettime(CLOCK_REALTIME, &ts);
         ts.tv_sec += timeout_milliseconds / 1000;
         ts.tv_nsec += timeout_milliseconds % 1000 * 1000000;
+        if (ts.tv_nsec >= 1000000000) {
+            ++ts.tv_sec;
+            ts.tv_nsec -= 1000000000;
+        }
+        assert(ts.tv_nsec >= 0);
+        assert(ts.tv_nsec < 1000000000);
 
         return sem_timedwait(&m_sema, &ts) == 0;
     }
@@ -203,7 +209,7 @@ public:
             waitWithPartialSpinning();
     }
 
-    // Be careful! Should check the return value, and can consume iff the return value is true.
+    // Be careful! Should check the return value, and can consume if the return value is true.
     bool wait(int timeout_milliseconds)
     {
         int oldCount = m_count.fetch_sub(1, std::memory_order_acquire);

--- a/src/core/core/message_utils.cpp
+++ b/src/core/core/message_utils.cpp
@@ -37,7 +37,8 @@ namespace dsn {
     auto msg = ::dsn::message_ex::create_receive_message_with_standalone_header(bb);
     msg->local_rpc_code = rpc_code;
     const char *name = rpc_code.to_string();
-    strncpy(msg->header->rpc_name, name, strlen(name));
+    strncpy(msg->header->rpc_name, name, sizeof(msg->header->rpc_name) - 1);
+    msg->header->rpc_name[sizeof(msg->header->rpc_name) - 1] = '\0';
 
     msg->header->client.thread_hash = thread_hash;
     msg->header->client.partition_hash = partition_hash;

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -741,7 +741,8 @@ void rpc_engine::reply(message_ex *response, error_code err)
 
     strncpy(response->header->server.error_name,
             err.to_string(),
-            sizeof(response->header->server.error_name));
+            sizeof(response->header->server.error_name) - 1);
+    response->header->server.error_name[sizeof(response->header->server.error_name) - 1] = '\0';
     response->header->server.error_code.local_code = err;
     response->header->server.error_code.local_hash = message_ex::s_local_hash;
 

--- a/src/core/tools/common/raw_message_parser.cpp
+++ b/src/core/tools/common/raw_message_parser.cpp
@@ -52,7 +52,9 @@ void raw_message_parser::notify_rpc_session_disconnected(rpc_session *sp)
         header->from_address = sp->remote_address();
         header->gpid.set_value(0);
 
-        strncpy(header->rpc_name, "RPC_CALL_RAW_SESSION_DISCONNECT", DSN_MAX_TASK_CODE_NAME_LENGTH);
+        strncpy(
+            header->rpc_name, "RPC_CALL_RAW_SESSION_DISCONNECT", sizeof(header->rpc_name) - 1);
+        header->rpc_name[sizeof(header->rpc_name) - 1] = '\0';
         special_msg->local_rpc_code = RPC_CALL_RAW_SESSION_DISCONNECT;
         special_msg->hdr_format = NET_HDR_RAW;
         sp->on_recv_message(special_msg, 0);
@@ -90,7 +92,8 @@ message_ex *raw_message_parser::get_message_on_receive(message_reader *reader,
 
         header->hdr_length = sizeof(*header);
         header->body_length = msg_length;
-        strncpy(header->rpc_name, "RPC_CALL_RAW_MESSAGE", DSN_MAX_TASK_CODE_NAME_LENGTH);
+        strncpy(header->rpc_name, "RPC_CALL_RAW_MESSAGE", sizeof(header->rpc_name) - 1);
+        header->rpc_name[sizeof(header->rpc_name) - 1] = '\0';
         header->gpid.set_value(0);
         header->context.u.is_request = 1;
         header->context.u.is_forwarded = 0;

--- a/src/core/tools/common/raw_message_parser.cpp
+++ b/src/core/tools/common/raw_message_parser.cpp
@@ -52,8 +52,7 @@ void raw_message_parser::notify_rpc_session_disconnected(rpc_session *sp)
         header->from_address = sp->remote_address();
         header->gpid.set_value(0);
 
-        strncpy(
-            header->rpc_name, "RPC_CALL_RAW_SESSION_DISCONNECT", sizeof(header->rpc_name) - 1);
+        strncpy(header->rpc_name, "RPC_CALL_RAW_SESSION_DISCONNECT", sizeof(header->rpc_name) - 1);
         header->rpc_name[sizeof(header->rpc_name) - 1] = '\0';
         special_msg->local_rpc_code = RPC_CALL_RAW_SESSION_DISCONNECT;
         special_msg->hdr_format = NET_HDR_RAW;

--- a/src/core/tools/common/thrift_message_parser.cpp
+++ b/src/core/tools/common/thrift_message_parser.cpp
@@ -261,8 +261,8 @@ dsn::message_ex *thrift_message_parser::parse_message(const thrift_message_heade
     dsn_hdr->hdr_crc32 = dsn_hdr->body_crc32 = CRC_INVALID;
 
     dsn_hdr->id = seqid;
-    strncpy(dsn_hdr->rpc_name, fname.c_str(), DSN_MAX_TASK_CODE_NAME_LENGTH);
-    dsn_hdr->rpc_name[DSN_MAX_TASK_CODE_NAME_LENGTH - 1] = '\0';
+    strncpy(dsn_hdr->rpc_name, fname.c_str(), sizeof(dsn_hdr->rpc_name) - 1);
+    dsn_hdr->rpc_name[sizeof(dsn_hdr->rpc_name) - 1] = '\0';
     dsn_hdr->gpid.set_app_id(thrift_header.app_id);
     dsn_hdr->gpid.set_partition_index(thrift_header.partition_index);
     dsn_hdr->client.timeout_ms = thrift_header.client_timeout;

--- a/src/dist/replication/lib/replica_context.cpp
+++ b/src/dist/replication/lib/replica_context.cpp
@@ -281,6 +281,7 @@ bool cold_backup_context::fail_check(const char *failure_reason)
     int checking = ColdBackupChecking;
     if (_status.compare_exchange_strong(checking, ColdBackupFailed)) {
         strncpy(_reason, failure_reason, sizeof(_reason) - 1);
+        _reason[sizeof(_reason) - 1] = '\0';
         if (_owner_replica != nullptr) {
             _owner_replica->get_replica_stub()->_counter_cold_backup_recent_fail_count->increment();
         }
@@ -319,6 +320,7 @@ bool cold_backup_context::fail_checkpoint(const char *failure_reason)
     int checkpointing = ColdBackupCheckpointing;
     if (_status.compare_exchange_strong(checkpointing, ColdBackupFailed)) {
         strncpy(_reason, failure_reason, sizeof(_reason) - 1);
+        _reason[sizeof(_reason) - 1] = '\0';
         if (_owner_replica != nullptr) {
             _owner_replica->get_replica_stub()->_counter_cold_backup_recent_fail_count->increment();
         }
@@ -359,6 +361,7 @@ bool cold_backup_context::fail_upload(const char *failure_reason)
     if (_status.compare_exchange_strong(uploading, ColdBackupFailed) ||
         _status.compare_exchange_strong(paused, ColdBackupFailed)) {
         strncpy(_reason, failure_reason, sizeof(_reason) - 1);
+        _reason[sizeof(_reason) - 1] = '\0';
         if (_owner_replica != nullptr) {
             _owner_replica->get_replica_stub()->_counter_cold_backup_recent_fail_count->increment();
         }

--- a/src/dist/replication/meta_server/meta_backup_service.h
+++ b/src/dist/replication/meta_server/meta_backup_service.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <cstdio>
-
+#include <sstream>
+#include <iomanip> // std::setfill, std::setw
 #include <functional>
 #include <dsn/dist/block_service.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
@@ -64,12 +65,12 @@ struct backup_start_time
     int32_t minute; // [0 ~ 60)
     backup_start_time() : hour(0), minute(0) {}
     backup_start_time(int32_t h, int32_t m) : hour(h), minute(m) {}
-    std::string to_string()
+    std::string to_string() const
     {
-        char res[10] = {"\0"};
-        if (snprintf(res, sizeof(res), "%02d:%02d", hour, minute) < 0)
-            return std::string("invalid time");
-        return std::string(res);
+        std::stringstream ss;
+        ss << std::setw(2) << std::setfill('0') << std::to_string(hour) << ":" << std::setw(2)
+           << std::setfill('0') << std::to_string(minute);
+        return ss.str();
     }
     // NOTICE: this function will modify hour and minute, if time is invalid, this func will set
     // hour = 24, minute = 0

--- a/src/dist/replication/meta_server/meta_backup_service.h
+++ b/src/dist/replication/meta_server/meta_backup_service.h
@@ -67,7 +67,8 @@ struct backup_start_time
     std::string to_string()
     {
         char res[10] = {"\0"};
-        sprintf(res, "%02d:%02d", hour, minute);
+        if (snprintf(res, sizeof(res), "%02d:%02d", hour, minute) < 0)
+            return std::string("invalid time");
         return std::string(res);
     }
     // NOTICE: this function will modify hour and minute, if time is invalid, this func will set


### PR DESCRIPTION
1. fix invalid argument of sem_timedwait: 
```
rdsn/src/core/tests/sema.cpp:47: Failure
Value of: s.wait(10)
  Actual: false
Expected: true
```
The bug is in this code: 
```
        clock_gettime(CLOCK_REALTIME, &ts);
        ts.tv_sec += timeout_milliseconds / 1000;
        ts.tv_nsec += timeout_milliseconds % 1000 * 1000000;
```
ts.tv_nsec may be greater than 1000 million, but it's invalid. And it may cause the error "EINVAL", which errno is 22.
>        The following additional errors can occur for sem_timedwait():
>        EINVAL The value of abs_timeout.tv_nsecs is less than 0, or greater
>               than or equal to 1000 million.
>       <http://man7.org/linux/man-pages/man3/sem_wait.3.html>

2. fix compile warnings when using gcc 8.3.0

```
error: ‘char* strncpy(char*, const char*, size_t)’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
```
```
error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 48 equals destination size [-Werror=stringop-truncation]
```
```
rdsn/src/core/core/rpc_message.cpp:165:50: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘dsn::message_header’ {aka ‘struct dsn::message_header’} with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
```
```
rdsn/src/dist/replication/meta_server/meta_backup_service.h:70:22: error: ‘%02d’ directive writing between 2 and 11 bytes into a region of size 10 [-Werror=format-overflow=]
         sprintf(res, "%02d:%02d", hour, minute);
note: directive argument in the range [-2147483648, 24]
```