### PR TITLE
configs: remove useless configs

### DIFF
--- a/include/dsn/tool-api/global_config.h
+++ b/include/dsn/tool-api/global_config.h
@@ -171,8 +171,6 @@ struct service_spec
     std::list<std::string> rwlock_nr_aspects;
     std::list<std::string> semaphore_aspects;
 
-    int io_worker_count; // for disk and rpc
-
     network_client_configs network_default_client_cfs; // default network configed by tools
     network_server_configs network_default_server_cfs; // default network configed by tools
     std::vector<threadpool_spec> threadpool_specs;
@@ -220,13 +218,6 @@ CONFIG_FLD_STRING_LIST(lock_nr_aspects,
 CONFIG_FLD_STRING_LIST(rwlock_nr_aspects,
                        "non-recursive rwlock aspect providers, usually for tooling purpose")
 CONFIG_FLD_STRING_LIST(semaphore_aspects, "semaphore aspect providers, usually for tooling purpose")
-
-CONFIG_FLD(int,
-           uint64,
-           io_worker_count,
-           2,
-           "io thread count, only for IOE_PER_NODE; "
-           "for IOE_PER_QUEUE, task workers are served as io threads")
 CONFIG_END
 
 enum sys_exit_type

--- a/src/core/tests/aio.cpp
+++ b/src/core/tests/aio.cpp
@@ -47,7 +47,6 @@ DEFINE_TASK_CODE_AIO(LPC_AIO_TEST, TASK_PRIORITY_COMMON, THREAD_POOL_TEST_SERVER
 
 TEST(core, aio)
 {
-    // if in dsn_mimic_app() and disk_io_mode == IOE_PER_QUEUE
     if (task::get_current_disk() == nullptr)
         return;
 
@@ -143,7 +142,6 @@ TEST(core, aio)
 
 TEST(core, aio_share)
 {
-    // if in dsn_mimic_app() and disk_io_mode == IOE_PER_QUEUE
     if (task::get_current_disk() == nullptr)
         return;
 
@@ -161,7 +159,6 @@ TEST(core, aio_share)
 
 TEST(core, operation_failed)
 {
-    // if in dsn_mimic_app() and disk_io_mode == IOE_PER_QUEUE
     if (task::get_current_disk() == nullptr)
         return;
 

--- a/src/core/tests/config-test-corrupt-message.ini
+++ b/src/core/tests/config-test-corrupt-message.ini
@@ -37,7 +37,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 
-io_worker_count = 1
 
 
 

--- a/src/core/tests/config-test-posix-aio.ini
+++ b/src/core/tests/config-test-posix-aio.ini
@@ -26,7 +26,6 @@ logging_factory_name = dsn::tools::simple_logger
 
 aio_factory_name = dsn::tools::posix_aio_provider
 
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/core/tests/config-test-sim.ini
+++ b/src/core/tests/config-test-sim.ini
@@ -40,12 +40,7 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 
-disk_io_mode = IOE_PER_QUEUE
-;rpc_io_mode = IOE_PER_QUEUE
-nfs_io_mode = IOE_PER_QUEUE
-timer_io_mode = IOE_PER_QUEUE
 
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/core/tests/config-test.ini
+++ b/src/core/tests/config-test.ini
@@ -53,7 +53,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 
-io_worker_count = 1
 
 
 

--- a/src/core/tests/service_api_c.cpp
+++ b/src/core/tests/service_api_c.cpp
@@ -205,7 +205,6 @@ struct aio_result
 };
 TEST(core, dsn_file)
 {
-    // if in dsn_mimic_app() and disk_io_mode == IOE_PER_QUEUE
     if (task::get_current_disk() == nullptr)
         return;
 

--- a/src/dist/nfs/test/config.ini
+++ b/src/dist/nfs/test/config.ini
@@ -16,4 +16,3 @@ tool = nativerun
 pause_on_start = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
-io_worker_count = 1

--- a/src/dist/nfs/test/nfs_test_file1
+++ b/src/dist/nfs/test/nfs_test_file1
@@ -58,7 +58,6 @@ cli_remote = true
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-io_worker_count = 1
 
 [tools.simulator]
 random_seed = 0

--- a/src/dist/nfs/test/nfs_test_file2
+++ b/src/dist/nfs/test/nfs_test_file2
@@ -45,12 +45,7 @@ cli_remote = true
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-disk_io_mode = IOE_PER_QUEUE
-;rpc_io_mode = IOE_PER_QUEUE
-nfs_io_mode = IOE_PER_QUEUE
-timer_io_mode = IOE_PER_QUEUE
 
-io_worker_count = 1
 
 [tools.simulator]
 random_seed = 0

--- a/src/dist/replication/common/test/config-test.ini
+++ b/src/dist/replication/common/test/config-test.ini
@@ -25,9 +25,6 @@ cli_remote = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/dist/replication/storage_engine/simple_kv/config.ini
+++ b/src/dist/replication/storage_engine/simple_kv/config.ini
@@ -127,7 +127,6 @@ app_type = simple_kv
 partition_count = 1
 max_replica_count = 3
 stateful = true
-package_id = 
 
 [replication]
 prepare_timeout_ms_for_secondaries = 10000

--- a/src/dist/replication/test/meta_test/unit_test/config-ddl-test.ini
+++ b/src/dist/replication/test/meta_test/unit_test/config-ddl-test.ini
@@ -23,9 +23,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/dist/replication/test/meta_test/unit_test/config-test.ini
+++ b/src/dist/replication/test/meta_test/unit_test/config-test.ini
@@ -23,9 +23,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/dist/replication/test/replica_test/unit_test/config-test.ini
+++ b/src/dist/replication/test/replica_test/unit_test/config-test.ini
@@ -23,9 +23,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/dist/replication/test/simple_kv/config.ini
+++ b/src/dist/replication/test/simple_kv/config.ini
@@ -154,7 +154,6 @@ app_type = simple_kv
 partition_count = 1
 max_replica_count = 3
 stateful = true
-package_id = 
 
 [replication]
 

--- a/src/tests/dsn/config-test.ini
+++ b/src/tests/dsn/config-test.ini
@@ -57,9 +57,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/tests/dsn/config-whitelist-test-failed.ini
+++ b/src/tests/dsn/config-whitelist-test-failed.ini
@@ -58,9 +58,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true

--- a/src/tests/dsn/config-whitelist-test.ini
+++ b/src/tests/dsn/config-whitelist-test.ini
@@ -58,9 +58,6 @@ pause_on_start = false
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
-io_worker_count = 1
 
 [tools.simple_logger]
 fast_flush = true


### PR DESCRIPTION
The following configs are removed:
- io_worker_count
- io_mode (see https://github.com/XiaoMi/rdsn/pull/117) 
- package_id
