### PR TITLE
minor refactoring on replica-server and meta-server

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -24,21 +24,7 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     interface for apps to be replicated using rDSN
- *
- * Revision history:
- *     Mar., 2015, @imzhenyu (Zhenyu Guo), first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
-
-//
-// replication_app_base is the base class for all app to be replicated using
-// this library
-//
 
 #include <dsn/cpp/serverlet.h>
 #include <dsn/cpp/json_helper.h>
@@ -92,6 +78,9 @@ public:
     error_code store(const char *file);
 };
 
+/// The store engine interface of Pegasus.
+/// Inherited by pegasus::pegasus_server_impl
+/// Inherited by dsn::apps::rrdb_service
 class replication_app_base : public replica_base
 {
 public:
@@ -247,7 +236,6 @@ public:
     {
         return _last_committed_decree.load();
     }
-    void reset_counters_after_learning();
 
 private:
     // routines for replica internal usage
@@ -264,7 +252,6 @@ private:
                                        int64_t private_log_offset,
                                        int64_t durable_decree);
     ::dsn::error_code update_init_info_ballot_and_decree(replica *r);
-    void install_perf_counters();
 
 protected:
     std::string _dir_data;   // ${replica_dir}/data
@@ -277,6 +264,5 @@ protected:
     explicit replication_app_base(::dsn::replication::replica *replica);
 };
 
-//------------------ inline implementation ---------------------
-}
-} // namespace
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/mutation_cache.cpp
+++ b/src/dist/replication/lib/mutation_cache.cpp
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #include "mutation_cache.h"
 #include "mutation.h"
 
@@ -137,18 +128,6 @@ mutation_ptr mutation_cache::get_mutation_by_decree(decree decree)
         return nullptr;
     else
         return _array[(_start_idx + (decree - _start_decree) + _max_count) % _max_count];
-}
-
-mutation_ptr mutation_cache::remove_mutation_by_decree(decree decree)
-{
-    if (decree < _start_decree || decree > _end_decree)
-        return nullptr;
-    else {
-        int idx = (_start_idx + (decree - _start_decree) + _max_count) % _max_count;
-        auto ret = _array[idx];
-        _array[idx] = nullptr;
-        return ret;
-    }
 }
 }
 } // namespace end

--- a/src/dist/replication/lib/mutation_cache.h
+++ b/src/dist/replication/lib/mutation_cache.h
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
 #include "../common/replication_common.h"
@@ -43,6 +34,10 @@
 namespace dsn {
 namespace replication {
 
+// mutation_cache is an in-memory array that stores a limited number
+// (SEE replication_options::max_mutation_count_in_prepare_list) of mutation log entries.
+//
+// Inherited by: prepare_list
 class mutation_cache
 {
 public:
@@ -52,7 +47,6 @@ public:
     error_code put(mutation_ptr &mu);
     mutation_ptr pop_min();
     mutation_ptr get_mutation_by_decree(decree decree);
-    mutation_ptr remove_mutation_by_decree(decree decree);
     void reset(decree init_decree, bool clear_mutations);
 
     decree min_decree() const { return _start_decree; }

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -82,12 +82,6 @@ replica::replica(
     }
 }
 
-// void replica::json_state(std::stringstream& out) const
-//{
-//    JSON_DICT_ENTRIES(out, *this, name(), _config, _app->last_committed_decree(),
-//    _app->last_durable_decree());
-//}
-
 void replica::update_last_checkpoint_generate_time()
 {
     _last_checkpoint_generate_time_ms = dsn_now_ms();
@@ -97,9 +91,13 @@ void replica::update_last_checkpoint_generate_time()
         _last_checkpoint_generate_time_ms + rand::next_u64(max_interval_ms / 2, max_interval_ms);
 }
 
-void replica::update_commit_statistics(int count)
+//            //
+// Statistics //
+//            //
+
+void replica::update_commit_qps(int count)
 {
-    _stub->_counter_replicas_total_commit_throught->add((uint64_t)count);
+    _stub->_counter_replicas_commit_qps->add((uint64_t)count);
 }
 
 void replica::init_state()

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -152,7 +152,11 @@ public:
 
     // void json_state(std::stringstream& out) const;
     void update_last_checkpoint_generate_time();
-    void update_commit_statistics(int count);
+
+    //
+    // Statistics
+    //
+    void update_commit_qps(int count);
 
     // routine for get extra envs from replica
     const std::map<std::string, std::string> &get_replica_extra_envs() const { return _extra_envs; }
@@ -233,9 +237,10 @@ private:
                                               partition_status::type news);
 
     // return false when update fails or replica is going to be closed
-    bool update_app_envs(const std::map<std::string, std::string> &envs);
+    void update_app_envs(const std::map<std::string, std::string> &envs);
     void update_app_envs_internal(const std::map<std::string, std::string> &envs);
-    bool query_app_envs(/*out*/ std::map<std::string, std::string> &envs);
+    void query_app_envs(/*out*/ std::map<std::string, std::string> &envs);
+
     bool update_configuration(const partition_configuration &config);
     bool update_local_configuration(const replica_configuration &config, bool same_ballot = false);
 

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -236,7 +236,6 @@ private:
     bool is_same_ballot_status_change_allowed(partition_status::type olds,
                                               partition_status::type news);
 
-    // return false when update fails or replica is going to be closed
     void update_app_envs(const std::map<std::string, std::string> &envs);
     void update_app_envs_internal(const std::map<std::string, std::string> &envs);
     void query_app_envs(/*out*/ std::map<std::string, std::string> &envs);

--- a/src/dist/replication/lib/replica_chkpt.cpp
+++ b/src/dist/replication/lib/replica_chkpt.cpp
@@ -235,7 +235,6 @@ void replica::on_copy_checkpoint_file_completed(error_code err,
             filename = utils::filesystem::path_combine(chk_dir, filename);
         }
         _app->apply_checkpoint(replication_app_base::chkpt_apply_mode::copy, resp->state);
-        _app->reset_counters_after_learning();
     }
 
     _primary_states.checkpoint_task = nullptr;

--- a/src/dist/replication/lib/replica_config.cpp
+++ b/src/dist/replication/lib/replica_config.cpp
@@ -531,14 +531,12 @@ void replica::on_update_configuration_on_meta_server_reply(
     _primary_states.reconfiguration_task = nullptr;
 }
 
-bool replica::update_app_envs(const std::map<std::string, std::string> &envs)
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica::update_app_envs(const std::map<std::string, std::string> &envs)
 {
     if (_app) {
         update_app_envs_internal(envs);
         _app->update_app_envs(envs);
-        return true;
-    } else {
-        return false;
     }
 }
 
@@ -588,13 +586,10 @@ void replica::update_app_envs_internal(const std::map<std::string, std::string> 
     }
 }
 
-bool replica::query_app_envs(/*out*/ std::map<std::string, std::string> &envs)
+void replica::query_app_envs(/*out*/ std::map<std::string, std::string> &envs)
 {
     if (_app) {
         _app->query_app_envs(envs);
-        return true;
-    } else {
-        return false;
     }
 }
 
@@ -997,6 +992,7 @@ bool replica::update_local_configuration_with_no_ballot_change(partition_status:
     return update_local_configuration(config, true);
 }
 
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica::on_config_sync(const app_info &info, const partition_configuration &config)
 {
     ddebug("%s: configuration sync", name());

--- a/src/dist/replication/lib/replica_learn.cpp
+++ b/src/dist/replication/lib/replica_learn.cpp
@@ -980,7 +980,6 @@ void replica::on_copy_remote_state_completed(error_code err,
             auto start_ts = dsn_now_ns();
             err = _app->apply_checkpoint(replication_app_base::chkpt_apply_mode::learn, lstate);
             if (err == ERR_OK) {
-                _app->reset_counters_after_learning();
 
                 dassert(_app->last_committed_decree() >= _app->last_durable_decree(),
                         "invalid app state, %" PRId64 " VS %" PRId64 "",

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -282,7 +282,7 @@ private:
     perf_counter_wrapper _counter_replicas_count;
     perf_counter_wrapper _counter_replicas_opening_count;
     perf_counter_wrapper _counter_replicas_closing_count;
-    perf_counter_wrapper _counter_replicas_total_commit_throught;
+    perf_counter_wrapper _counter_replicas_commit_qps;
 
     perf_counter_wrapper _counter_replicas_learning_count;
     perf_counter_wrapper _counter_replicas_learning_max_duration_time_ms;

--- a/src/dist/replication/meta_server/meta_state_service_utils_impl.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils_impl.h
@@ -90,10 +90,11 @@ struct operation : pipeline::environment
             pipeline::repeat(std::move(*this_instance), 1_s);
             return;
         }
-        dfatal_f("request({}) on path({}) encountered an unexpected error({})",
-                 op_type::to_string(type),
-                 path,
-                 ec.to_string());
+        dassert_f(false,
+                  "request({}) on path({}) encountered an unexpected error({})",
+                  op_type::to_string(type),
+                  path,
+                  ec.to_string());
     }
 
     dist::meta_state_service *remote_storage() const { return _ms->_remote; }

--- a/src/dist/replication/test/replica_test/unit_test/main.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/main.cpp
@@ -30,14 +30,6 @@ TEST(cold_backup_context, write_current_chkpt_file) { app->write_current_chkpt_f
 
 error_code replication_service_test_app::start(const std::vector<std::string> &args)
 {
-    int argc = args.size();
-    char *argv[20];
-    for (int i = 0; i < argc; ++i) {
-        argv[i] = (char *)(args[i].c_str());
-    }
-
-    testing::InitGoogleTest(&argc, argv);
-    app = this;
     gtest_ret = RUN_ALL_TESTS();
     gtest_flags = 1;
     return dsn::ERR_OK;
@@ -45,12 +37,11 @@ error_code replication_service_test_app::start(const std::vector<std::string> &a
 
 GTEST_API_ int main(int argc, char **argv)
 {
-    dsn::service_app::register_factory<replication_service_test_app>("replica");
-    if (argc < 2)
-        dassert(dsn_run_config("config-test.ini", false), "");
-    else
-        dassert(dsn_run_config(argv[1], false), "");
+    testing::InitGoogleTest(&argc, argv);
 
+    dsn::service_app::register_factory<replication_service_test_app>("replica");
+
+    dsn_run_config("config-test.ini", false);
     while (gtest_flags == 0) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }

--- a/src/dist/replication/test/replica_test/unit_test/run.sh
+++ b/src/dist/replication/test/replica_test/unit_test/run.sh
@@ -6,4 +6,4 @@ fi
 
 ./clear.sh
 output_xml="${REPORT_DIR}/dsn.replica.test.1.xml"
-GTEST_OUTPUT="xml:${output_xml}" GTEST_FILTER="cold_backup_context.*" ./dsn.replica.test
+GTEST_OUTPUT="xml:${output_xml}" ./dsn.replica.test


### PR DESCRIPTION
What this PR did:

Remove some of the useless functions in replica-server:

- `replication_app_base::reset_counters_after_learning`
- `replication_app_base::install_perf_counters`
- `mutation_cache::remove_mutation_by_decree`

Some functions are refactored:

- `replica::query_app_envs`
- `replica::update_app_envs`

Rename  `update_commit_statistics` to `update_commit_qps`, `_counter_replicas_total_commit_throught` to `_counter_replicas_commit_qps`.