### PR TITLE
use c++14 mode for compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: cpp
 
 os: linux
 
-env: COMPILER=g++-5
-
 compiler: 
     - gcc
 
@@ -16,6 +14,7 @@ cache:
 
 addons:
     apt:
+        update: true
         sources:
             - ubuntu-toolchain-r-test
         packages:
@@ -39,7 +38,7 @@ before_script:
     - ulimit -c unlimited -S
 
 script:
-    - ./run.sh test --skip_thirdparty --check --disable_gperf
+    - ./run.sh test --compiler "gcc-5,g++-5" --skip_thirdparty --check --disable_gperf
 
 after_script:
     - ./run.sh stop_zk

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: cpp
 
 os: linux
 
+env: COMPILER=g++-5
+
 compiler: 
     - gcc
 
@@ -16,6 +18,7 @@ addons:
     apt:
         packages:
             - clang-format-3.9
+            - g++-5
 
 before_install:
     - wget https://raw.githubusercontent.com/xiaomi/pegasus-common/master/build-depends.tar.gz
@@ -24,9 +27,6 @@ before_install:
     - cd packages
     - ls | xargs sudo dpkg -i --force-depends
     - cd ..
-
-install:
-    # - ./run.sh format
 
 before_script:
     - cd thirdparty

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ cache:
 
 addons:
     apt:
+        sources:
+            - ubuntu-toolchain-r-test
         packages:
             - clang-format-3.9
             - g++-5

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -209,10 +209,17 @@ function(dsn_setup_compiler_flags)
     # We want access to the PRI* print format macros.
     add_definitions(-D__STDC_FORMAT_MACROS)
 
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
+    if(NOT ${COMPILER_SUPPORTS_CXX14})
+        message(FATAL_ERROR "You need a compiler with C++14 support.")
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" CACHE STRING "" FORCE)
+
     # -fno-omit-frame-pointer
     #   use frame pointers to allow simple stack frame walking for backtraces.
     #   This has a small perf hit but worth it for the ability to profile in production
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-omit-frame-pointer" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer" CACHE STRING "" FORCE)
 
     #  -Wall: Enable all warnings.
     add_compile_options(-Wall)
@@ -335,12 +342,6 @@ function(dsn_common_setup)
     endif()
 
     set(BUILD_SHARED_LIBS OFF)
-
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++1y" COMPILER_SUPPORTS_CXX1Y)
-    if(NOT ${COMPILER_SUPPORTS_CXX1Y})
-        message(FATAL_ERROR "You need a compiler with C++1y support.")
-    endif()
 
     dsn_setup_system_libs()
     dsn_setup_compiler_flags()

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -211,10 +211,11 @@ function(dsn_setup_compiler_flags)
 
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-    if(NOT ${COMPILER_SUPPORTS_CXX14})
+    if(COMPILER_SUPPORTS_CXX14)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" CACHE STRING "" FORCE)
+    else()
         message(FATAL_ERROR "You need a compiler with C++14 support.")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" CACHE STRING "" FORCE)
 
     # -fno-omit-frame-pointer
     #   use frame pointers to allow simple stack frame walking for backtraces.

--- a/src/core/core/fail_point.cpp
+++ b/src/core/core/fail_point.cpp
@@ -18,7 +18,7 @@
 #include "fail_point_impl.h"
 
 #include <dsn/c/api_layer1.h>
-#include <boost/regex.hpp>
+#include <regex>
 #include <dsn/utility/rand.h>
 
 namespace dsn {
@@ -57,13 +57,13 @@ bool fail_point::parse_from_string(string_view action)
     _max_cnt = -1;
     _freq = 100;
 
-    boost::regex regex(R"((\d+\%)?(\d+\*)?(\w+)(\((.*)\))?)");
-    boost::smatch match;
+    std::regex regex(R"((\d+\%)?(\d+\*)?(\w+)(\((.*)\))?)");
+    std::smatch match;
 
     std::string tmp(action.data(), action.length());
-    if (boost::regex_match(tmp, match, regex)) {
+    if (std::regex_match(tmp, match, regex)) {
         if (match.size() == 6) {
-            boost::ssub_match sub_match = match[1];
+            std::ssub_match sub_match = match[1];
             if (!sub_match.str().empty()) {
                 sscanf(sub_match.str().data(), "%d%%", &_freq);
             }

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ set(MY_PROJ_INC_PATH
     ../core ../tools/common ../tools/simulator ../tools/hpc ../tools/nfs 
     )
     
-set(MY_BOOST_PACKAGES system filesystem regex)
+set(MY_BOOST_PACKAGES system filesystem)
 
 set(MY_PROJ_LIBS gtest
                  dsn_runtime


### PR DESCRIPTION
C++14 has many advantages over C++11, and now it's fully mature for nearly three years. Besides, there's no difficulty for our current codebase to move onto C++14. What we need to do is to upgrade our least compiler support to gcc-5 (suggested GCC-5.5).

The first benefit is that we are no longer suffering from the bug of `std::regex` lib in gcc-4.9, so no need for `boost::regex` then.

New features introduced in C++14 can be found in https://www.wikiwand.com/en/C%2B%2B14, some by far are useful for us:

- `std::make_unique`: will replace `dsn::make_unique`
- user-defined literals: will replace `dsn/utility/chrono_literals.h`
