### PR TITLE
rpc: fix asio bug that causes coredump

### DIFF
--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -334,7 +334,6 @@ rpc_session::rpc_session(connection_oriented_network &net,
       _message_count(0),
       _is_sending_next(false),
       _message_sent(0),
-
       _net(net),
       _remote_addr(remote_addr),
       _max_buffer_block_count_per_send(net.max_buffer_block_count_per_send()),
@@ -724,4 +723,4 @@ void connection_oriented_network::on_client_session_disconnected(rpc_session_ptr
                scount);
     }
 }
-}
+} // namespace dsn


### PR DESCRIPTION
Fixed https://github.com/XiaoMi/pegasus/issues/307. 
The core problem is when the socket is reading/writing, the other threads which encounter a network error will close that socket, and may cause its internal `descriptor_data` to be null, then the thread w/r using the wild pointer will coredump in this case.
The solution is to add write-lock on close and read-lock on r/w, so that will ensure thread-safety of the Boost-ASIO socket.
