### PR TITLE
utility: enhance fail point functionality

### DIFF
--- a/include/dsn/utility/fail_point.h
+++ b/include/dsn/utility/fail_point.h
@@ -23,25 +23,17 @@
 #include <dsn/utility/string_view.h>
 
 /// The only entry to define a fail point.
-/// Add following line to cmake to compile target with fault injection.
-/// ```
-///   add_definition(-DENABLE_FAIL)
-/// ```
 /// When a fail point is defined, it's referenced via the name.
-#ifdef ENABLE_FAIL
 #define FAIL_POINT_INJECT_F(name, lambda)                                                          \
     do {                                                                                           \
+        if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
+            break;                                                                                 \
         auto __Func = lambda;                                                                      \
         auto __Res = ::dsn::fail::eval(name);                                                      \
         if (__Res != nullptr) {                                                                    \
             return __Func(*__Res);                                                                 \
         }                                                                                          \
     } while (0)
-#define FAIL_POINT_INJECT(name) ::dsn::fail::eval(name)
-#else
-#define FAIL_POINT_INJECT_F(name, lambda)
-#define FAIL_POINT_INJECT(name)
-#endif
 
 namespace dsn {
 namespace fail {
@@ -59,6 +51,8 @@ extern void setup();
 
 /// Tear down the fail point system.
 extern void teardown();
+
+extern bool _S_FAIL_POINT_ENABLED;
 
 } // namespace fail
 } // namespace dsn

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -36,5 +36,4 @@ set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config-bad-section.ini"
                  "${CMAKE_CURRENT_SOURCE_DIR}/gtest.filter"
 )
 add_definitions(-Wno-dangling-else)
-add_definitions(-DENABLE_FAIL)
 dsn_add_test()

--- a/src/core/tests/fail_point_test.cpp
+++ b/src/core/tests/fail_point_test.cpp
@@ -130,5 +130,26 @@ TEST(fail_point, macro_use)
     teardown();
 }
 
+void test_func_return_void(int &a)
+{
+    FAIL_POINT_INJECT_F("test_1", [](string_view str) {});
+    a++;
+}
+TEST(fail_point, return_void)
+{
+    setup();
+
+    int a = 0;
+    cfg("test_1", "1*return()");
+    test_func_return_void(a);
+    ASSERT_EQ(a, 0);
+
+    cfg("test_1", "off");
+    test_func_return_void(a);
+    ASSERT_EQ(a, 1);
+
+    teardown();
+}
+
 } // namespace fail
 } // namespace dsn

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -284,6 +284,7 @@ if [ ! -d $TP_OUTPUT/include/curl ]; then
     --disable-smtp \
     --disable-telnet \
     --disable-tftp \
+    --disable-shared \
     --without-librtmp \
     --without-libssh2 \
     --without-ssl"


### PR DESCRIPTION
What does this PR do:

- enable fail point directly by `setup()`, rather than using macro `ENABLE_FAIL`. This will allow us to compile once for both testing purpose (enable fail point) and production purpose (disable fail point).
- add debugging logs on fail point

Additionally, this PR also disables building shared lib of curl (https://github.com/XiaoMi/rdsn/pull/288/files), which may conflict with system-built libcurl.so in some environment.