### PR TITLE
duplication: bugfix on pause_dup

### DIFF
--- a/include/dsn/dist/replication/duplication_common.h
+++ b/include/dsn/dist/replication/duplication_common.h
@@ -43,6 +43,11 @@ typedef int32_t dupid_t;
 
 extern const char *duplication_status_to_string(duplication_status::type status);
 
+inline bool is_duplication_status_valid(duplication_status::type status)
+{
+    return status == duplication_status::DS_PAUSE || status == duplication_status::DS_START;
+}
+
 /// Returns the cluster name (i.e, "onebox") if it's configured under
 /// "replication" section:
 ///    [replication]

--- a/src/dist/replication/meta_server/duplication/duplication_info.cpp
+++ b/src/dist/replication/meta_server/duplication/duplication_info.cpp
@@ -134,7 +134,9 @@ void duplication_info::persist_status()
 {
     zauto_write_lock l(_lock);
 
-    dassert_dup(_is_altering, this, "");
+    dassert_dup(_is_altering,
+                this,
+                "impossible, callers never write a duplication that is not altering to meta store");
     ddebug_dup(this,
                "change duplication status from {} to {} successfully [app_id: {}]",
                duplication_status_to_string(_status),

--- a/src/dist/replication/meta_server/duplication/duplication_info.h
+++ b/src/dist/replication/meta_server/duplication/duplication_info.h
@@ -88,10 +88,7 @@ public:
     void persist_status();
 
     // if this duplication is in valid status.
-    bool is_valid() const
-    {
-        return _status == duplication_status::DS_START || _status == duplication_status::DS_PAUSE;
-    }
+    bool is_valid() const { return is_duplication_status_valid(_status); }
 
     ///
     /// alter_progress -> persist_progress
@@ -118,14 +115,11 @@ public:
 
     // duplication_query_rpc is handled in THREAD_POOL_META_SERVER,
     // which is not thread safe for read.
-    void append_if_valid(std::vector<duplication_entry> &entry_list) const
+    void append_if_valid_for_query(
+        /*out*/ std::vector<duplication_entry> &entry_list) const
     {
         zauto_read_lock l(_lock);
-
-        // the invalid duplication is not visible to user.
-        if (is_valid()) {
-            entry_list.emplace_back(to_duplication_entry());
-        }
+        entry_list.emplace_back(to_duplication_entry());
     }
 
     duplication_entry to_duplication_entry() const
@@ -136,6 +130,9 @@ public:
         entry.remote = remote;
         entry.status = _status;
         for (const auto &kv : _progress) {
+            if (!kv.second.is_inited) {
+                continue;
+            }
             entry.progress[kv.first] = kv.second.stored_decree;
         }
         return entry;

--- a/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
+++ b/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
@@ -53,7 +53,7 @@ void meta_duplication_service::query_duplication_info(const duplication_query_re
             response.appid = app->app_id;
             for (auto &dup_id_to_info : app->duplications) {
                 const duplication_info_s_ptr &dup = dup_id_to_info.second;
-                dup->append_if_valid(response.entry_list);
+                dup->append_if_valid_for_query(response.entry_list);
             }
         }
     }
@@ -86,6 +86,9 @@ void meta_duplication_service::change_duplication_status(duplication_status_chan
 
     response.err = dup->alter_status(request.status);
     if (response.err != ERR_OK) {
+        return;
+    }
+    if (!dup->is_altering()) {
         return;
     }
 

--- a/src/dist/replication/meta_server/duplication/meta_duplication_service.h
+++ b/src/dist/replication/meta_server/duplication/meta_duplication_service.h
@@ -32,6 +32,19 @@
 namespace dsn {
 namespace replication {
 
+/// On meta storage, duplication info are stored in the following layout:
+///
+///   <app_path>/duplication/<dup_id> -> {
+///                                         "remote": ...,
+///                                         "status": ...,
+///                                         "create_timestamp_ms": ...,
+///                                      }
+///
+///   <app_path>/duplication/<dup_id>/<partition_index> -> <confirmed_decree>
+///
+/// Each app has an attribute called "duplicating" which indicates
+/// whether this app should prevent its unconfirmed WAL from being compacted.
+///
 class meta_duplication_service
 {
 public:

--- a/src/dist/replication/test/meta_test/unit_test/meta_duplication_service_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_duplication_service_test.cpp
@@ -44,7 +44,7 @@ public:
 
     void SetUp() override
     {
-        _ms.reset(new fake_receiver_meta_service);
+        _ms = make_unique<fake_receiver_meta_service>();
         ASSERT_EQ(_ms->remote_storage_initialize(), ERR_OK);
         _ms->initialize_duplication_service();
         ASSERT_TRUE(_ms->_dup_svc);
@@ -296,7 +296,6 @@ TEST_F(meta_duplication_service_test, change_duplication_status)
 
     create_app(test_app);
     auto app = find_app(test_app);
-
     dupid_t test_dup = create_dup(test_app).dupid;
 
     struct TestData
@@ -310,7 +309,10 @@ TEST_F(meta_duplication_service_test, change_duplication_status)
         {test_app, test_dup + 1, duplication_status::DS_INIT, ERR_OBJECT_NOT_FOUND},
 
         // ok test
-        {test_app, test_dup, duplication_status::DS_PAUSE, ERR_OK},
+        {test_app, test_dup, duplication_status::DS_PAUSE, ERR_OK}, // start->pause
+        {test_app, test_dup, duplication_status::DS_PAUSE, ERR_OK}, // pause->pause
+        {test_app, test_dup, duplication_status::DS_START, ERR_OK}, // pause->start
+        {test_app, test_dup, duplication_status::DS_START, ERR_OK}, // start->start
     };
 
     for (auto tt : tests) {


### PR DESCRIPTION
What this PR does:

- Fix the bug where:

Change a PAUSED duplication to PAUSED, since the status is not altered, after
meta server successfully persist the change to zookeeper, `dup->persist_status` will
unexpectedly fail because of the assertion:

```cpp
void duplication_info::persist_status()
{
    zauto_write_lock l(_lock);
   // this line fails
    dassert_dup(_is_altering,
                this,
                "impossible, callers never write a duplication that is not altering to meta store");
```

Solution:

If the status is not altered, meta server return ERR_OK instead of writing this change to zookeeper.

```cpp
+    if (!dup->is_altering()) {
+        return;
+    }
```

- The removed duplication is still visible to users, for ease of debugging.

```cpp
-        // the invalid duplication is not visible to user.
-        if (is_valid()) {
-            entry_list.emplace_back(to_duplication_entry());
-        }
+        entry_list.emplace_back(to_duplication_entry());
```
