### PR TITLE
ddl_client: JSON output supported for list_app and cluster_info

### DIFF
--- a/include/dsn/dist/replication/replication_ddl_client.h
+++ b/include/dsn/dist/replication/replication_ddl_client.h
@@ -84,10 +84,11 @@ public:
 
     dsn::error_code cluster_name(int64_t timeout_ms, std::string &cluster_name);
 
-    dsn::error_code cluster_info(const std::string &file_name, bool resolve_ip = false);
+    dsn::error_code cluster_info(const std::string &file_name, bool resolve_ip, bool json);
 
     dsn::error_code list_app(const std::string &app_name,
                              bool detailed,
+                             bool json,
                              const std::string &file_name,
                              bool resolve_ip = false);
 

--- a/include/dsn/utility/output_utils.h
+++ b/include/dsn/utility/output_utils.h
@@ -158,7 +158,10 @@ private:
     {
         rapidjson::OStreamWrapper wrapper(out);
         Writer writer(wrapper);
+        writer.StartObject();
         json_encode(writer, *this);
+        writer.EndObject();
+        out << std::endl;
     }
 
 private:


### PR DESCRIPTION
- JSON output supported for `list_app` and `cluster_info`
- fix a bug in single `table_printer` object output in JSON