### PR TITLE
thirdparty: add curl to help build prometheus

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -269,7 +269,25 @@ fi
 #build curl
 if [ ! -d $TP_OUTPUT/include/curl ]; then
     cd $TP_SRC/curl-7.47.0
-    ./configure --prefix=$TP_OUTPUT
+    CONFIG_FLAGS="--prefix=$TP_OUTPUT \
+    --disable-dict \
+    --disable-file \
+    --disable-ftp \
+    --disable-gopher \
+    --disable-imap \
+    --disable-ipv6 \
+    --disable-ldap \
+    --disable-ldaps \
+    --disable-manual \
+    --disable-pop3 \
+    --disable-rtsp \
+    --disable-smtp \
+    --disable-telnet \
+    --disable-tftp \
+    --without-librtmp \
+    --without-libssh2"
+
+    ./configure $CONFIG_FLAGS
     make -j8 && make install
     res=$?
     cd $TP_DIR

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -266,6 +266,18 @@ else
     echo "skip build gflags"
 fi
 
+#build curl
+if [ ! -f $TP_OUTPUT/include/curl ]; then
+    cd $TP_SRC/curl-7.47.0
+    ./configure --prefix=$TP_OUTPUT
+    make -j8 && make install
+    res=$?
+    cd $TP_DIR
+    exit_if_fail "curl" $res
+else
+    echo "skip build curl"
+fi
+
 #build prometheus-cpp
 if [ ! -d $TP_OUTPUT/include/prometheus ]; then
     mkdir -p $TP_BUILD/prometheus

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -267,7 +267,7 @@ else
 fi
 
 #build curl
-if [ ! -f $TP_OUTPUT/include/curl ]; then
+if [ ! -d $TP_OUTPUT/include/curl ]; then
     cd $TP_SRC/curl-7.47.0
     ./configure --prefix=$TP_OUTPUT
     make -j8 && make install

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -270,6 +270,16 @@ cd $TP_SRC/prometheus-cpp-0.7.0/3rdparty
 mv civetweb-1.11 civetweb
 cd $TP_SRC
 
+# curl
+# from: http://curl.haxx.se/download/curl-7.47.0.tar.gz
+CURL_NAME=curl-7.47.0
+CURL_PKG=${CURL_NAME}.tar.gz
+check_and_download "${CURL_PKG}"\
+    "${OSS_URL_PREFIX}/${CURL_PKG}"\
+    "5109d1232d208dfd712c0272b8360393"\
+    "${CURL_NAME}"
+exit_if_fail $?
+
 # s2geometry
 # from: https://github.com/google/s2geometry/archive/0239455c1e260d6d2c843649385b4fb9f5b28dba.zip
 S2GEOMETRY_NAME=s2geometry-0239455c1e260d6d2c843649385b4fb9f5b28dba


### PR DESCRIPTION
prometheus-gateway need "curl.h" to run
so add curl to 3rdparty to build prometheus-cpp 