### PR TITLE
build: use official thrift, cmake set default 3rdlibs, curl without idn

### DIFF
--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -126,7 +126,7 @@ function(dsn_add_project)
     endif()
 
     if((MY_PROJ_TYPE STREQUAL "SHARED") OR (MY_PROJ_TYPE STREQUAL "EXECUTABLE"))
-        set(MY_PROJ_LIBS ${MY_PROJ_LIBS} ${TEMP_LIBS} ${MY_BOOST_LIBS} ${DSN_SYSTEM_LIBS})
+        set(MY_PROJ_LIBS ${MY_PROJ_LIBS} ${DEFAULT_THIRDPARTY_LIBS} ${MY_BOOST_LIBS} ${DSN_SYSTEM_LIBS})
     endif()
     ms_add_project("${MY_PROJ_TYPE}" "${MY_PROJ_NAME}" "${MY_PROJ_SRC}" "${MY_PROJ_LIBS}" "${MY_BINPLACES}")
 endfunction(dsn_add_project)
@@ -256,7 +256,6 @@ function(dsn_setup_system_libs)
 
     set(DSN_SYSTEM_LIBS
         ${DSN_SYSTEM_LIBS}
-        thrift
         ${CMAKE_THREAD_LIBS_INIT} # the thread library found by FindThreads
         CACHE STRING "rDSN system libs" FORCE
     )
@@ -266,17 +265,25 @@ function(dsn_setup_include_path)#TODO(huangwei5): remove this
     include_directories(${DSN_THIRDPARTY_ROOT}/include)
 endfunction(dsn_setup_include_path)
 
-function(dsn_setup_link_path)#TODO(huangwei5): dsn_setup_thirdparty_libs()
+function(dsn_setup_thirdparty_libs)
     set(Boost_USE_MULTITHREADED ON)
     set(Boost_USE_STATIC_LIBS OFF)
     set(Boost_USE_STATIC_RUNTIME OFF)
 
+    set(CMAKE_PREFIX_PATH ${DSN_THIRDPARTY_ROOT};${CMAKE_PREFIX_PATH})
     find_package(Boost COMPONENTS system filesystem regex REQUIRED)
     include_directories(${Boost_INCLUDE_DIRS})
-    
+
+    find_library(THRIFT_LIB NAMES libthrift.a PATHS ${DSN_THIRDPARTY_ROOT}/lib NO_DEFAULT_PATH)
+    if(NOT THRIFT_LIB)
+        message(FATAL_ERROR "thrift library not found in ${DSN_THIRDPARTY_ROOT}/lib")
+    endif()
+    find_package(fmt REQUIRED)
+    set(DEFAULT_THIRDPARTY_LIBS ${THRIFT_LIB} fmt::fmt CACHE STRING "default thirdparty libs" FORCE)
+
     link_directories(${DSN_THIRDPARTY_ROOT}/lib)
     link_directories(${DSN_THIRDPARTY_ROOT}/lib64)
-endfunction(dsn_setup_link_path)
+endfunction(dsn_setup_thirdparty_libs)
 
 function(dsn_common_setup)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(notdir $(abspath $<))\"'")
@@ -304,5 +311,5 @@ function(dsn_common_setup)
     dsn_setup_system_libs()
     dsn_setup_compiler_flags()
     dsn_setup_include_path()
-    dsn_setup_link_path()
+    dsn_setup_thirdparty_libs()
 endfunction(dsn_common_setup)

--- a/compile_thrift.py
+++ b/compile_thrift.py
@@ -95,17 +95,6 @@ thrift_description = [
     }
 ]
 
-thrift_exe = os.getcwd() + "/bin/Linux/thrift"
-root_dir = os.getcwd()
-print "thrift_exe = " + thrift_exe
-print "root_dir = " + root_dir
-
-if not os.path.isfile(thrift_exe):
-    os.system("wget --no-check-certificate "
-              "https://github.com/xiaomi/pegasus-common/raw/master/pre-built/ubuntu14.04/thrift "
-              "&& chmod u+x thrift "
-              "&& mv thrift "+thrift_exe)
-
 class CompileError(Exception):
     """ Raised when dealing with thrift idl have errors"""
 
@@ -270,6 +259,15 @@ def add_hook(name, path, func, args):
 
 
 if __name__ == "__main__":
+    thrift_exe = os.getcwd() + "/thirdparty/output/bin/thrift"
+    root_dir = os.getcwd()
+    print "thrift_exe = " + thrift_exe
+    print "root_dir = " + root_dir
+
+    if not os.path.isfile(thrift_exe):
+        print "Error: can't find compiler %s\nPlease build thrift in thirdparty/" % thrift_exe
+        sys.exit()
+
     ctor_kv_pair = "  kv_pair(const std::string& _key, const std::string& _val): key(_key), value(_val) {\n  }"
     ctor_configuration_proposal_action = "  configuration_proposal_action(::dsn::rpc_address t, ::dsn::rpc_address n, config_type::type tp): target(t), node(n), type(tp) {}"
     add_hook("simple_kv", "src/apps/skv", constructor_hook,

--- a/src/dist/cli/shell/CMakeLists.txt
+++ b/src/dist/cli/shell/CMakeLists.txt
@@ -9,11 +9,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-if (UNIX)
-    set(MY_PROJ_LIBS pthread dsn_cli)
-else()
-    set(MY_PROJ_LIBS dsn_cli)
-endif()
+set(MY_PROJ_LIBS dsn_cli)
 
 list(APPEND MY_PROJ_LIBS dsn_runtime)
 

--- a/src/dist/http/CMakeLists.txt
+++ b/src/dist/http/CMakeLists.txt
@@ -4,7 +4,7 @@ set(MY_PROJ_SRC "")
 
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS fmt)
+set(MY_PROJ_LIBS "")
 
 dsn_add_static_library()
 

--- a/src/dist/http/test/CMakeLists.txt
+++ b/src/dist/http/test/CMakeLists.txt
@@ -9,7 +9,6 @@ set(MY_PROJ_LIBS
     dsn_runtime
     gtest
     gtest_main
-    fmt
     )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/dist/replication/common/test/CMakeLists.txt
+++ b/src/dist/replication/common/test/CMakeLists.txt
@@ -6,7 +6,6 @@ set(MY_PROJ_LIBS
         dsn_replication_common
         dsn_runtime
         gtest
-        fmt
         )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/dist/replication/lib/duplication/test/CMakeLists.txt
+++ b/src/dist/replication/lib/duplication/test/CMakeLists.txt
@@ -19,7 +19,6 @@ set(MY_PROJ_LIBS dsn_meta_server
         PocoJSON
         crypto
         gtest
-        fmt
 )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/dist/replication/storage_engine/simple_kv/CMakeLists.txt
+++ b/src/dist/replication/storage_engine/simple_kv/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server dsn_replication_client dsn_runtime fmt)
+set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server dsn_replication_client dsn_runtime)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 

--- a/src/dist/replication/test/meta_test/balancer_simulator/CMakeLists.txt
+++ b/src/dist/replication/test/meta_test/balancer_simulator/CMakeLists.txt
@@ -15,7 +15,6 @@ set(MY_PROJ_LIBS
     dsn.block_service.local
     dsn.block_service.fds
     dsn_runtime
-    fmt
     gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/dist/replication/test/meta_test/unit_test/CMakeLists.txt
+++ b/src/dist/replication/test/meta_test/unit_test/CMakeLists.txt
@@ -29,7 +29,6 @@ set(MY_PROJ_LIBS
         PocoNetSSL
         PocoJSON
         crypto
-        fmt
         gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/dist/replication/test/replica_test/unit_test/CMakeLists.txt
+++ b/src/dist/replication/test/replica_test/unit_test/CMakeLists.txt
@@ -25,7 +25,6 @@ set(MY_PROJ_LIBS dsn_meta_server
                  PocoNetSSL
                  PocoJSON
                  crypto
-                 fmt
                  gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/dist/replication/test/simple_kv/CMakeLists.txt
+++ b/src/dist/replication/test/simple_kv/CMakeLists.txt
@@ -23,7 +23,6 @@ set(MY_PROJ_LIBS dsn_replica_server
                  PocoNetSSL
                  PocoJSON
                  crypto
-                 fmt
                  gtest
                  )
 

--- a/src/tests/dsn/CMakeLists.txt
+++ b/src/tests/dsn/CMakeLists.txt
@@ -9,12 +9,6 @@ set(MY_PROJ_SRC "")
 #  "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-if (UNIX)
-    set(MY_PROJ_LIBS gtest pthread)
-else()
-    set(MY_PROJ_LIBS gtest)
-endif()
-
 set(MY_PROJ_LIBS 
     dsn_meta_server
     dsn_replica_server
@@ -32,8 +26,7 @@ set(MY_PROJ_LIBS
     PocoNetSSL
     PocoJSON
     crypto
-    fmt
-    ${MY_PROJ_LIBS}
+    gtest
     )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -105,7 +105,7 @@ if [ ! -d $TP_OUTPUT/include/thrift ]; then
         -DWITH_QT5=OFF\
         -DWITH_QT4=OFF\
         -DWITH_OPENSSL=OFF\
-        -DBUILD_COMPILER=OFF\
+        -DBUILD_COMPILER=ON\
         -DBUILD_TUTORIALS=OFF\
         -DWITH_LIBEVENT=OFF\
         -DCMAKE_INSTALL_PREFIX=$TP_OUTPUT\
@@ -168,7 +168,7 @@ fi
 if [ ! -d $TP_OUTPUT/include/Poco ]; then
     mkdir -p $TP_BUILD/poco-1.7.8-release
     cd $TP_BUILD/poco-1.7.8-release
-    CMAKE_FLAGS="-DENABLE_XML=OFF\
+    CMAKE_FLAGS="
     -DENABLE_MONGODB=OFF\
     -DENABLE_PDF=OFF\
     -DENABLE_DATA=OFF\
@@ -288,7 +288,8 @@ if [ ! -d $TP_OUTPUT/include/curl ]; then
     --without-librtmp \
     --without-zlib \
     --without-libssh2 \
-    --without-ssl"
+    --without-ssl \
+    --without-libidn"
 
     ./configure $CONFIG_FLAGS
     make -j8 && make install


### PR DESCRIPTION
https://github.com/XiaoMi/pegasus/issues/361#issuecomment-515656652

It's unnecessary to build curl with [libidn](https://www.gnu.org/software/libidn/manual/libidn.html#Introduction).
