### PR TITLE
feat: optimize tcmalloc release memory

### DIFF
--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -100,7 +100,8 @@ replication_options::replication_options()
     config_sync_interval_ms = 30000;
 
     mem_release_enabled = true;
-    mem_release_interval_ms = 86400000;
+    mem_release_check_interval_ms = 86400000;
+    mem_release_tcmalloc_max_reserved_memory_percentage = 10;
 
     lb_interval_ms = 10000;
 
@@ -479,11 +480,18 @@ void replication_options::initialize()
                                                     mem_release_enabled,
                                                     "whether to enable periodic memory release");
 
-    mem_release_interval_ms = (int)dsn_config_get_value_uint64(
+    mem_release_check_interval_ms = (int)dsn_config_get_value_uint64(
         "replication",
-        "mem_release_interval_ms",
-        mem_release_interval_ms,
-        "the replica releases its idle memory to the system every this period of time(ms)");
+        "mem_release_check_interval_ms",
+        mem_release_check_interval_ms,
+        "the replica check if should release memory to the system every this period of time(ms)");
+
+    mem_release_tcmalloc_max_reserved_memory_percentage = (int)dsn_config_get_value_uint64(
+        "replication",
+        "mem_release_tcmalloc_max_reserved_memory_percentage",
+        mem_release_tcmalloc_max_reserved_memory_percentage,
+        "if tcmalloc reserved but not-used memory exceed this percentage of application allocated "
+        "memory, replica server will release the exceeding memory back to operating system");
 
     lb_interval_ms = (int)dsn_config_get_value_uint64(
         "replication",

--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -100,7 +100,7 @@ replication_options::replication_options()
     config_sync_interval_ms = 30000;
 
     mem_release_enabled = true;
-    mem_release_check_interval_ms = 86400000;
+    mem_release_check_interval_ms = 3600000;
     mem_release_tcmalloc_max_reserved_memory_percentage = 10;
 
     lb_interval_ms = 10000;

--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -101,7 +101,7 @@ replication_options::replication_options()
 
     mem_release_enabled = true;
     mem_release_check_interval_ms = 3600000;
-    mem_release_tcmalloc_max_reserved_memory_percentage = 10;
+    mem_release_max_reserved_mem_percentage = 10;
 
     lb_interval_ms = 10000;
 
@@ -486,10 +486,10 @@ void replication_options::initialize()
         mem_release_check_interval_ms,
         "the replica check if should release memory to the system every this period of time(ms)");
 
-    mem_release_tcmalloc_max_reserved_memory_percentage = (int)dsn_config_get_value_uint64(
+    mem_release_max_reserved_mem_percentage = (int)dsn_config_get_value_uint64(
         "replication",
-        "mem_release_tcmalloc_max_reserved_memory_percentage",
-        mem_release_tcmalloc_max_reserved_memory_percentage,
+        "mem_release_max_reserved_mem_percentage",
+        mem_release_max_reserved_mem_percentage,
         "if tcmalloc reserved but not-used memory exceed this percentage of application allocated "
         "memory, replica server will release the exceeding memory back to operating system");
 

--- a/src/dist/replication/common/replication_common.h
+++ b/src/dist/replication/common/replication_common.h
@@ -104,7 +104,8 @@ public:
     int32_t config_sync_interval_ms;
 
     bool mem_release_enabled;
-    int32_t mem_release_interval_ms;
+    int32_t mem_release_check_interval_ms;
+    int32_t mem_release_tcmalloc_max_reserved_memory_percentage;
 
     int32_t lb_interval_ms;
 

--- a/src/dist/replication/common/replication_common.h
+++ b/src/dist/replication/common/replication_common.h
@@ -105,7 +105,7 @@ public:
 
     bool mem_release_enabled;
     int32_t mem_release_check_interval_ms;
-    int32_t mem_release_tcmalloc_max_reserved_memory_percentage;
+    int32_t mem_release_max_reserved_mem_percentage;
 
     int32_t lb_interval_ms;
 

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2053,6 +2053,7 @@ void replica_stub::open_service()
             return result;
         });
 
+#ifdef DSN_ENABLE_GPERF
     _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_app_command(
         {"mem-release-max-reserved-percentage"},
         "mem-release-max-reserved-percentage [num | DEFAULT]",
@@ -2079,6 +2080,7 @@ void replica_stub::open_service()
             }
             return result;
         });
+#endif
 }
 
 std::string
@@ -2204,7 +2206,9 @@ void replica_stub::close()
     dsn::command_manager::instance().deregister_command(_query_compact_command);
     dsn::command_manager::instance().deregister_command(_query_app_envs_command);
     dsn::command_manager::instance().deregister_command(_useless_dir_reserve_seconds_command);
+#ifdef DSN_ENABLE_GPERF
     dsn::command_manager::instance().deregister_command(_max_reserved_memory_percentage_command);
+#endif
 
     _kill_partition_command = nullptr;
     _deny_client_command = nullptr;

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -680,7 +680,18 @@ void replica_stub::initialize_start()
                     central_cache_free_bytes,
                     transfer_cache_free_bytes);
                 ddebug_f("Memory need_release={}", need_release);
-                ::MallocExtension::instance()->ReleaseFreeMemory();
+
+                // ::MallocExtension::instance()->ReleaseFreeMemory();
+
+                int64_t bytes_overhead = pageheap_free_bytes;
+                if (bytes_overhead > max_overhead) {
+                    int64_t extra = bytes_overhead - max_overhead;
+                    while (extra > 0) {
+                        ::MallocExtension::instance()->ReleaseToSystem(1024 * 1024);
+                        extra -= 1024 * 1024;
+                    }
+                }
+
                 ddebug("Memory release has ended...");
                 int64_t after_release_total_allocated_bytes =
                     get_tcmalloc_property("generic.current_allocated_bytes");

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -68,13 +68,13 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
       _query_compact_command(nullptr),
       _query_app_envs_command(nullptr),
       _useless_dir_reserve_seconds_command(nullptr),
-      _mem_release_max_reserved_percentage_command(nullptr),
+      _max_reserved_memory_percentage_command(nullptr),
       _deny_client(false),
       _verbose_client_log(false),
       _verbose_commit_log(false),
       _gc_disk_error_replica_interval_seconds(3600),
       _gc_disk_garbage_replica_interval_seconds(3600),
-      _mem_release_tcmalloc_max_reserved_memory_percentage(10),
+      _mem_release_max_reserved_mem_percentage(10),
       _learn_app_concurrent_count(0),
       _fs_manager(false)
 {
@@ -319,8 +319,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     _verbose_commit_log = _options.verbose_commit_log_on_start;
     _gc_disk_error_replica_interval_seconds = _options.gc_disk_error_replica_interval_seconds;
     _gc_disk_garbage_replica_interval_seconds = _options.gc_disk_garbage_replica_interval_seconds;
-    _mem_release_tcmalloc_max_reserved_memory_percentage =
-        _options.mem_release_tcmalloc_max_reserved_memory_percentage;
+    _mem_release_max_reserved_mem_percentage = _options.mem_release_max_reserved_mem_percentage;
 
     // clear dirs if need
     if (clear) {
@@ -2054,32 +2053,32 @@ void replica_stub::open_service()
             return result;
         });
 
-    _mem_release_max_reserved_percentage_command =
-        dsn::command_manager::instance().register_app_command(
-            {"mem-release-max-reserved-percentage"},
-            "mem-release-max-reserved-percentage [num | DEFAULT]",
-            "control tcmalloc max reserved but not-used memory percentage",
-            [this](const std::vector<std::string> &args) {
-                std::string result("OK");
-                if (args.empty()) {
-                    result = "mem-release-max-reserved-percentage=" +
-                             std::to_string(_mem_release_tcmalloc_max_reserved_memory_percentage);
-                } else {
-                    if (args[0] == "DEFAULT") {
-                        _mem_release_tcmalloc_max_reserved_memory_percentage =
-                            _options.mem_release_tcmalloc_max_reserved_memory_percentage;
-                    } else {
-                        int32_t percentage = 0;
-                        if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 ||
-                            percentage >= 100) {
-                            result = std::string("ERR: invalid arguments");
-                        } else {
-                            _mem_release_tcmalloc_max_reserved_memory_percentage = percentage;
-                        }
-                    }
-                }
+    _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_app_command(
+        {"mem-release-max-reserved-percentage"},
+        "mem-release-max-reserved-percentage [num | DEFAULT]",
+        "control tcmalloc max reserved but not-used memory percentage",
+        [this](const std::vector<std::string> &args) {
+            std::string result("OK");
+            if (args.empty()) {
+                // show current value
+                result = "mem-release-max-reserved-percentage = " +
+                         std::to_string(_mem_release_max_reserved_mem_percentage);
                 return result;
-            });
+            }
+            if (args[0] == "DEFAULT") {
+                // set to default value
+                _mem_release_max_reserved_mem_percentage =
+                    _options.mem_release_max_reserved_mem_percentage;
+                return result;
+            }
+            int32_t percentage = 0;
+            if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 || percentage >= 100) {
+                result = std::string("ERR: invalid arguments");
+            } else {
+                _mem_release_max_reserved_mem_percentage = percentage;
+            }
+            return result;
+        });
 }
 
 std::string
@@ -2205,8 +2204,7 @@ void replica_stub::close()
     dsn::command_manager::instance().deregister_command(_query_compact_command);
     dsn::command_manager::instance().deregister_command(_query_app_envs_command);
     dsn::command_manager::instance().deregister_command(_useless_dir_reserve_seconds_command);
-    dsn::command_manager::instance().deregister_command(
-        _mem_release_max_reserved_percentage_command);
+    dsn::command_manager::instance().deregister_command(_max_reserved_memory_percentage_command);
 
     _kill_partition_command = nullptr;
     _deny_client_command = nullptr;
@@ -2216,7 +2214,7 @@ void replica_stub::close()
     _query_compact_command = nullptr;
     _query_app_envs_command = nullptr;
     _useless_dir_reserve_seconds_command = nullptr;
-    _mem_release_max_reserved_percentage_command = nullptr;
+    _max_reserved_memory_percentage_command = nullptr;
 
     if (_config_sync_timer_task != nullptr) {
         _config_sync_timer_task->cancel(true);
@@ -2355,7 +2353,7 @@ void replica_stub::gc_tcmalloc_memory()
     }
 
     int64_t max_reserved_bytes =
-        total_allocated_bytes * _mem_release_tcmalloc_max_reserved_memory_percentage / 100.0;
+        total_allocated_bytes * _mem_release_max_reserved_mem_percentage / 100.0;
     if (reserved_bytes > max_reserved_bytes) {
         int64_t release_bytes = reserved_bytes - max_reserved_bytes;
         ddebug_f("Memory release started, almost {} bytes will be released", release_bytes);

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2337,7 +2337,10 @@ replica_stub::get_child_dir(const char *app_type, gpid child_pid, const std::str
 }
 
 #ifdef DSN_ENABLE_GPERF
-int64_t replica_stub::get_tcmalloc_numeric_property(const char *prop)
+// Get tcmalloc numeric property (name is "prop") value.
+// Return -1 if get property failed (property we used will be greater than zero)
+// Properties can be found in 'gperftools/malloc_extension.h'
+static int64_t get_tcmalloc_numeric_property(const char *prop)
 {
     size_t value;
     if (!::MallocExtension::instance()->GetNumericProperty(prop, &value)) {

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -666,13 +666,12 @@ void replica_stub::initialize_start()
                     get_tcmalloc_property("tcmalloc.central_cache_free_bytes");
                 int64_t transfer_cache_free_bytes =
                     get_tcmalloc_property("tcmalloc.transfer_cache_free_bytes");
-                int64_t max_overhead = current_allocated_bytes * 10 / 100;
+                int64_t max_overhead = current_allocated_bytes * 5 / 100;
                 bool need_release = pageheap_free_bytes > max_overhead;
 
-                ddebug_f("Memory total_allocated={}, pageheap_free={}, need_release={}",
+                ddebug_f("Memory total_allocated={}, pageheap_free={}",
                          current_allocated_bytes,
-                         pageheap_free_bytes,
-                         need_release);
+                         pageheap_free_bytes);
                 ddebug_f(
                     "Memory total_thread_cache={}, thread_cache_free={}, central_cache_free={}, "
                     "transfer_free={}",
@@ -680,6 +679,7 @@ void replica_stub::initialize_start()
                     thread_cache_free_bytes,
                     central_cache_free_bytes,
                     transfer_cache_free_bytes);
+                ddebug_f("Memory need_release={}", need_release);
                 ::MallocExtension::instance()->ReleaseFreeMemory();
                 ddebug("Memory release has ended...");
                 int64_t after_release_total_allocated_bytes =

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -315,12 +315,14 @@ private:
     dsn_handle_t _query_compact_command;
     dsn_handle_t _query_app_envs_command;
     dsn_handle_t _useless_dir_reserve_seconds_command;
+    dsn_handle_t _mem_release_max_reserved_percentage_command;
 
     bool _deny_client;
     bool _verbose_client_log;
     bool _verbose_commit_log;
     int32_t _gc_disk_error_replica_interval_seconds;
     int32_t _gc_disk_garbage_replica_interval_seconds;
+    int32_t _mem_release_tcmalloc_max_reserved_memory_percentage;
 
     // we limit LT_APP max concurrent count, because nfs service implementation is
     // too simple, it do not support priority.

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -315,14 +315,14 @@ private:
     dsn_handle_t _query_compact_command;
     dsn_handle_t _query_app_envs_command;
     dsn_handle_t _useless_dir_reserve_seconds_command;
-    dsn_handle_t _mem_release_max_reserved_percentage_command;
+    dsn_handle_t _max_reserved_memory_percentage_command;
 
     bool _deny_client;
     bool _verbose_client_log;
     bool _verbose_commit_log;
     int32_t _gc_disk_error_replica_interval_seconds;
     int32_t _gc_disk_garbage_replica_interval_seconds;
-    int32_t _mem_release_tcmalloc_max_reserved_memory_percentage;
+    int32_t _mem_release_max_reserved_mem_percentage;
 
     // we limit LT_APP max concurrent count, because nfs service implementation is
     // too simple, it do not support priority.

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -246,6 +246,16 @@ private:
                          partition_status::type status,
                          error_code error);
 
+#ifdef DSN_ENABLE_GPERF
+    // Get tcmalloc numeric property (name is "prop") value.
+    // Return -1 if get property failed (property we used will be greater than zero)
+    // Properties can be found in 'gperftools/malloc_extension.h'
+    int64_t get_tcmalloc_numeric_property(const char *prop);
+
+    // Try to release tcmalloc memory back to operating system
+    void gc_tcmalloc_memory();
+#endif
+
 private:
     friend class ::dsn::replication::replication_checker;
     friend class ::dsn::replication::test::test_checker;

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -247,11 +247,6 @@ private:
                          error_code error);
 
 #ifdef DSN_ENABLE_GPERF
-    // Get tcmalloc numeric property (name is "prop") value.
-    // Return -1 if get property failed (property we used will be greater than zero)
-    // Properties can be found in 'gperftools/malloc_extension.h'
-    int64_t get_tcmalloc_numeric_property(const char *prop);
-
     // Try to release tcmalloc memory back to operating system
     void gc_tcmalloc_memory();
 #endif


### PR DESCRIPTION
## What this pr solved
Pull request #278 add a new feature that releasing memory periodically by tcmalloc `ReleaseFreeMemory`. `ReleaseFreeMemory` will release all tcmalloc reserved and not-used memory back to operating system. Releasing memory will lock `page heap`, the structure used to allocate memory from operating system and release memory back to operating system, shared by all threads. As a result, releasing all free memory will lock `page heap` for a long time and block all threads, more seriously, it will affect cluster performance. More tcmalloc information can be find in [tcmalloc website](https://gperftools.github.io/gperftools/tcmalloc.html).

So we optimize the releasing memory method, which is similar to kudu's way [(kudu gc_memory).](https://github.com/apache/kudu/blob/3d57198663f3ed6980f4d92720963ddd0f3a1471/src/kudu/util/process_memory.cc#L140) 
We use tcmalloc statistics below:
```
'tcmalloc.pageheap_free_bytes' - tcmalloc reserved but not-used memory
'generic.current_allocated_bytes' - application whole allocated memory
```
We set a maximum percentage `p`, we assume that tcmalloc reserved but not-used memory should not be greater `whole_used_memory * p`, if exceed this threshold, we will release the exceeding memory by `ReleaseToSystem`. To avoid locking `page heap` for a long time, we only release 1MB at a time.

Besides, we make such percentage `mem_release_max_reserved_mem_percentage` configurable dynamically. Cluster administrator can show and change this value by `remote_command`.
```
>>> remote_command -t replica-server replica.mem-release-max-reserved-percentage 5
COMMAND: replica.mem-release-max-reserved-percentage 5

CALL [replica-server] [ip1:port1] succeed: OK
CALL [replica-server] [ip2:port2] succeed: OK
CALL [replica-server] [ip3:port3] succeed: OK

Succeed count: 3
Failed count: 0

```

```
>>> remote_command -t replica-server replica.mem-release-max-reserved-percentage
COMMAND: replica.mem-release-max-reserved-percentage

CALL [replica-server] [[ip1:port1] succeed: mem-release-max-reserved-percentage=5
CALL [replica-server] [[ip2:port2] succeed: mem-release-max-reserved-percentage=5
CALL [replica-server] [[ip3:port3] succeed: mem-release-max-reserved-percentage=5

Succeed count: 3
Failed count: 0

```
## Config updates
Add two new config
```
mem_release_check_interval_ms = 3600000;
mem_release_max_reserved_mem_percentage = 10;
```
remove config `mem_release_interval_ms`
