### PR TITLE
duplication: add meta_duplication_service (part 0)

### DIFF
--- a/src/dist/replication/meta_server/duplication/meta_duplication_service.h
+++ b/src/dist/replication/meta_server/duplication/meta_duplication_service.h
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "dist/replication/meta_server/server_state.h"
+#include "dist/replication/meta_server/meta_data.h"
+
+namespace dsn {
+namespace replication {
+
+class meta_duplication_service
+{
+public:
+    meta_duplication_service(server_state *ss, meta_service *ms) : _state(ss), _meta_svc(ms)
+    {
+        dassert(_state, "_state should not be null");
+        dassert(_meta_svc, "_meta_svc should not be null");
+    }
+
+private:
+    friend class meta_duplication_service_test;
+
+    server_state *_state;
+
+    meta_service *_meta_svc;
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/meta_server/meta_data.h
+++ b/src/dist/replication/meta_server/meta_data.h
@@ -49,6 +49,8 @@
 #include <dsn/tool-api/zlocks.h>
 #include <dsn/dist/block_service.h>
 
+#include "duplication/duplication_info.h"
+
 namespace dsn {
 namespace replication {
 
@@ -332,6 +334,8 @@ public:
     const char *get_logname() const { return log_name.c_str(); }
     std::shared_ptr<app_state_helper> helpers;
     std::vector<partition_configuration> partitions;
+    std::map<dupid_t, duplication_info_s_ptr> duplications;
+
     static std::shared_ptr<app_state> create(const app_info &info);
     dsn::blob to_json(app_status::type temp_status)
     {

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -786,9 +786,7 @@ void meta_service::on_query_restore_status(dsn::message_ex *req)
 void meta_service::initialize_duplication_service()
 {
     if (!_opts.duplication_disabled) {
-        _dup_svc = dsn::make_unique<meta_duplication_service>(_state.get(), this);
-    } else {
-        _dup_svc.reset();
+        _dup_svc = make_unique<meta_duplication_service>(_state.get(), this);
     }
 }
 

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -42,7 +42,7 @@
 #include "server_state.h"
 #include "meta_server_failure_detector.h"
 #include "server_load_balancer.h"
-#include "dist/replication/meta_server/duplication/meta_duplication_service.h"
+#include "duplication/meta_duplication_service.h"
 
 namespace dsn {
 namespace replication {
@@ -788,7 +788,7 @@ void meta_service::initialize_duplication_service()
     if (!_opts.duplication_disabled) {
         _dup_svc = dsn::make_unique<meta_duplication_service>(_state.get(), this);
     } else {
-        _dup_svc.reset(nullptr);
+        _dup_svc.reset();
     }
 }
 

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -361,7 +361,6 @@ void meta_service::register_rpc_handlers()
     register_rpc_handler(RPC_CM_QUERY_RESTORE_STATUS,
                          "query_restore_status",
                          &meta_service::on_query_restore_status);
-
     register_rpc_handler_with_rpc_holder(
         RPC_CM_UPDATE_APP_ENV, "update_app_env(set/del/clear)", &meta_service::update_app_env);
     register_rpc_handler_with_rpc_holder(

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -24,14 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
 #include <sys/stat.h>
 
 #include <boost/lexical_cast.hpp>
@@ -41,6 +33,7 @@
 #include <dsn/utility/extensible_object.h>
 #include <dsn/utility/string_conv.h>
 #include <dsn/dist/meta_state_service.h>
+#include <dsn/dist/replication/duplication_common.h>
 #include <dsn/tool-api/command_manager.h>
 #include <algorithm> // for std::remove_if
 #include <cctype>    // for ::isspace
@@ -49,6 +42,7 @@
 #include "server_state.h"
 #include "meta_server_failure_detector.h"
 #include "server_load_balancer.h"
+#include "dist/replication/meta_server/duplication/meta_duplication_service.h"
 
 namespace dsn {
 namespace replication {
@@ -107,6 +101,7 @@ error_code meta_service::remote_storage_initialize()
         return err;
     }
     _storage.reset(storage);
+    _meta_storage.reset(new mss::meta_storage(_storage.get(), &_tracker));
 
     std::vector<std::string> slices;
     utils::split_args(_meta_opts.cluster_root.c_str(), slices, '/');
@@ -318,6 +313,8 @@ error_code meta_service::start()
                err.to_string());
     }
 
+    initialize_duplication_service();
+
     _state->register_cli_commands();
 
     start_service();
@@ -364,6 +361,7 @@ void meta_service::register_rpc_handlers()
     register_rpc_handler(RPC_CM_QUERY_RESTORE_STATUS,
                          "query_restore_status",
                          &meta_service::on_query_restore_status);
+
     register_rpc_handler_with_rpc_holder(
         RPC_CM_UPDATE_APP_ENV, "update_app_env(set/del/clear)", &meta_service::update_app_env);
     register_rpc_handler_with_rpc_holder(
@@ -786,6 +784,15 @@ void meta_service::on_query_restore_status(dsn::message_ex *req)
                      std::bind(&server_state::on_query_restore_status, _state.get(), req));
 }
 
+void meta_service::initialize_duplication_service()
+{
+    if (!_opts.duplication_disabled) {
+        _dup_svc = dsn::make_unique<meta_duplication_service>(_state.get(), this);
+    } else {
+        _dup_svc.reset(nullptr);
+    }
+}
+
 void meta_service::update_app_env(app_env_rpc env_rpc)
 {
     auto &response = env_rpc.response();
@@ -825,5 +832,6 @@ void meta_service::ddd_diagnose(ddd_diagnose_rpc rpc)
     get_balancer()->get_ddd_partitions(rpc.request().pid, response.partitions);
     response.err = ERR_OK;
 }
-}
-}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -56,6 +56,7 @@ class server_state;
 class meta_server_failure_detector;
 class server_load_balancer;
 class replication_checker;
+class meta_duplication_service;
 namespace test {
 class test_checker;
 }
@@ -169,6 +170,15 @@ private:
     void on_report_restore_status(dsn::message_ex *req);
     void on_query_restore_status(dsn::message_ex *req);
 
+    // duplication
+    void on_add_duplication(duplication_add_rpc rpc);
+    void on_change_duplication_status(duplication_status_change_rpc rpc);
+    void on_query_duplication_info(duplication_query_rpc rpc);
+    void on_duplication_sync(duplication_sync_rpc rpc);
+    void register_duplication_rpc_handlers();
+    void recover_duplication_from_meta_state();
+    void initialize_duplication_service();
+
     // common routines
     // ret:
     //   1. the meta is leader
@@ -198,6 +208,10 @@ private:
     std::shared_ptr<server_load_balancer> _balancer;
     std::shared_ptr<backup_service> _backup_handler;
 
+    friend class meta_duplication_service_test;
+    friend class meta_duplication_service;
+    std::unique_ptr<meta_duplication_service> _dup_svc;
+
     // handle all the block filesystems for current meta service
     // (in other words, current service node)
     block_service_manager _block_service_manager;
@@ -224,5 +238,6 @@ private:
 
     dsn::task_tracker _tracker;
 };
-}
-}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/meta_server/server_state.h
+++ b/src/dist/replication/meta_server/server_state.h
@@ -301,6 +301,8 @@ private:
     friend class replication_checker;
     friend class test::test_checker;
     friend class ::meta_service_test_app;
+    friend class meta_duplication_service_test;
+    friend class meta_duplication_service;
 
     dsn::task_tracker _tracker;
 
@@ -337,5 +339,6 @@ private:
     perf_counter_wrapper _recent_partition_change_unwritable_count;
     perf_counter_wrapper _recent_partition_change_writable_count;
 };
-}
-}
+
+} // namespace replication
+} // namespace dsn


### PR DESCRIPTION
考虑到目前 code review 比较慢，我们这里把大 PR 做拆分，这样既方便大家通过，我也可以做更多解释。

1. 处理热备份 rpc 的类不是 meta_service，也不是 server_state，而是 **meta_duplication_service** （`_dup_svc`）。解耦之后代码会变得更干净。

2. 每个表的元信息 app_state 现在会多一个字段，叫 **duplications**，一个表可以有多个热备份，即一个集群可以热备到多个集群上。

3. 关于 `_meta_storage`。热备份的 zk 读写都是用 `mss::meta_storage` 实现的，它和 `meta_state_service`
最大的区别就是我们隐藏了错误重试的细节，精简了代码和逻辑。
这个工具类在 #83 #51 引入，但我们在当前 PR 才第一次使用。
