### PR TITLE
dup: add duplication_sync_timer

### DIFF
--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -48,7 +48,7 @@ replication_options::replication_options()
     delay_for_fd_timeout_on_start = false;
     empty_write_disabled = false;
     allow_non_idempotent_write = false;
-    duplication_disabled = false;
+    duplication_disabled = true;
 
     prepare_timeout_ms_for_secondaries = 1000;
     prepare_timeout_ms_for_potential_secondaries = 3000;

--- a/src/dist/replication/lib/CMakeLists.txt
+++ b/src/dist/replication/lib/CMakeLists.txt
@@ -1,8 +1,12 @@
 set(MY_PROJ_NAME dsn_replica_server)
 
+set(DUPLICATION_SRC
+        duplication/duplication_sync_timer.cpp
+)
+
 # Source files under CURRENT project directory will be automatically included.
 # You can manually set MY_PROJ_SRC to include source files under other directories.
-set(MY_PROJ_SRC "")
+set(MY_PROJ_SRC ${DUPLICATION_SRC})
 
 # Search mode for source files under CURRENT project directory?
 # "GLOB_RECURSE" for recursive search

--- a/src/dist/replication/lib/duplication/duplication_sync_timer.cpp
+++ b/src/dist/replication/lib/duplication/duplication_sync_timer.cpp
@@ -58,7 +58,6 @@ void duplication_sync_timer::on_duplication_sync_reply(error_code err,
     if (err != ERR_OK) {
         derror_f("on_duplication_sync_reply: err({})", err.to_string());
     } else {
-        ddebug("on_duplication_sync_reply");
         update_duplication_map(resp.dup_map);
     }
 
@@ -72,9 +71,8 @@ void duplication_sync_timer::update_duplication_map(
     for (replica_ptr &r : get_all_replicas()) {
         auto it = dup_map.find(r->get_gpid().get_app_id());
         if (it == dup_map.end()) {
-            // no duplication assigned to this app
+            // no duplication is assigned to this app
             r->get_duplication_manager()->update_duplication_map({});
-            continue;
         } else {
             r->get_duplication_manager()->update_duplication_map(it->second);
         }

--- a/src/dist/replication/lib/duplication/duplication_sync_timer.cpp
+++ b/src/dist/replication/lib/duplication/duplication_sync_timer.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include "dist/replication/lib/replica_stub.h"
+#include "dist/replication/lib/replica.h"
+
+#include "duplication_sync_timer.h"
+#include "replica_duplicator_manager.h"
+
+#include <dsn/dist/fmt_logging.h>
+#include <dsn/tool-api/command_manager.h>
+#include <dsn/utility/output_utils.h>
+#include <dsn/utility/string_conv.h>
+
+namespace dsn {
+namespace replication {
+
+DEFINE_TASK_CODE(LPC_DUPLICATION_SYNC_TIMER, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT)
+
+void duplication_sync_timer::run()
+{
+    // ensure duplication sync never be concurrent
+    if (_rpc_task) {
+        ddebug_f("a duplication sync is already ongoing");
+        return;
+    }
+
+    {
+        zauto_lock l(_stub->_state_lock);
+        if (_stub->_state == replica_stub::NS_Disconnected) {
+            ddebug_f("stop this round of duplication sync because this server is disconnected from "
+                     "meta server");
+            return;
+        }
+    }
+
+    auto req = make_unique<duplication_sync_request>();
+    req->node = _stub->primary_address();
+
+    duplication_sync_rpc rpc(std::move(req), RPC_CM_DUPLICATION_SYNC, 3_s);
+    rpc_address meta_server_address(_stub->get_meta_server_address());
+    ddebug_f("duplication_sync to meta({})", meta_server_address.to_string());
+
+    zauto_lock l(_lock);
+    _rpc_task =
+        rpc.call(meta_server_address, &_stub->_tracker, [this, rpc](error_code err) mutable {
+            on_duplication_sync_reply(err, rpc.response());
+        });
+}
+
+void duplication_sync_timer::on_duplication_sync_reply(error_code err,
+                                                       const duplication_sync_response &resp)
+{
+    if (err == ERR_OK && resp.err != ERR_OK) {
+        err = resp.err;
+    }
+    if (err != ERR_OK) {
+        derror_f("on_duplication_sync_reply: err({})", err.to_string());
+    } else {
+        ddebug("on_duplication_sync_reply");
+        update_duplication_map(resp.dup_map);
+    }
+
+    zauto_lock l(_lock);
+    _rpc_task = nullptr;
+}
+
+void duplication_sync_timer::update_duplication_map(
+    const std::map<int32_t, std::map<int32_t, duplication_entry>> &dup_map)
+{
+    for (replica_ptr &r : get_all_replicas()) {
+        auto it = dup_map.find(r->get_gpid().get_app_id());
+        if (it == dup_map.end()) {
+            // no duplication assigned to this app
+            r->get_duplication_manager()->update_duplication_map({});
+            continue;
+        } else {
+            r->get_duplication_manager()->update_duplication_map(it->second);
+        }
+    }
+}
+
+duplication_sync_timer::duplication_sync_timer(replica_stub *stub) : _stub(stub) {}
+
+duplication_sync_timer::~duplication_sync_timer() {}
+
+std::vector<replica_ptr> duplication_sync_timer::get_all_primaries()
+{
+    std::vector<replica_ptr> replica_vec;
+    {
+        zauto_read_lock l(_stub->_replicas_lock);
+        for (auto &kv : _stub->_replicas) {
+            replica_ptr r = kv.second;
+            if (r->status() != partition_status::PS_PRIMARY) {
+                continue;
+            }
+            replica_vec.emplace_back(std::move(r));
+        }
+    }
+    return replica_vec;
+}
+
+std::vector<replica_ptr> duplication_sync_timer::get_all_replicas()
+{
+    std::vector<replica_ptr> replica_vec;
+    {
+        zauto_read_lock l(_stub->_replicas_lock);
+        for (auto &kv : _stub->_replicas) {
+            replica_ptr r = kv.second;
+            replica_vec.emplace_back(std::move(r));
+        }
+    }
+    return replica_vec;
+}
+
+void duplication_sync_timer::close()
+{
+    ddebug("stop duplication sync");
+
+    {
+        zauto_lock l(_lock);
+        if (_rpc_task) {
+            _rpc_task->cancel(true);
+            _rpc_task = nullptr;
+        }
+    }
+
+    if (_timer_task) {
+        _timer_task->cancel(true);
+        _timer_task = nullptr;
+    }
+}
+
+void duplication_sync_timer::start()
+{
+    ddebug_f("run duplication sync periodically in {}s", DUPLICATION_SYNC_PERIOD_SECOND);
+
+    _timer_task = tasking::enqueue_timer(LPC_DUPLICATION_SYNC_TIMER,
+                                         &_stub->_tracker,
+                                         [this]() { run(); },
+                                         DUPLICATION_SYNC_PERIOD_SECOND * 1_s,
+                                         0,
+                                         DUPLICATION_SYNC_PERIOD_SECOND * 1_s);
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/duplication_sync_timer.h
+++ b/src/dist/replication/lib/duplication/duplication_sync_timer.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <atomic>
+
+#include "dist/replication/lib/replica_stub.h"
+
+#include <dsn/dist/replication/duplication_common.h>
+#include <dsn/utility/chrono_literals.h>
+
+namespace dsn {
+namespace replication {
+
+using namespace literals::chrono_literals;
+
+constexpr int DUPLICATION_SYNC_PERIOD_SECOND = 10;
+
+// Per-server(replica_stub)-instance.
+class duplication_sync_timer
+{
+public:
+    explicit duplication_sync_timer(replica_stub *stub);
+
+    ~duplication_sync_timer();
+
+    void start();
+
+    void close();
+
+private:
+    // replica server periodically uploads current confirm points to meta server by sending
+    // `duplication_sync_request`.
+    // if success, meta server will respond with `duplication_sync_response`, which contains
+    // the entire set of duplications on this server.
+    void run();
+
+    /// \param dup_map: <appid -> list<dup_entry>>
+    void
+    update_duplication_map(const std::map<app_id, std::map<dupid_t, duplication_entry>> &dup_map);
+
+    void on_duplication_sync_reply(error_code err, const duplication_sync_response &resp);
+
+    std::vector<replica_ptr> get_all_primaries();
+
+    std::vector<replica_ptr> get_all_replicas();
+
+private:
+    friend class duplication_sync_timer_test;
+
+    replica_stub *_stub{nullptr};
+
+    task_ptr _timer_task;
+    task_ptr _rpc_task;
+    mutable zlock _lock; // protect _rpc_task
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/replica_duplicator_manager.h
+++ b/src/dist/replication/lib/duplication/replica_duplicator_manager.h
@@ -18,13 +18,42 @@ namespace replication {
 class replica_duplicator_manager : public replica_base
 {
 public:
-    explicit replica_duplicator_manager(replica *r) : replica_base(r) {}
+    explicit replica_duplicator_manager(replica *r) : replica_base(r), _replica(r) {}
 
     // Immediately stop duplication in the following conditions:
     // - replica is not primary on replica-server perspective (status != PRIMARY)
     // - replica is not primary on meta-server perspective (progress.find(partition_id) == end())
     // - the app is not assigned with duplication (dup_map.empty())
-    void update_duplication_map(const std::map<int32_t, duplication_entry> &new_dup_map) {}
+    void update_duplication_map(const std::map<int32_t, duplication_entry> &new_dup_map)
+    {
+        if (_replica->status() != partition_status::PS_PRIMARY || new_dup_map.empty()) {
+            remove_all_duplications();
+            return;
+        }
+
+        remove_non_existed_duplications(new_dup_map);
+
+        for (const auto &kv2 : new_dup_map) {
+            sync_duplication(kv2.second);
+        }
+    }
+
+    /// collect updated duplication confirm points from this node.
+    std::vector<duplication_confirm_entry> get_duplication_confirms_to_update() const { return {}; }
+
+private:
+    void sync_duplication(const duplication_entry &ent) {}
+
+    void remove_non_existed_duplications(const std::map<dupid_t, duplication_entry> &) {}
+
+    void remove_all_duplications() {}
+
+private:
+    friend class duplication_sync_timer_test;
+    friend class duplication_test_base;
+    friend class replica_duplicator_manager_test;
+
+    replica *_replica;
 };
 
 } // namespace replication

--- a/src/dist/replication/lib/duplication/replica_duplicator_manager.h
+++ b/src/dist/replication/lib/duplication/replica_duplicator_manager.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <dsn/dist/replication/replication_types.h>
+#include <dsn/dist/replication/duplication_common.h>
+
+#include "dist/replication/lib/replica.h"
+#include "dist/replication/lib/mutation_log.h"
+
+namespace dsn {
+namespace replication {
+
+/// replica_duplicator_manager manages the set of duplications on this replica.
+/// \see duplication_sync_timer
+class replica_duplicator_manager : public replica_base
+{
+public:
+    explicit replica_duplicator_manager(replica *r) : replica_base(r) {}
+
+    // Immediately stop duplication in the following conditions:
+    // - replica is not primary on replica-server perspective (status != PRIMARY)
+    // - replica is not primary on meta-server perspective (progress.find(partition_id) == end())
+    // - the app is not assigned with duplication (dup_map.empty())
+    void update_duplication_map(const std::map<int32_t, duplication_entry> &new_dup_map) {}
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -28,6 +28,7 @@
 #include "mutation.h"
 #include "mutation_log.h"
 #include "replica_stub.h"
+#include "duplication/replica_duplicator_manager.h"
 
 #include <dsn/cpp/json_helper.h>
 #include <dsn/dist/replication/replication_app_base.h>

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -62,6 +62,7 @@ namespace replication {
 class replication_app_base;
 class replica_stub;
 class replication_checker;
+class replica_duplicator_manager;
 namespace test {
 class test_checker;
 }
@@ -150,7 +151,8 @@ public:
     bool verbose_commit_log() const;
     dsn::task_tracker *tracker() { return &_tracker; }
 
-    // void json_state(std::stringstream& out) const;
+    replica_duplicator_manager *get_duplication_manager() const { return _duplication_mgr.get(); }
+
     void update_last_checkpoint_generate_time();
     void update_commit_statistics(int count);
 
@@ -309,6 +311,9 @@ private:
     friend class ::dsn::replication::mutation_queue;
     friend class ::dsn::replication::replica_stub;
     friend class mock_replica;
+    friend class replica_learn_test;
+    friend class replica_duplicator_manager;
+    friend class load_mutation;
 
     // replica configuration, updated by update_local_configuration ONLY
     replica_configuration _config;
@@ -378,6 +383,9 @@ private:
     bool _is_initializing;       // when initializing, switching to primary need to update ballot
     bool _deny_client_write;     // if deny all write requests
     throttling_controller _write_throttling_controller;
+
+    // duplication
+    std::unique_ptr<replica_duplicator_manager> _duplication_mgr;
 
     // perf counters
     perf_counter_wrapper _counter_private_log_size;

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -650,6 +650,11 @@ void replica_stub::initialize_start()
     }
 #endif
 
+    if (!_options.duplication_disabled) {
+        _duplication_sync_timer = dsn::make_unique<duplication_sync_timer>(this);
+        _duplication_sync_timer->start();
+    }
+
     // init liveness monitor
     dassert(NS_Disconnected == _state, "");
     if (_options.fd_disabled == false) {

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -37,6 +37,7 @@
 #include "replica_stub.h"
 #include "mutation_log.h"
 #include "mutation.h"
+#include "duplication/duplication_sync_timer.h"
 #include <dsn/cpp/json_helper.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/rand.h>


### PR DESCRIPTION
This is the first part of the implementation of duplication on the replica-server side.

## Introduction

`duplication_sync_timer` is the timer periodically (10 seconds) sends `duplication_sync` to meta-server for retrieving the entire set of duplications on this server (aka `replica_stub`).

```
         +-----------------------+
         |                       |
         |     meta server       |
         |                       |
         +-------^--------+------+
                 |        |
duplication_sync_request  duplication_sync_response
                 |        |
                 |        |
             +------------+---+
             |   |            |
         +---+---+--------v---+--+
         | duplication_sync_timer|
         |   |                |  |
         |   +----------------+  |
         |                       |
         |    replica server     |
         |                       |
         +-----------------------+
```

If the replica server successfully get the response from meta-server (`on_duplication_sync_reply`), 
it will update its local duplication map (`duplication_sync_timer::update_duplication_map`) to:

1. assign new duplications
2. remove unused duplications
3. synchronize the `confirmed_decree` of each primary replica that's on duplication.

Each of the replica (which may be secondary) has one `replica_duplicator_manager` managing the entire set of duplications that it is assigned (each duplicating destination is tasked by one duplication)

```
+-----------------------------------+
|                                   |
|                                   |
|        +----replica-------+       |
|        |                  |       |
|        +------------------+       |
|                                   |
|     +-------replica---------+     |
|     |                       |     |
|  +--+-----------------------+--+  |
|  | replica_duplicator_manager  |  |
|  +--+-----------------------+--+  |
|     |                       |     |
|     +-----------------------+     |
|                                   |
|        +---+replica+------+       |
|        |                  |       |
|        +------------------+       |
|                                   |
+-----------------------------------+
```

