### PR TITLE
fix perf_counter_info::timestamp

### DIFF
--- a/include/dsn/perf_counter/perf_counters.h
+++ b/include/dsn/perf_counter/perf_counters.h
@@ -147,7 +147,8 @@ private:
     };
     std::unordered_map<std::string, counter_snapshot> _snapshots;
 
-    int64_t _timestamp;  // in seconds
+    // timestamp in seconds when take snapshot of current counters
+    int64_t _timestamp;
 };
 
 } // end namespace dsn::utils

--- a/include/dsn/perf_counter/perf_counters.h
+++ b/include/dsn/perf_counter/perf_counters.h
@@ -146,6 +146,8 @@ private:
         bool updated_recently{false};
     };
     std::unordered_map<std::string, counter_snapshot> _snapshots;
+
+    int64_t _timestamp;  // in seconds
 };
 
 } // end namespace dsn::utils

--- a/src/core/perf_counter/perf_counters.cpp
+++ b/src/core/perf_counter/perf_counters.cpp
@@ -201,7 +201,7 @@ std::string perf_counters::list_snapshot_by_regexp(const std::vector<std::string
     }
 
     std::stringstream ss;
-    info.timestamp = dsn_now_ms() / 1000;
+    info.timestamp = _timestamp;
     char buf[20];
     utils::time_ms_to_date_time(info.timestamp * 1000, buf, sizeof(buf));
     info.timestamp_str = buf;
@@ -235,6 +235,8 @@ void perf_counters::take_snapshot()
             cs.value = c->get_percentile(COUNTER_PERCENTILE_99);
         }
     }
+
+    _timestamp = dsn_now_ms() / 1000;
 
     // delete old counters
     std::vector<std::string> old_counters;


### PR DESCRIPTION
fix perf_counter_info::timestamp to the timestamp when perf_counters::take_snapshot()