### PR TITLE
dup: complete implementation of replica_duplicator_manager

### DIFF
--- a/src/dist/replication/lib/CMakeLists.txt
+++ b/src/dist/replication/lib/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(MY_PROJ_NAME dsn_replica_server)
 
 set(DUPLICATION_SRC
+        duplication/replica_duplicator_manager.cpp
         duplication/duplication_sync_timer.cpp
+        duplication/replica_duplicator.cpp
 )
 
 # Source files under CURRENT project directory will be automatically included.
@@ -15,7 +17,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_INC_PATH "")
 
-set(MY_PROJ_LIBS 
+set(MY_PROJ_LIBS
     dsn_replication_common
     dsn.failure_detector
     dsn.failure_detector.multimaster
@@ -30,3 +32,5 @@ set(MY_PROJ_LIB_PATH "")
 set(MY_BINPLACES "")
 
 dsn_add_shared_library()
+
+add_subdirectory(duplication/test)

--- a/src/dist/replication/lib/duplication/replica_duplicator.cpp
+++ b/src/dist/replication/lib/duplication/replica_duplicator.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include "replica_duplicator.h"
+#include "dist/replication/lib/replica_stub.h"
+
+#include <dsn/dist/replication/replication_app_base.h>
+#include <dsn/dist/fmt_logging.h>
+#include <rapidjson/writer.h>
+
+namespace dsn {
+namespace replication {
+
+replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
+    : replica_base(r),
+      _id(ent.dupid),
+      _remote_cluster_name(ent.remote),
+      _replica(r),
+      _stub(r->get_replica_stub())
+{
+    _status = ent.status;
+
+    auto it = ent.progress.find(get_gpid().get_partition_index());
+    if (it->second == invalid_decree) {
+        // keep current max committed_decree as start point.
+        _progress.last_decree = _replica->private_log()->max_commit_on_disk();
+    } else {
+        _progress.last_decree = _progress.confirmed_decree = it->second;
+    }
+    ddebug_replica(
+        "initialize replica_duplicator [dupid:{}, meta_confirmed_decree:{}]", id(), it->second);
+
+    if (_status == duplication_status::DS_START) {
+        start_dup();
+    }
+}
+
+std::string replica_duplicator::to_string() const
+{
+    rapidjson::Document doc;
+    doc.SetObject();
+    auto &alloc = doc.GetAllocator();
+
+    doc.AddMember("dupid", id(), alloc);
+    doc.AddMember("status", rapidjson::StringRef(duplication_status_to_string(_status)), alloc);
+    doc.AddMember("remote", rapidjson::StringRef(_remote_cluster_name.data()), alloc);
+    doc.AddMember("confirmed", _progress.confirmed_decree, alloc);
+    doc.AddMember("app",
+                  rapidjson::StringRef(_replica->get_app_info()->app_name.data(),
+                                       _replica->get_app_info()->app_name.size()),
+                  alloc);
+
+    rapidjson::StringBuffer sb;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+    doc.Accept(writer);
+    return sb.GetString();
+}
+
+void replica_duplicator::update_status_if_needed(duplication_status::type next_status)
+{
+    if (_status == next_status) {
+        return;
+    }
+
+    if (next_status == duplication_status::DS_START) {
+        start_dup();
+        _status = next_status;
+    } else if (next_status == duplication_status::DS_PAUSE) {
+        pause_dup();
+        _status = next_status;
+    } else {
+        derror_replica("unexpected duplication status ({})",
+                       duplication_status_to_string(next_status));
+        // _status keeps unchanged
+    }
+}
+
+replica_duplicator::~replica_duplicator() { ddebug_replica("closing duplication {}", to_string()); }
+
+error_s replica_duplicator::update_progress(const duplication_progress &p)
+{
+    zauto_write_lock l(_lock);
+
+    if (p.confirmed_decree >= 0 && p.confirmed_decree < _progress.confirmed_decree) {
+        return FMT_ERR(ERR_INVALID_STATE,
+                       "never decrease confirmed_decree: new({}) old({})",
+                       p.confirmed_decree,
+                       _progress.confirmed_decree);
+    }
+
+    _progress.confirmed_decree = std::max(_progress.confirmed_decree, p.confirmed_decree);
+    _progress.last_decree = std::max(_progress.last_decree, p.last_decree);
+
+    if (_progress.confirmed_decree > _progress.last_decree) {
+        return FMT_ERR(ERR_INVALID_STATE,
+                       "last_decree({}) should always larger than confirmed_decree({})",
+                       _progress.last_decree,
+                       _progress.confirmed_decree);
+    }
+    return error_s::ok();
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/replica_duplicator.h
+++ b/src/dist/replication/lib/duplication/replica_duplicator.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <dsn/dist/replication/duplication_common.h>
+#include <dsn/cpp/pipeline.h>
+#include <dsn/dist/replication/replica_base.h>
+#include <dsn/dist/replication.h>
+#include <dsn/tool-api/zlocks.h>
+
+namespace dsn {
+namespace replication {
+
+class duplication_progress
+{
+public:
+    // the maximum decree that's been persisted in meta server
+    decree confirmed_decree{invalid_decree};
+
+    // the maximum decree that's been duplicated to remote.
+    decree last_decree{invalid_decree};
+
+    duplication_progress &set_last_decree(decree d)
+    {
+        last_decree = d;
+        return *this;
+    }
+
+    duplication_progress &set_confirmed_decree(decree d)
+    {
+        confirmed_decree = d;
+        return *this;
+    }
+};
+
+class load_mutation;
+class ship_mutation;
+class load_from_private_log;
+class replica;
+class replica_stub;
+
+// Each replica_duplicator is responsible for one duplication.
+// It works in THREAD_POOL_REPLICATION (LPC_DUPLICATE_MUTATIONS),
+// sharded by gpid, thus all functions are single-threaded,
+// no read lock required (of course write lock is necessary when
+// reader could be in other thread).
+//
+// TODO(wutao1): Optimization for multi-duplication
+//               Currently we create duplicator for each duplication.
+//               They're isolated even if they share the same private log.
+class replica_duplicator : public replica_base
+{
+public:
+    replica_duplicator(const duplication_entry &ent, replica *r);
+
+    // This is a blocking call.
+    // The thread may be seriously blocked under the destruction.
+    // Take care when running in THREAD_POOL_REPLICATION, though
+    // duplication removal is extremely rare.
+    ~replica_duplicator();
+
+    // Updates this duplication to `next_status`.
+    // Not thread-safe.
+    void update_status_if_needed(duplication_status::type next_status);
+
+    dupid_t id() const { return _id; }
+
+    // Thread-safe
+    duplication_progress progress() const
+    {
+        zauto_read_lock l(_lock);
+        return _progress;
+    }
+
+    // Thread-safe
+    error_s update_progress(const duplication_progress &p);
+
+    void start_dup() { /*TBD*/}
+
+    // Pausing duplication will clear all the internal volatile states, thus
+    // when next time it restarts, the states will be reinitialized like the
+    // server being restarted.
+    // It is useful when something went wrong internally.
+    void pause_dup() { /*TBD*/}
+
+    // Holds its own tracker, so that other tasks
+    // won't be effected when this duplication is removed.
+    dsn::task_tracker *tracker() { return &_tracker; }
+
+    std::string to_string() const;
+
+private:
+    friend class replica_duplicator_test;
+    friend class duplication_sync_timer_test;
+    friend class load_from_private_log_test;
+
+    friend class load_mutation;
+    friend class ship_mutation;
+
+    const dupid_t _id;
+    const std::string _remote_cluster_name;
+
+    replica *_replica;
+    replica_stub *_stub;
+    dsn::task_tracker _tracker;
+
+    duplication_status::type _status{duplication_status::DS_INIT};
+
+    // protect the access of _progress.
+    mutable zrwlock_nr _lock;
+    duplication_progress _progress;
+};
+
+typedef std::unique_ptr<replica_duplicator> replica_duplicator_u_ptr;
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/replica_duplicator_manager.cpp
+++ b/src/dist/replication/lib/duplication/replica_duplicator_manager.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <dsn/dist/replication/duplication_common.h>
+#include <dsn/dist/fmt_logging.h>
+
+#include "replica_duplicator_manager.h"
+
+namespace dsn {
+namespace replication {
+
+std::vector<duplication_confirm_entry>
+replica_duplicator_manager::get_duplication_confirms_to_update() const
+{
+    zauto_lock l(_lock);
+
+    std::vector<duplication_confirm_entry> updates;
+    for (const auto &kv : _duplications) {
+        replica_duplicator *duplicator = kv.second.get();
+        duplication_progress p = duplicator->progress();
+        if (p.last_decree != p.confirmed_decree) {
+            dcheck_gt_replica(p.last_decree, p.confirmed_decree);
+            duplication_confirm_entry entry;
+            entry.dupid = duplicator->id();
+            entry.confirmed_decree = p.last_decree;
+            updates.emplace_back(entry);
+        }
+    }
+    return updates;
+}
+
+void replica_duplicator_manager::sync_duplication(const duplication_entry &ent)
+{
+    // state is inconsistent with meta-server
+    auto it = ent.progress.find(get_gpid().get_partition_index());
+    if (it == ent.progress.end()) {
+        _duplications.erase(ent.dupid);
+        return;
+    }
+
+    zauto_lock l(_lock);
+
+    dupid_t dupid = ent.dupid;
+    duplication_status::type next_status = ent.status;
+
+    replica_duplicator_u_ptr &dup = _duplications[dupid];
+    if (dup == nullptr) {
+        if (is_duplication_status_valid(next_status)) {
+            dup = make_unique<replica_duplicator>(ent, _replica);
+        } else {
+            derror_replica("illegal duplication status: {}",
+                           duplication_status_to_string(next_status));
+        }
+    } else {
+        // update progress
+        duplication_progress newp = dup->progress().set_confirmed_decree(it->second);
+        dcheck_eq_replica(dup->update_progress(newp), error_s::ok());
+        dup->update_status_if_needed(next_status);
+    }
+}
+
+// Remove the duplications that are not in the `new_dup_map`.
+// NOTE: this function may be blocked when destroying replica_duplicator.
+void replica_duplicator_manager::remove_non_existed_duplications(
+    const std::map<dupid_t, duplication_entry> &new_dup_map)
+{
+    zauto_lock l(_lock);
+
+    std::vector<dupid_t> removal_set;
+    for (auto &pair : _duplications) {
+        dupid_t cur_dupid = pair.first;
+        if (new_dup_map.find(cur_dupid) == new_dup_map.end()) {
+            removal_set.emplace_back(cur_dupid);
+        }
+    }
+
+    for (dupid_t dupid : removal_set) {
+        _duplications.erase(dupid);
+    }
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/test/CMakeLists.txt
+++ b/src/dist/replication/lib/duplication/test/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(MY_PROJ_NAME dsn_replica_dup_test)
+
+set(MY_PROJ_SRC "")
+
+set(MY_SRC_SEARCH_MODE "GLOB")
+
+set(MY_PROJ_LIBS dsn_meta_server
+        dsn_replica_server
+        dsn.replication.zookeeper_provider
+        dsn_replication_common
+        dsn.block_service.local
+        dsn.block_service.fds
+        dsn.failure_detector
+        zookeeper_mt
+        galaxy-fds-sdk-cpp
+        PocoNet
+        PocoFoundation
+        PocoNetSSL
+        PocoJSON
+        crypto
+        gtest
+        fmt
+)
+
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
+
+set(MY_BINPLACES
+        config-test.ini
+        run.sh
+)
+
+dsn_add_test()

--- a/src/dist/replication/lib/duplication/test/config-test.ini
+++ b/src/dist/replication/lib/duplication/test/config-test.ini
@@ -1,0 +1,31 @@
+[apps..default]
+run = true
+
+[apps.replica]
+type = replica
+pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION
+
+[core]
+tool = nativerun
+
+[tools.simple_logger]
+stderr_start_level = LOG_LEVEL_WARNING
+
+; specification for each thread pool
+[threadpool..default]
+worker_count = 2
+
+[threadpool.THREAD_POOL_DEFAULT]
+name = default
+partitioned = false
+
+[threadpool.THREAD_POOL_REPLICATION]
+name = replica
+partitioned = true
+
+[threadpool.THREAD_POOL_REPLICATION_LONG]
+name = replica_long
+
+[duplication-group]
+master-cluster = 1
+slave-cluster  = 2

--- a/src/dist/replication/lib/duplication/test/duplication_sync_timer_test.cpp
+++ b/src/dist/replication/lib/duplication/test/duplication_sync_timer_test.cpp
@@ -1,0 +1,368 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include "dist/replication/lib/duplication/duplication_sync_timer.h"
+#include "duplication_test_base.h"
+
+#include <dsn/tool-api/command_manager.h>
+#include <dsn/tool-api/rpc_message.h>
+
+namespace dsn {
+namespace replication {
+
+class duplication_sync_timer_test : public duplication_test_base
+{
+public:
+    void SetUp() override { dup_sync = make_unique<duplication_sync_timer>(stub.get()); }
+
+    void TearDown() override { stub.reset(); }
+
+    void test_on_duplication_sync_reply()
+    {
+        // replica: {app_id:2, partition_id:1, duplications:{}}
+        stub->add_primary_replica(2, 1);
+        ASSERT_NE(stub->find_replica(2, 1), nullptr);
+
+        // appid:2 -> dupid:1
+        duplication_entry ent;
+        ent.dupid = 1;
+        ent.remote = "slave-cluster";
+        ent.status = duplication_status::DS_PAUSE;
+        ent.progress[1] = 1000; // partition 1 => confirmed 1000
+        duplication_sync_response resp;
+        resp.dup_map[2] = {{ent.dupid, ent}};
+
+        dup_sync->_rpc_task = new raw_task(LPC_TEST, []() {});
+        dup_sync->on_duplication_sync_reply(ERR_OK, resp);
+        replica_duplicator *dup =
+            stub->find_replica(2, 1)->get_replica_duplicator_manager()._duplications[1].get();
+
+        ASSERT_TRUE(dup);
+        ASSERT_EQ(dup->_status, duplication_status::DS_PAUSE);
+        ASSERT_EQ(dup->_progress.confirmed_decree, 1000);
+        ASSERT_EQ(dup_sync->_rpc_task, nullptr);
+    }
+
+    void test_duplication_sync()
+    {
+        int total_app_num = 4;
+        for (int appid = 1; appid <= total_app_num; appid++) {
+            auto r = stub->add_non_primary_replica(appid, 1);
+
+            // trigger duplication sync on partition 1
+            duplication_entry ent;
+            ent.dupid = 1;
+            ent.progress[r->get_gpid().get_partition_index()] = 1000;
+            ent.status = duplication_status::DS_PAUSE;
+            auto dup = dsn::make_unique<replica_duplicator>(ent, r);
+            add_dup(r, std::move(dup));
+        }
+
+        RPC_MOCKING(duplication_sync_rpc)
+        {
+            {
+                // replica server should not sync to meta when it's disconnected
+                dup_sync->run();
+                ASSERT_EQ(duplication_sync_rpc::mail_box().size(), 0);
+            }
+            {
+                // never collects confirm points from non-primaries
+                stub->set_state_connected();
+                dup_sync->run();
+                ASSERT_EQ(duplication_sync_rpc::mail_box().size(), 1);
+
+                auto &req = duplication_sync_rpc::mail_box().back().request();
+                ASSERT_EQ(req.confirm_list.size(), 0);
+            }
+        }
+
+        RPC_MOCKING(duplication_sync_rpc)
+        {
+            for (auto &e : stub->mock_replicas) {
+                e.second->as_primary();
+            }
+            dup_sync->run();
+            ASSERT_EQ(duplication_sync_rpc::mail_box().size(), 1);
+
+            auto &req = duplication_sync_rpc::mail_box().back().request();
+            ASSERT_EQ(req.node, stub->primary_address());
+
+            // ensure confirm list is empty when no progress
+            ASSERT_EQ(req.confirm_list.size(), 0);
+
+            // ensure this rpc has timeout set.
+            auto &rpc = duplication_sync_rpc::mail_box().back();
+            ASSERT_GT(rpc.dsn_request()->header->client.timeout_ms, 0);
+        }
+
+        RPC_MOCKING(duplication_sync_rpc)
+        {
+            for (int appid = 1; appid <= total_app_num; appid++) {
+                auto &dup = stub->mock_replicas[gpid(appid, 1)]
+                                ->get_replica_duplicator_manager()
+                                ._duplications[1];
+                dup->update_progress(duplication_progress().set_last_decree(1500));
+            }
+
+            dup_sync->run();
+            ASSERT_EQ(duplication_sync_rpc::mail_box().size(), 1);
+
+            auto &req = *duplication_sync_rpc::mail_box().back().mutable_request();
+            ASSERT_EQ(req.node, stub->primary_address());
+            ASSERT_EQ(req.confirm_list.size(), total_app_num);
+
+            for (int appid = 1; appid <= total_app_num; appid++) {
+                ASSERT_TRUE(req.confirm_list.find(gpid(appid, 1)) != req.confirm_list.end());
+
+                auto dup_list = req.confirm_list[gpid(appid, 1)];
+                ASSERT_EQ(dup_list.size(), 1);
+
+                auto dup = dup_list[0];
+                ASSERT_EQ(dup.dupid, 1);
+                ASSERT_EQ(dup.confirmed_decree, 1500);
+            }
+        }
+    }
+
+    void test_update_duplication_map()
+    {
+        std::map<int32_t, std::map<dupid_t, duplication_entry>> dup_map;
+        for (int32_t appid = 1; appid <= 10; appid++) {
+            for (int partition_id = 0; partition_id < 3; partition_id++) {
+                stub->add_primary_replica(appid, partition_id);
+            }
+        }
+
+        { // Ensure update_duplication_map adds new duplications if they are not existed.
+            duplication_entry ent;
+            ent.dupid = 2;
+            ent.status = duplication_status::DS_PAUSE;
+            for (int i = 0; i < 3; i++) {
+                ent.progress[i] = 0;
+            }
+
+            // add duplication 2 for app 1, 3, 5 (of course in real world cases duplication
+            // will not be the same for different tables)
+            dup_map[1][ent.dupid] = ent;
+            dup_map[3][ent.dupid] = ent;
+            dup_map[5][ent.dupid] = ent;
+
+            dup_sync->update_duplication_map(dup_map);
+
+            for (int32_t appid : {1, 3, 5}) {
+                for (int partition_id : {0, 1, 2}) {
+                    auto dup = find_dup(stub->find_replica(appid, partition_id), 2);
+                    ASSERT_TRUE(dup);
+                }
+            }
+
+            // update duplicated decree of 1, 3, 5 to 2
+            auto dup = find_dup(stub->find_replica(1, 1), 2);
+            dup->update_progress(dup->progress().set_last_decree(2));
+
+            dup = find_dup(stub->find_replica(3, 1), 2);
+            dup->update_progress(dup->progress().set_last_decree(2));
+
+            dup = find_dup(stub->find_replica(5, 1), 2);
+            dup->update_progress(dup->progress().set_last_decree(2));
+        }
+
+        RPC_MOCKING(duplication_sync_rpc)
+        {
+            stub->set_state_connected();
+            dup_sync->run();
+            ASSERT_EQ(duplication_sync_rpc::mail_box().size(), 1);
+
+            auto &req = duplication_sync_rpc::mail_box().back().request();
+            ASSERT_EQ(req.confirm_list.size(), 3);
+
+            ASSERT_TRUE(req.confirm_list.find(gpid(1, 1)) != req.confirm_list.end());
+            ASSERT_TRUE(req.confirm_list.find(gpid(3, 1)) != req.confirm_list.end());
+            ASSERT_TRUE(req.confirm_list.find(gpid(5, 1)) != req.confirm_list.end());
+        }
+
+        {
+            dup_map.erase(3);
+            dup_sync->update_duplication_map(dup_map);
+            ASSERT_TRUE(find_dup(stub->find_replica(1, 1), 2) != nullptr);
+            ASSERT_TRUE(find_dup(stub->find_replica(3, 1), 2) == nullptr);
+            ASSERT_TRUE(find_dup(stub->find_replica(5, 1), 2) != nullptr);
+        }
+
+        {
+            dup_map.clear();
+            dup_sync->update_duplication_map(dup_map);
+            ASSERT_TRUE(find_dup(stub->find_replica(1, 1), 2) == nullptr);
+            ASSERT_TRUE(find_dup(stub->find_replica(3, 1), 2) == nullptr);
+            ASSERT_TRUE(find_dup(stub->find_replica(5, 1), 2) == nullptr);
+        }
+    }
+
+    void test_update_on_non_primary()
+    {
+        stub->add_non_primary_replica(2, 1);
+
+        duplication_entry ent;
+        ent.dupid = 1;
+        ent.status = duplication_status::DS_PAUSE;
+
+        std::map<int32_t, std::map<dupid_t, duplication_entry>> dup_map;
+        dup_map[2][ent.dupid] = ent; // app 2 doesn't have a primary replica
+
+        dup_sync->update_duplication_map(dup_map);
+
+        ASSERT_TRUE(stub->mock_replicas[gpid(2, 1)]
+                        ->get_replica_duplicator_manager()
+                        ._duplications.empty());
+    }
+
+    void test_update_confirmed_points()
+    {
+        for (int32_t appid = 1; appid <= 10; appid++) {
+            stub->add_primary_replica(appid, 1);
+        }
+
+        for (int appid = 1; appid <= 3; appid++) {
+            auto r = stub->find_replica(appid, 1);
+
+            duplication_entry ent;
+            ent.dupid = 1;
+            ent.status = duplication_status::DS_PAUSE;
+            ent.progress[r->get_gpid().get_partition_index()] = 0;
+            auto dup = make_unique<replica_duplicator>(ent, r);
+            dup->update_progress(dup->progress().set_last_decree(3).set_confirmed_decree(1));
+            add_dup(r, std::move(dup));
+        }
+
+        duplication_entry ent;
+        ent.dupid = 1;
+        ent.progress[1] = 3; // app=[1,2,3], partition=1, confirmed=3
+        duplication_sync_response resp;
+        resp.dup_map[1][ent.dupid] = ent;
+        resp.dup_map[2][ent.dupid] = ent;
+        resp.dup_map[3][ent.dupid] = ent;
+
+        dup_sync->on_duplication_sync_reply(ERR_OK, resp);
+
+        for (int appid = 1; appid <= 3; appid++) {
+            auto r = stub->find_replica(appid, 1);
+            auto dup = find_dup(r, 1);
+
+            ASSERT_EQ(dup->progress().confirmed_decree, 3);
+        }
+    }
+
+    // ensure dup-sync behaves correctly regardless
+    // replica status transition (PRIMARY->SECONDARY/SECONDARY->PRIMARY)
+    void test_replica_status_transition()
+    {
+        // 10 primaries
+        int appid = 1;
+        for (int partition_id = 0; partition_id < 10; partition_id++) {
+            stub->add_primary_replica(appid, partition_id);
+        }
+
+        duplication_entry ent;
+        ent.dupid = 2;
+        ent.status = duplication_status::DS_PAUSE;
+        for (int i = 0; i < 10; i++) {
+            ent.progress[i] = 0;
+        }
+        std::map<int32_t, std::map<dupid_t, duplication_entry>> dup_map;
+        dup_map[appid][ent.dupid] = ent;
+
+        dup_sync->update_duplication_map(dup_map);
+        for (int partition_id = 0; partition_id < 10; partition_id++) {
+            ASSERT_NE(find_dup(stub->find_replica(1, partition_id), 2), nullptr) << partition_id;
+            ASSERT_EQ(find_dup(stub->find_replica(1, partition_id), 2)->id(), 2);
+        }
+
+        // primary -> secondary
+        for (int partition_id = 0; partition_id < 10; partition_id++) {
+            stub->find_replica(1, partition_id)->as_secondary();
+        }
+        dup_sync->update_duplication_map(dup_map);
+        for (int partition_id = 0; partition_id < 10; partition_id++) {
+            ASSERT_TRUE(stub->find_replica(1, partition_id)
+                            ->get_duplication_manager()
+                            ->_duplications.empty());
+        }
+
+        // secondary back to primary
+        for (int partition_id = 0; partition_id < 10; partition_id++) {
+            stub->find_replica(1, partition_id)->as_primary();
+        }
+        dup_sync->update_duplication_map(dup_map);
+        for (int partition_id = 0; partition_id < 10; partition_id++) {
+            ASSERT_EQ(find_dup(stub->find_replica(1, partition_id), 2)->id(), 2);
+        }
+
+        // on meta's perspective, only 3 partitions are hosted on this server
+        ent.progress.clear();
+        for (int i = 0; i < 3; i++) {
+            ent.progress[i] = 0;
+        }
+        dup_map[appid][ent.dupid] = ent;
+        dup_sync->update_duplication_map(dup_map);
+        for (int partition_id = 0; partition_id < 3; partition_id++) {
+            ASSERT_EQ(find_dup(stub->find_replica(1, partition_id), 2)->id(), 2);
+        }
+        for (int partition_id = 3; partition_id < 10; partition_id++) {
+            ASSERT_TRUE(stub->find_replica(1, partition_id)
+                            ->get_duplication_manager()
+                            ->_duplications.empty());
+        }
+    }
+
+    // meta server doesn't suppose to sync duplication that's INIT or REMOVED
+    // there must be some internal problems.
+    void test_receive_illegal_duplication_status()
+    {
+        stub->add_primary_replica(1, 0);
+
+        duplication_entry ent;
+        ent.dupid = 2;
+        ent.status = duplication_status::DS_PAUSE;
+        for (int i = 0; i < 16; i++) {
+            ent.progress[i] = 0;
+        }
+        std::map<int32_t, std::map<dupid_t, duplication_entry>> dup_map;
+        dup_map[1][ent.dupid] = ent;
+        dup_sync->update_duplication_map(dup_map);
+        ASSERT_EQ(find_dup(stub->find_replica(1, 0), 2)->_status, duplication_status::DS_PAUSE);
+
+        ent.status = duplication_status::DS_INIT;
+        dup_map[1][ent.dupid] = ent;
+        dup_sync->update_duplication_map(dup_map);
+        ASSERT_EQ(find_dup(stub->find_replica(1, 0), 2)->_status, duplication_status::DS_PAUSE);
+
+        ent.status = duplication_status::DS_REMOVED;
+        dup_map[1][ent.dupid] = ent;
+        dup_sync->update_duplication_map(dup_map);
+        ASSERT_EQ(find_dup(stub->find_replica(1, 0), 2)->_status, duplication_status::DS_PAUSE);
+    }
+
+protected:
+    std::unique_ptr<duplication_sync_timer> dup_sync;
+};
+
+TEST_F(duplication_sync_timer_test, duplication_sync) { test_duplication_sync(); }
+
+TEST_F(duplication_sync_timer_test, update_duplication_map) { test_update_duplication_map(); }
+
+TEST_F(duplication_sync_timer_test, update_on_non_primary) { test_update_on_non_primary(); }
+
+TEST_F(duplication_sync_timer_test, update_confirmed_points) { test_update_confirmed_points(); }
+
+TEST_F(duplication_sync_timer_test, on_duplication_sync_reply) { test_on_duplication_sync_reply(); }
+
+TEST_F(duplication_sync_timer_test, replica_status_transition) { test_replica_status_transition(); }
+
+TEST_F(duplication_sync_timer_test, receive_illegal_duplication_status)
+{
+    test_receive_illegal_duplication_status();
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/test/duplication_test_base.h
+++ b/src/dist/replication/lib/duplication/test/duplication_test_base.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "dist/replication/test/replica_test/unit_test/replica_test_base.h"
+#include "dist/replication/lib/duplication/replica_duplicator.h"
+#include "dist/replication/lib/duplication/replica_duplicator_manager.h"
+
+namespace dsn {
+namespace replication {
+
+class duplication_test_base : public replica_test_base
+{
+public:
+    duplication_test_base() {}
+
+    void add_dup(mock_replica *r, replica_duplicator_u_ptr dup)
+    {
+        r->get_replica_duplicator_manager()._duplications[dup->id()] = std::move(dup);
+    }
+
+    replica_duplicator *find_dup(mock_replica *r, dupid_t dupid)
+    {
+        auto &dup_entities = r->get_replica_duplicator_manager()._duplications;
+        if (dup_entities.find(dupid) == dup_entities.end()) {
+            return nullptr;
+        }
+        return dup_entities[dupid].get();
+    }
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/test/main.cpp
+++ b/src/dist/replication/lib/duplication/test/main.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <dsn/service_api_cpp.h>
+
+int g_test_count = 0;
+int g_test_ret = 0;
+
+class gtest_app : public dsn::service_app
+{
+public:
+    gtest_app(const dsn::service_app_info *info) : ::dsn::service_app(info) {}
+
+    dsn::error_code start(const std::vector<std::string> &args) override
+    {
+        g_test_ret = RUN_ALL_TESTS();
+        g_test_count = 1;
+        return dsn::ERR_OK;
+    }
+
+    dsn::error_code stop(bool) override { return dsn::ERR_OK; }
+};
+
+GTEST_API_ int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+
+    dsn::service_app::register_factory<gtest_app>("replica");
+
+    dsn_run_config("config-test.ini", false);
+    while (g_test_count == 0) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    dsn_exit(g_test_ret);
+}

--- a/src/dist/replication/lib/duplication/test/replica_duplicator_manager_test.cpp
+++ b/src/dist/replication/lib/duplication/test/replica_duplicator_manager_test.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include "duplication_test_base.h"
+
+namespace dsn {
+namespace replication {
+
+class replica_duplicator_manager_test : public duplication_test_base
+{
+public:
+    void SetUp() override { stub = make_unique<mock_replica_stub>(); }
+
+    void TearDown() override { stub.reset(); }
+
+    void test_remove_non_existed_duplications()
+    {
+        auto r = stub->add_primary_replica(2, 1);
+        auto &d = r->get_replica_duplicator_manager();
+
+        duplication_entry ent;
+        ent.dupid = 1;
+        ent.status = duplication_status::DS_PAUSE;
+        ent.remote = "dsn://slave-cluster";
+        ent.progress[r->get_gpid().get_partition_index()] = 0;
+        d.sync_duplication(ent);
+        ASSERT_EQ(d._duplications.size(), 1);
+
+        // remove all dup
+        d.remove_non_existed_duplications({});
+        ASSERT_EQ(d._duplications.size(), 0);
+
+        ent.dupid = 2;
+        d.sync_duplication(ent);
+        ASSERT_EQ(d._duplications.size(), 1);
+    }
+
+    void test_get_duplication_confirms()
+    {
+        auto r = stub->add_primary_replica(2, 1);
+
+        int total_dup_num = 10;
+        int update_dup_num = 4; // the number of dups that will be updated
+
+        for (dupid_t id = 1; id <= update_dup_num; id++) {
+            duplication_entry ent;
+            ent.dupid = id;
+            ent.status = duplication_status::DS_PAUSE;
+            ent.progress[r->get_gpid().get_partition_index()] = 0;
+
+            auto dup = make_unique<replica_duplicator>(ent, r);
+            dup->update_progress(dup->progress().set_last_decree(2).set_confirmed_decree(1));
+            add_dup(r, std::move(dup));
+        }
+
+        for (dupid_t id = update_dup_num + 1; id <= total_dup_num; id++) {
+            duplication_entry ent;
+            ent.dupid = id;
+            ent.status = duplication_status::DS_PAUSE;
+            ent.progress[r->get_gpid().get_partition_index()] = 0;
+
+            auto dup = make_unique<replica_duplicator>(ent, r);
+            dup->update_progress(dup->progress().set_last_decree(1).set_confirmed_decree(1));
+            add_dup(r, std::move(dup));
+        }
+
+        auto result = r->get_replica_duplicator_manager().get_duplication_confirms_to_update();
+        ASSERT_EQ(result.size(), update_dup_num);
+    }
+};
+
+TEST_F(replica_duplicator_manager_test, get_duplication_confirms)
+{
+    test_get_duplication_confirms();
+}
+
+TEST_F(replica_duplicator_manager_test, remove_non_existed_duplications)
+{
+    test_remove_non_existed_duplications();
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/test/run.sh
+++ b/src/dist/replication/lib/duplication/test/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+./dsn_replica_dup_test
+
+if [ $? -ne 0 ]; then
+    tail -n 100 data/log/log.1.txt
+    if [ -f core ]; then
+        gdb ./dsn_replica_dup_test core -ex "bt"
+    fi
+    exit 1
+fi

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -54,7 +54,8 @@ replica::replica(
       _chkpt_total_size(0),
       _cur_download_size(0),
       _restore_progress(0),
-      _restore_status(ERR_OK)
+      _restore_status(ERR_OK),
+      _duplication_mgr(new replica_duplicator_manager(this))
 {
     dassert(_app_info.app_type != "", "");
     dassert(stub != nullptr, "");
@@ -436,5 +437,5 @@ std::string replica::query_compact_state() const
     dassert_replica(_app != nullptr, "");
     return _app->query_compact_state();
 }
-}
-} // namespace
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/test/replica_test/unit_test/replica_test_base.h
+++ b/src/dist/replication/test/replica_test/unit_test/replica_test_base.h
@@ -41,10 +41,7 @@ namespace replication {
 
 struct replica_stub_test_base : ::testing::Test
 {
-    replica_stub_test_base()
-    {
-        stub = make_unique<mock_replica_stub>(); // mock mutation_duplicator
-    }
+    replica_stub_test_base() { stub = make_unique<mock_replica_stub>(); }
 
     ~replica_stub_test_base() { stub.reset(); }
 


### PR DESCRIPTION
```
+--------------------------------+
|                                |
|  +--------------------------+  |
|  |                          |  |
|  |                          |  |          +--------------+
|  |   +-----------------+    |  |          |              |
|  |   |                 +----------------->+  bjsrv ad    |
|  |   |                 |    |  |          |              |
|  |   +--replica_duplicator  |  |          +--------------+
|  |                          |  |
|  |   +-----------------+    |  |          +--------------+
|  |   |                 +----------------->+              |
|  |   |                 |    |  |          |  gzsrv ad    |
|  |   +--replica_duplicator  |  |          |              |
|  |                          |  |          +--------------+
|  |                          |  |
|  +--------------------------+  |
|                                |
| replica_duplication_manager    |
|                                |
|                                |
+-----------replica--------------+
```

This PR follows https://github.com/XiaoMi/rdsn/pull/281, which introduced `duplication_sync_timer`.
The duplication_sync_timer syncs with meta-server, and assign duplications to each primary replicas on this server. 

Each replica holds a `replica_duplication_manager` which manages several duplications, one for a remote cluster. Each duplication is a `replica_duplicator`.

## What does a `replica_duplication_manager` do?

- Manages duplications to different remote clusters. 

```cpp
    std::map<dupid_t, replica_duplicator_u_ptr> _duplications;
```

- Collects duplication progress and reports them to `duplication_sync_timer`.

```
replica_duplicator_manager::get_duplication_confirms_to_update() const {
```

- Passes down the confirmed decree to each replica duplicator, so that those preserved private log can be cleaned up once they are confirmed.

```cpp
void replica_duplicator_manager::sync_duplication(const duplication_entry &ent)
{
    dupid_t dupid = ent.dupid;
    replica_duplicator_u_ptr &dup = _duplications[dupid];
    ...
        // update progress
        duplication_progress newp = dup->progress().set_confirmed_decree(it->second);
        dcheck_eq_replica(dup->update_progress(newp), error_s::ok());
    ...
}
```