### PR TITLE
refactor: remove useless functions from binary_reader

### DIFF
--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -43,10 +43,6 @@ public:
     int read(blob &blob);
     int read(blob &blob, int len);
 
-    bool next(const void **data, int *size);
-    bool skip(int count);
-    bool backup(int count);
-
     blob get_buffer() const { return _blob; }
     blob get_remaining_buffer() const { return _blob.range(static_cast<int>(_ptr - _blob.data())); }
     bool is_eof() const { return _ptr >= _blob.data() + _size; }

--- a/src/core/core/binary_reader.cpp
+++ b/src/core/core/binary_reader.cpp
@@ -82,38 +82,4 @@ int binary_reader::read(char *buffer, int sz)
     }
 }
 
-bool binary_reader::next(const void **data, int *size)
-{
-    if (get_remaining_size() > 0) {
-        *data = (const void *)_ptr;
-        *size = _remaining_size;
-
-        _ptr += _remaining_size;
-        _remaining_size = 0;
-        return true;
-    } else
-        return false;
-}
-
-bool binary_reader::backup(int count)
-{
-    if (count <= static_cast<int>(_ptr - _blob.data())) {
-        _ptr -= count;
-        _remaining_size += count;
-        return true;
-    } else
-        return false;
-}
-
-bool binary_reader::skip(int count)
-{
-    if (count <= get_remaining_size()) {
-        _ptr += count;
-        _remaining_size -= count;
-        return true;
-    } else {
-        assert(false);
-        return false;
-    }
-}
-}
+} // namespace dsn


### PR DESCRIPTION
I didn't find any usage of the three functions. So let's remove them.