### PR TITLE
feat(dup): add interface mutation_duplicator & duplication procedure

### DIFF
--- a/include/dsn/dist/replication/mutation_duplicator.h
+++ b/include/dsn/dist/replication/mutation_duplicator.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <dsn/utility/errors.h>
+#include <dsn/dist/replication/replication_types.h>
+#include <dsn/dist/replication/replica_base.h>
+#include <dsn/cpp/pipeline.h>
+
+namespace dsn {
+namespace replication {
+
+/// \brief Each of the mutation is a tuple made up of
+/// <timestamp, task_code, dsn::blob>.
+/// dsn::blob is the content of the mutation.
+typedef std::tuple<uint64_t, task_code, blob> mutation_tuple;
+
+/// mutations are sorted by timestamp in mutation_tuple_set.
+struct mutation_tuple_cmp
+{
+    inline bool operator()(const mutation_tuple &lhs, const mutation_tuple &rhs)
+    {
+        // different mutations is probable to be batched together
+        // and sharing the same timestamp, so here we also compare
+        // the data pointer.
+        if (std::get<0>(lhs) == std::get<0>(rhs)) {
+            return std::get<2>(lhs).data() < std::get<2>(rhs).data();
+        }
+        return std::get<0>(lhs) < std::get<0>(rhs);
+    }
+};
+typedef std::set<mutation_tuple, mutation_tuple_cmp> mutation_tuple_set;
+
+/// \brief This is an interface for handling the mutation logs intended to
+/// be duplicated to remote cluster.
+/// \see dsn::replication::replica_duplicator
+class mutation_duplicator : public replica_base
+{
+public:
+    typedef std::function<void(size_t /*total_shipped_size*/)> callback;
+
+    /// Duplicate the provided mutations to the remote cluster.
+    /// The implementation must be non-blocking.
+    ///
+    /// \param cb: Call it when all the given mutations were sent successfully
+    virtual void duplicate(mutation_tuple_set mutations, callback cb) = 0;
+
+    // Singleton creator of mutation_duplicator.
+    static std::function<std::unique_ptr<mutation_duplicator>(
+        replica_base *, string_view /*remote cluster*/, string_view /*app name*/)>
+        creator;
+
+    explicit mutation_duplicator(replica_base *r) : replica_base(r) {}
+
+    virtual ~mutation_duplicator() = default;
+
+    void set_task_environment(pipeline::environment *env) { _env = *env; }
+
+protected:
+    friend class replica_duplicator_test;
+
+    pipeline::environment _env;
+};
+
+inline std::unique_ptr<mutation_duplicator>
+new_mutation_duplicator(replica_base *r, string_view remote_cluster_address, string_view app)
+{
+    return mutation_duplicator::creator(r, remote_cluster_address, app);
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/core/tests/task_test.cpp
+++ b/src/core/tests/task_test.cpp
@@ -51,8 +51,6 @@ public:
         // in simulator environment this task will be executed immediately,
         // so we excluded config-test-sim.ini for this test.
         auto t = file::read(fp, buffer, 128, 0, LPC_TASK_TEST, nullptr, nullptr);
-        ASSERT_EQ(t->_state, task_state::TASK_STATE_READY);
-        ASSERT_TRUE(t->_is_null);
 
         t->wait(10000);
         ASSERT_TRUE(t->_wait_event.load() != nullptr);

--- a/src/dist/replication/lib/CMakeLists.txt
+++ b/src/dist/replication/lib/CMakeLists.txt
@@ -4,6 +4,8 @@ set(DUPLICATION_SRC
         duplication/replica_duplicator_manager.cpp
         duplication/duplication_sync_timer.cpp
         duplication/replica_duplicator.cpp
+        duplication/duplication_pipeline.cpp
+        duplication/load_from_private_log.cpp
 )
 
 # Source files under CURRENT project directory will be automatically included.

--- a/src/dist/replication/lib/duplication/duplication_pipeline.cpp
+++ b/src/dist/replication/lib/duplication/duplication_pipeline.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <dsn/dist/replication/replication_app_base.h>
+#include <dsn/dist/fmt_logging.h>
+
+#include "dist/replication/lib/replica_stub.h"
+#include "duplication_pipeline.h"
+#include "load_from_private_log.h"
+
+namespace dsn {
+namespace replication {
+
+//               //
+// load_mutation //
+//               //
+
+void load_mutation::run()
+{
+    // TBD
+}
+
+load_mutation::~load_mutation() = default;
+
+load_mutation::load_mutation(replica_duplicator *duplicator,
+                             replica *r,
+                             load_from_private_log *load_private)
+    : replica_base(r)
+{
+    // TBD
+}
+
+//               //
+// ship_mutation //
+//               //
+
+void ship_mutation::run(decree &&last_decree, mutation_tuple_set &&in)
+{
+    // TBD
+}
+
+ship_mutation::ship_mutation(replica_duplicator *duplicator) : replica_base(duplicator)
+{
+    // TBD
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/duplication_pipeline.h
+++ b/src/dist/replication/lib/duplication/duplication_pipeline.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <dsn/cpp/pipeline.h>
+#include <dsn/dist/replication/replica_base.h>
+#include <dsn/dist/replication/mutation_duplicator.h>
+
+#include "dist/replication/lib/replica.h"
+#include "replica_duplicator.h"
+
+namespace dsn {
+namespace replication {
+
+using namespace literals::chrono_literals;
+
+// load_mutation is a pipeline stage for loading mutations, aka mutation_tuple_set,
+// to the next stage, `ship_mutation`.
+// ThreadPool: THREAD_POOL_REPLICATION
+class load_mutation : public replica_base,
+                      public pipeline::when<>,
+                      public pipeline::result<decree, mutation_tuple_set>
+{
+public:
+    void run() override;
+
+    /// ==== Implementation ==== ///
+
+    load_mutation(replica_duplicator *duplicator, replica *r, load_from_private_log *load_private);
+
+    ~load_mutation();
+};
+
+// ship_mutation is a pipeline stage receiving a set of mutations,
+// sending them to the remote cluster. After finished, the pipeline
+// will restart from load_mutation.
+// ThreadPool: THREAD_POOL_REPLICATION
+class ship_mutation : public replica_base,
+                      public pipeline::when<decree, mutation_tuple_set>,
+                      public pipeline::result<>
+{
+public:
+    void run(decree &&last_decree, mutation_tuple_set &&in) override;
+
+    /// ==== Implementation ==== ///
+
+    explicit ship_mutation(replica_duplicator *duplicator);
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/load_from_private_log.cpp
+++ b/src/dist/replication/lib/duplication/load_from_private_log.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include "dist/replication/lib/replica.h"
+#include "load_from_private_log.h"
+#include "replica_duplicator.h"
+
+namespace dsn {
+namespace replication {
+
+void load_from_private_log::run()
+{
+    // TBD
+}
+
+load_from_private_log::load_from_private_log(replica *r, replica_duplicator *dup)
+    : replica_base(r), _private_log(r->private_log()), _duplicator(dup)
+{
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/load_from_private_log.h
+++ b/src/dist/replication/lib/duplication/load_from_private_log.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <dsn/cpp/pipeline.h>
+#include <dsn/utility/errors.h>
+#include <dsn/dist/replication/mutation_duplicator.h>
+
+#include "dist/replication/lib/mutation_log.h"
+
+namespace dsn {
+namespace replication {
+
+class replica_duplicator;
+class replica_stub;
+
+/// Loads mutations from private log into memory.
+/// It works in THREAD_POOL_REPLICATION_LONG (LPC_DUPLICATION_LOAD_MUTATIONS),
+/// which permits tasks to be executed in a blocking way.
+/// NOTE: The resulted `mutation_tuple_set` may be empty.
+class load_from_private_log : public replica_base,
+                              public pipeline::when<>,
+                              public pipeline::result<decree, mutation_tuple_set>
+{
+public:
+    load_from_private_log(replica *r, replica_duplicator *dup);
+
+    // Start loading block from private log file.
+    // The loaded mutations will be passed down to `ship_mutation`.
+    void run() override;
+
+private:
+    friend class load_from_private_log_test;
+
+    mutation_log_ptr _private_log;
+    replica_duplicator *_duplicator;
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/dist/replication/lib/duplication/replica_duplicator.h
+++ b/src/dist/replication/lib/duplication/replica_duplicator.h
@@ -50,7 +50,7 @@ class replica_stub;
 // TODO(wutao1): Optimization for multi-duplication
 //               Currently we create duplicator for each duplication.
 //               They're isolated even if they share the same private log.
-class replica_duplicator : public replica_base
+class replica_duplicator : public replica_base, public pipeline::base
 {
 public:
     replica_duplicator(const duplication_entry &ent, replica *r);
@@ -77,13 +77,13 @@ public:
     // Thread-safe
     error_s update_progress(const duplication_progress &p);
 
-    void start_dup() { /*TBD*/}
+    void start_dup();
 
     // Pausing duplication will clear all the internal volatile states, thus
     // when next time it restarts, the states will be reinitialized like the
     // server being restarted.
     // It is useful when something went wrong internally.
-    void pause_dup() { /*TBD*/}
+    void pause_dup();
 
     // Holds its own tracker, so that other tasks
     // won't be effected when this duplication is removed.
@@ -111,6 +111,11 @@ private:
     // protect the access of _progress.
     mutable zrwlock_nr _lock;
     duplication_progress _progress;
+
+    /// === pipeline === ///
+    std::unique_ptr<load_mutation> _load;
+    std::unique_ptr<ship_mutation> _ship;
+    std::unique_ptr<load_from_private_log> _load_private;
 };
 
 typedef std::unique_ptr<replica_duplicator> replica_duplicator_u_ptr;


### PR DESCRIPTION
This PR added interface `mutation_duplicator` and pipeline of duplication procedure.

## mutation_duplicator

This is the interface of data "sender" to be extensible for multiple endpoint types.
For example, if the remote endpoint is a pegasus cluster, the `pegasus_mutation_duplicator` will
transfer client RPCs to the remote pegasus.
If there's a further requirement to duplicate data to HBase/MySQL/etc., we can implement this interface.

## Duplication Pipeline

The other part of this PR is simple. In each round of duplication, a batch of mutations is loaded
from private-log, and is sent via `mutation_duplicator` to remote endpoint.

So the pipeline can be declared like the following (in bash convention):

```bash
while true
do
  load_from_private_log | ship_mutations
done
```

Each procedure in our implementation is declared as a **class**:

-  `load_from_private_log`, run in thread pool, `REPLICATION_LONG`
- `ship_mutations`, run in thread pool, `REPLICATION`

In our real implementation, we make this design slightly complicated:

```bash
while true
do
  load_mutations | ship_mutations
done

# load_mutations will fork a new task to load from private-log, aka `load_from_private_log`
```

- `load_mutations` runs in thread pool  `REPLICATION`, because we need to obtain the latest information of this replica. Leave to future refactoring if we find this unnecessary and we can delete this class.

## replica_duplicator

`replica_duplicator` is the basement of this pipeline, so it extends `pipeline::base`.

```cpp
thread_pool(LPC_REPLICATION_LOW).task_tracker(tracker()).thread_hash(get_gpid().thread_hash());
```
It means that the pipeline is running in the environment of:

- `LPC_REPLICATION_LOW`: in low priority of thread pool `REPLICATION`.
- using the task tracker of replica, which means when the replica destructs, the pipeline will be detroyed.
- using the thread hash of this replica.
