### PR TITLE
feat: add table level latency perf counters

### DIFF
--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -429,12 +429,14 @@ public:
     mutation_update(mutation_update &&);
     mutation_update &operator=(const mutation_update &);
     mutation_update &operator=(mutation_update &&);
-    mutation_update() : serialization_type(0) {}
+    mutation_update() : serialization_type(0), start_time_ns(dsn_now_ns()) {}
 
     virtual ~mutation_update() throw();
     ::dsn::task_code code;
     int32_t serialization_type;
     ::dsn::blob data;
+    // start_time_ns doesn't need to serialization, because we only use it in local node
+    uint64_t start_time_ns;
 
     _mutation_update__isset __isset;
 
@@ -451,6 +453,8 @@ public:
         if (!(serialization_type == rhs.serialization_type))
             return false;
         if (!(data == rhs.data))
+            return false;
+        if (!(start_time_ns == rhs.start_time_ns))
             return false;
         return true;
     }

--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -435,7 +435,7 @@ public:
     ::dsn::task_code code;
     int32_t serialization_type;
     ::dsn::blob data;
-    // start_time_ns doesn't need to serialization, because we only use it in local node
+    // start_time_ns doesn't need to serialization, because we only use it on local node
     uint64_t start_time_ns;
 
     _mutation_update__isset __isset;

--- a/include/dsn/tool-api/task_spec.h
+++ b/include/dsn/tool-api/task_spec.h
@@ -139,7 +139,7 @@ class message_ex;
 class admission_controller;
 typedef void (*task_rejection_handler)(task *, admission_controller *);
 
-extern std::set<int> storage_rpc_req_codes;
+extern std::set<int> s_storage_rpc_req_codes;
 
 class task_spec : public extensible_object<task_spec, 4>
 {

--- a/include/dsn/tool-api/task_spec.h
+++ b/include/dsn/tool-api/task_spec.h
@@ -139,7 +139,7 @@ class message_ex;
 class admission_controller;
 typedef void (*task_rejection_handler)(task *, admission_controller *);
 
-extern std::set<int> s_storage_rpc_req_codes;
+extern std::set<dsn::task_code> s_storage_rpc_req_codes;
 
 class task_spec : public extensible_object<task_spec, 4>
 {

--- a/include/dsn/tool-api/task_spec.h
+++ b/include/dsn/tool-api/task_spec.h
@@ -139,6 +139,8 @@ class message_ex;
 class admission_controller;
 typedef void (*task_rejection_handler)(task *, admission_controller *);
 
+extern std::vector<dsn::task_code> storage_rpc_req_codes;
+
 class task_spec : public extensible_object<task_spec, 4>
 {
 public:

--- a/include/dsn/tool-api/task_spec.h
+++ b/include/dsn/tool-api/task_spec.h
@@ -139,7 +139,7 @@ class message_ex;
 class admission_controller;
 typedef void (*task_rejection_handler)(task *, admission_controller *);
 
-extern std::vector<dsn::task_code> storage_rpc_req_codes;
+extern std::set<int> storage_rpc_req_codes;
 
 class task_spec : public extensible_object<task_spec, 4>
 {

--- a/src/core/core/task_spec.cpp
+++ b/src/core/core/task_spec.cpp
@@ -42,7 +42,7 @@ namespace dsn {
 
 constexpr int TASK_SPEC_STORE_CAPACITY = 512;
 
-std::vector<dsn::task_code> storage_rpc_req_codes;
+std::set<int> storage_rpc_req_codes;
 
 // A sequential storage maps task_code to task_spec.
 static std::array<std::unique_ptr<task_spec>, TASK_SPEC_STORE_CAPACITY> s_task_spec_store;
@@ -115,7 +115,7 @@ void task_spec::register_storage_task_code(task_code code,
     spec->rpc_request_is_write_allow_batch = allow_batch;
     spec->rpc_request_is_write_idempotent = is_idempotent;
     if (TASK_TYPE_RPC_REQUEST == type) {
-        storage_rpc_req_codes.push_back(code);
+        storage_rpc_req_codes.insert(code);
     }
 }
 

--- a/src/core/core/task_spec.cpp
+++ b/src/core/core/task_spec.cpp
@@ -42,7 +42,7 @@ namespace dsn {
 
 constexpr int TASK_SPEC_STORE_CAPACITY = 512;
 
-std::set<int> storage_rpc_req_codes;
+std::set<int> s_storage_rpc_req_codes;
 
 // A sequential storage maps task_code to task_spec.
 static std::array<std::unique_ptr<task_spec>, TASK_SPEC_STORE_CAPACITY> s_task_spec_store;
@@ -115,7 +115,7 @@ void task_spec::register_storage_task_code(task_code code,
     spec->rpc_request_is_write_allow_batch = allow_batch;
     spec->rpc_request_is_write_idempotent = is_idempotent;
     if (TASK_TYPE_RPC_REQUEST == type) {
-        storage_rpc_req_codes.insert(code);
+        s_storage_rpc_req_codes.insert(code);
     }
 }
 

--- a/src/core/core/task_spec.cpp
+++ b/src/core/core/task_spec.cpp
@@ -42,6 +42,8 @@ namespace dsn {
 
 constexpr int TASK_SPEC_STORE_CAPACITY = 512;
 
+std::vector<dsn::task_code> storage_rpc_req_codes;
+
 // A sequential storage maps task_code to task_spec.
 static std::array<std::unique_ptr<task_spec>, TASK_SPEC_STORE_CAPACITY> s_task_spec_store;
 
@@ -112,6 +114,9 @@ void task_spec::register_storage_task_code(task_code code,
     spec->rpc_request_is_write_operation = is_write_operation;
     spec->rpc_request_is_write_allow_batch = allow_batch;
     spec->rpc_request_is_write_idempotent = is_idempotent;
+    if (TASK_TYPE_RPC_REQUEST == type) {
+        storage_rpc_req_codes.push_back(code);
+    }
 }
 
 task_spec *task_spec::get(int code)

--- a/src/core/core/task_spec.cpp
+++ b/src/core/core/task_spec.cpp
@@ -42,7 +42,7 @@ namespace dsn {
 
 constexpr int TASK_SPEC_STORE_CAPACITY = 512;
 
-std::set<int> s_storage_rpc_req_codes;
+std::set<dsn::task_code> s_storage_rpc_req_codes;
 
 // A sequential storage maps task_code to task_spec.
 static std::array<std::unique_ptr<task_spec>, TASK_SPEC_STORE_CAPACITY> s_task_spec_store;

--- a/src/dist/replication/common/replication_types.cpp
+++ b/src/dist/replication/common/replication_types.cpp
@@ -435,6 +435,7 @@ void swap(mutation_update &a, mutation_update &b)
     swap(a.code, b.code);
     swap(a.serialization_type, b.serialization_type);
     swap(a.data, b.data);
+    swap(a.start_time_ns, b.start_time_ns);
     swap(a.__isset, b.__isset);
 }
 
@@ -443,6 +444,7 @@ mutation_update::mutation_update(const mutation_update &other4)
     code = other4.code;
     serialization_type = other4.serialization_type;
     data = other4.data;
+    start_time_ns = other4.start_time_ns;
     __isset = other4.__isset;
 }
 mutation_update::mutation_update(mutation_update &&other5)
@@ -450,6 +452,7 @@ mutation_update::mutation_update(mutation_update &&other5)
     code = std::move(other5.code);
     serialization_type = std::move(other5.serialization_type);
     data = std::move(other5.data);
+    start_time_ns = std::move(other5.start_time_ns);
     __isset = std::move(other5.__isset);
 }
 mutation_update &mutation_update::operator=(const mutation_update &other6)
@@ -457,6 +460,7 @@ mutation_update &mutation_update::operator=(const mutation_update &other6)
     code = other6.code;
     serialization_type = other6.serialization_type;
     data = other6.data;
+    start_time_ns = other6.start_time_ns;
     __isset = other6.__isset;
     return *this;
 }
@@ -465,6 +469,7 @@ mutation_update &mutation_update::operator=(mutation_update &&other7)
     code = std::move(other7.code);
     serialization_type = std::move(other7.serialization_type);
     data = std::move(other7.data);
+    start_time_ns = std::move(other7.start_time_ns);
     __isset = std::move(other7.__isset);
     return *this;
 }
@@ -477,6 +482,8 @@ void mutation_update::printTo(std::ostream &out) const
         << "serialization_type=" << to_string(serialization_type);
     out << ", "
         << "data=" << to_string(data);
+    out << ", "
+        << "start_time_ns=" << to_string(start_time_ns);
     out << ")";
 }
 

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -79,7 +79,7 @@ replica::replica(
 
     // init table level latency perf counters
     for (auto code : storage_rpc_req_codes) {
-        counter_str = fmt::format("table.level.{}.latency(us)@{}", code, app.app_name);
+        counter_str = fmt::format("table.level.{}.latency(ns)@{}", code, app.app_name);
         _counters_table_level_latency[code].init_app_counter("eon.replica",
                                                              counter_str.c_str(),
                                                              COUNTER_TYPE_NUMBER_PERCENTILES,
@@ -178,7 +178,7 @@ void replica::on_client_read(dsn::message_ex *request)
 
     auto iter = _counters_table_level_latency.find(request->rpc_code());
     if (iter != _counters_table_level_latency.end()) {
-        iter->second->set((dsn_now_ns() - start_time_ns) * 1e-3);
+        iter->second->set(dsn_now_ns() - start_time_ns);
     }
 }
 
@@ -306,7 +306,7 @@ void replica::execute_mutation(mutation_ptr &mu)
         for (auto update : mu->data.updates) {
             auto iter = _counters_table_level_latency.find(update.code);
             if (iter != _counters_table_level_latency.end()) {
-                iter->second->set((now_ns - update.start_time_ns) * 1e-3);
+                iter->second->set(now_ns - update.start_time_ns);
             }
         }
     }

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -414,7 +414,7 @@ void replica::init_table_level_latency_counters()
 
     for (int code = 0; code <= max_task_code; code++) {
         _counters_table_level_latency[code] = nullptr;
-        if (storage_rpc_req_codes.find(code) != storage_rpc_req_codes.end()) {
+        if (s_storage_rpc_req_codes.find(code) != s_storage_rpc_req_codes.end()) {
             std::string counter_str =
                 fmt::format("table.level.{}.latency(ns)@{}", task_code(code), _app_info.app_name);
             _counters_table_level_latency[code] =

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -300,12 +300,14 @@ void replica::execute_mutation(mutation_ptr &mu)
         }
     }
 
-    // update table level latency perf-counters
-    uint64_t now_ns = dsn_now_ns();
-    for (auto update : mu->data.updates) {
-        auto iter = _counters_table_level_latency.find(update.code);
-        if (iter != _counters_table_level_latency.end()) {
-            iter->second->set((now_ns - update.start_time_ns) * 1e-3);
+    // update table level latency perf-counters for primary partition
+    if (partition_status::PS_PRIMARY == status()) {
+        uint64_t now_ns = dsn_now_ns();
+        for (auto update : mu->data.updates) {
+            auto iter = _counters_table_level_latency.find(update.code);
+            if (iter != _counters_table_level_latency.end()) {
+                iter->second->set((now_ns - update.start_time_ns) * 1e-3);
+            }
         }
     }
 }

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -407,6 +407,9 @@ std::string replica::query_compact_state() const
     return _app->query_compact_state();
 }
 
+// Replicas on the server which serves for the same table will share the same perf-counter.
+// For example counter `table.level.RPC_RRDB_RRDB_MULTI_PUT.latency(ns)@test_table` is shared by
+// all the replicas for `test_table`.
 void replica::init_table_level_latency_counters()
 {
     int max_task_code = task_code::max();

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -414,7 +414,7 @@ void replica::init_table_level_latency_counters()
 
     for (int code = 0; code <= max_task_code; code++) {
         _counters_table_level_latency[code] = nullptr;
-        if (s_storage_rpc_req_codes.find(code) != s_storage_rpc_req_codes.end()) {
+        if (s_storage_rpc_req_codes.find(task_code(code)) != s_storage_rpc_req_codes.end()) {
             std::string counter_str =
                 fmt::format("table.level.{}.latency(ns)@{}", task_code(code), _app_info.app_name);
             _counters_table_level_latency[code] =

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -470,6 +470,7 @@ private:
     perf_counter_wrapper _counter_private_log_size;
     perf_counter_wrapper _counter_recent_write_throttling_delay_count;
     perf_counter_wrapper _counter_recent_write_throttling_reject_count;
+    std::map<dsn::task_code, perf_counter_wrapper> _counters_table_level_latency;
 
     dsn::task_tracker _tracker;
     // the thread access checker

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -372,6 +372,8 @@ private:
     // child handle error while async learn parent states
     void child_handle_async_learn_error();
 
+    void init_table_level_latency_counters();
+
 private:
     friend class ::dsn::replication::replication_checker;
     friend class ::dsn::replication::test::test_checker;
@@ -470,7 +472,7 @@ private:
     perf_counter_wrapper _counter_private_log_size;
     perf_counter_wrapper _counter_recent_write_throttling_delay_count;
     perf_counter_wrapper _counter_recent_write_throttling_reject_count;
-    std::map<dsn::task_code, perf_counter_wrapper> _counters_table_level_latency;
+    std::vector<perf_counter *> _counters_table_level_latency;
 
     dsn::task_tracker _tracker;
     // the thread access checker


### PR DESCRIPTION
Add table level latency perf-counters for all of the table read or write operations.
   1.Count all the storage request rpc codes into `std::vector<dsn::task_code> storage_rpc_req_codes`  from function register_storage_task_code, which would be called by creating storage rpc code.
   2.when a replica is created, using the replica's table name,  a list of perf counters will be created for each task code in storage_rpc_req_codes. If a perf counter was already created, it would not created repeatly.
   3.For read operations, the running time of `_app->on_request(request)` is Statisticed in function replica::on_client_read.
   4.For write operations, a variable was added in mutation_update, which name is start_time_ns. So in execute_mutation function, the running time of the write operaiton will be statisticed by `dsn_now_ns() - update.start_time_ns`.

Related issue: https://github.com/XiaoMi/pegasus/issues/406