### PR TITLE
fix(bug): resolve static initialization order problem of s_storage_rpc_req_codes

### DIFF
--- a/include/dsn/tool-api/task_spec.h
+++ b/include/dsn/tool-api/task_spec.h
@@ -139,7 +139,7 @@ class message_ex;
 class admission_controller;
 typedef void (*task_rejection_handler)(task *, admission_controller *);
 
-extern std::set<dsn::task_code> s_storage_rpc_req_codes;
+std::set<dsn::task_code> &get_storage_rpc_req_codes();
 
 class task_spec : public extensible_object<task_spec, 4>
 {

--- a/src/core/core/task_spec.cpp
+++ b/src/core/core/task_spec.cpp
@@ -42,7 +42,11 @@ namespace dsn {
 
 constexpr int TASK_SPEC_STORE_CAPACITY = 512;
 
-std::set<dsn::task_code> s_storage_rpc_req_codes;
+std::set<dsn::task_code> &get_storage_rpc_req_codes()
+{
+    static std::set<dsn::task_code> s_storage_rpc_req_codes;
+    return s_storage_rpc_req_codes;
+}
 
 // A sequential storage maps task_code to task_spec.
 static std::array<std::unique_ptr<task_spec>, TASK_SPEC_STORE_CAPACITY> s_task_spec_store;
@@ -115,7 +119,7 @@ void task_spec::register_storage_task_code(task_code code,
     spec->rpc_request_is_write_allow_batch = allow_batch;
     spec->rpc_request_is_write_idempotent = is_idempotent;
     if (TASK_TYPE_RPC_REQUEST == type) {
-        s_storage_rpc_req_codes.insert(code);
+        get_storage_rpc_req_codes().insert(code);
     }
 }
 

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -417,7 +417,8 @@ void replica::init_table_level_latency_counters()
 
     for (int code = 0; code <= max_task_code; code++) {
         _counters_table_level_latency[code] = nullptr;
-        if (s_storage_rpc_req_codes.find(task_code(code)) != s_storage_rpc_req_codes.end()) {
+        if (get_storage_rpc_req_codes().find(task_code(code)) !=
+            get_storage_rpc_req_codes().end()) {
             std::string counter_str =
                 fmt::format("table.level.{}.latency(ns)@{}", task_code(code), _app_info.app_name);
             _counters_table_level_latency[code] =


### PR DESCRIPTION
In function test of pegasus, insert into s_storage_rpc_req_codes will cause coredump, which was call by macro DEFINE_STORAGE_WRITE_RPC_CODE. But it`s normal when I runs onebox on local environment. It is caused by static initialization order probleom. Because DEFINE_STORAGE_WRITE_RPC_CODE was called first, but s_storage_rpc_req_codes was not initlized, so it produces coredump.  As description, we have a 50%-50% chance of corrupting the program.