### PR TITLE
feat: add http interface to get perf counter info

### DIFF
--- a/include/dsn/perf_counter/perf_counters.h
+++ b/include/dsn/perf_counter/perf_counters.h
@@ -72,6 +72,11 @@ public:
     ///
     bool remove_counter(const char *full_name);
 
+    ///
+    /// get perf counter by full name
+    ///
+    perf_counter_ptr get_counter(const std::string &full_name);
+
     struct counter_snapshot
     {
         double value{0.0};

--- a/include/dsn/perf_counter/perf_counters.h
+++ b/include/dsn/perf_counter/perf_counters.h
@@ -72,9 +72,6 @@ public:
     ///
     bool remove_counter(const char *full_name);
 
-    ///
-    /// get perf counter by full name
-    ///
     perf_counter_ptr get_counter(const std::string &full_name);
 
     struct counter_snapshot

--- a/src/core/perf_counter/perf_counters.cpp
+++ b/src/core/perf_counter/perf_counters.cpp
@@ -27,19 +27,19 @@
 #include <regex>
 
 #include <dsn/perf_counter/perf_counter.h>
-#include <dsn/perf_counter/perf_counter_utils.h>
 #include <dsn/perf_counter/perf_counters.h>
+#include <dsn/perf_counter/perf_counter_utils.h>
 
-#include <dsn/cpp/json_helper.h>
 #include <dsn/cpp/service_app.h>
+#include <dsn/cpp/json_helper.h>
 
 #include <dsn/tool-api/command_manager.h>
 #include <dsn/tool-api/task.h>
 #include <dsn/utility/string_view.h>
 
+#include "perf_counter_atomic.h"
 #include "builtin_counters.h"
 #include "core/core/service_engine.h"
-#include "perf_counter_atomic.h"
 
 namespace dsn {
 
@@ -47,16 +47,14 @@ perf_counters::perf_counters()
 {
     command_manager::instance().register_command(
         {"perf-counters"},
-        "perf-counters - query perf counters, filtered by OR "
-        "of POSIX basic regular expressions",
+        "perf-counters - query perf counters, filtered by OR of POSIX basic regular expressions",
         "perf-counters [regexp]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_regexp(args);
         });
     command_manager::instance().register_command(
         {"perf-counters-by-substr"},
-        "perf-counters-by-substr - query perf "
-        "counters, filtered by OR of substrs",
+        "perf-counters-by-substr - query perf counters, filtered by OR of substrs",
         "perf-counters-by-substr [substr]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_literal(
@@ -66,8 +64,7 @@ perf_counters::perf_counters()
         });
     command_manager::instance().register_command(
         {"perf-counters-by-prefix"},
-        "perf-counters-by-prefix - query perf "
-        "counters, filtered by OR of prefix strings",
+        "perf-counters-by-prefix - query perf counters, filtered by OR of prefix strings",
         "perf-counters-by-prefix [prefix]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_literal(
@@ -78,9 +75,7 @@ perf_counters::perf_counters()
         });
     command_manager::instance().register_command(
         {"perf-counters-by-postfix"},
-        "perf-counters-by-postfix - query perf "
-        "counters, filtered by OR of postfix "
-        "strings",
+        "perf-counters-by-postfix - query perf counters, filtered by OR of postfix strings",
         "perf-counters-by-postfix [postfix]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_literal(

--- a/src/core/perf_counter/perf_counters.cpp
+++ b/src/core/perf_counter/perf_counters.cpp
@@ -166,7 +166,7 @@ bool perf_counters::remove_counter(const char *full_name)
 
 perf_counter_ptr perf_counters::get_counter(const std::string &full_name)
 {
-    utils::auto_write_lock l(_lock);
+    utils::auto_read_lock l(_lock);
     auto it = _counters.find(full_name);
     if (it != _counters.end())
         return it->second.counter;

--- a/src/core/perf_counter/perf_counters.cpp
+++ b/src/core/perf_counter/perf_counters.cpp
@@ -27,19 +27,19 @@
 #include <regex>
 
 #include <dsn/perf_counter/perf_counter.h>
-#include <dsn/perf_counter/perf_counters.h>
 #include <dsn/perf_counter/perf_counter_utils.h>
+#include <dsn/perf_counter/perf_counters.h>
 
-#include <dsn/cpp/service_app.h>
 #include <dsn/cpp/json_helper.h>
+#include <dsn/cpp/service_app.h>
 
 #include <dsn/tool-api/command_manager.h>
 #include <dsn/tool-api/task.h>
 #include <dsn/utility/string_view.h>
 
-#include "perf_counter_atomic.h"
 #include "builtin_counters.h"
 #include "core/core/service_engine.h"
+#include "perf_counter_atomic.h"
 
 namespace dsn {
 
@@ -47,14 +47,16 @@ perf_counters::perf_counters()
 {
     command_manager::instance().register_command(
         {"perf-counters"},
-        "perf-counters - query perf counters, filtered by OR of POSIX basic regular expressions",
+        "perf-counters - query perf counters, filtered by OR "
+        "of POSIX basic regular expressions",
         "perf-counters [regexp]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_regexp(args);
         });
     command_manager::instance().register_command(
         {"perf-counters-by-substr"},
-        "perf-counters-by-substr - query perf counters, filtered by OR of substrs",
+        "perf-counters-by-substr - query perf "
+        "counters, filtered by OR of substrs",
         "perf-counters-by-substr [substr]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_literal(
@@ -64,7 +66,8 @@ perf_counters::perf_counters()
         });
     command_manager::instance().register_command(
         {"perf-counters-by-prefix"},
-        "perf-counters-by-prefix - query perf counters, filtered by OR of prefix strings",
+        "perf-counters-by-prefix - query perf "
+        "counters, filtered by OR of prefix strings",
         "perf-counters-by-prefix [prefix]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_literal(
@@ -75,7 +78,9 @@ perf_counters::perf_counters()
         });
     command_manager::instance().register_command(
         {"perf-counters-by-postfix"},
-        "perf-counters-by-postfix - query perf counters, filtered by OR of postfix strings",
+        "perf-counters-by-postfix - query perf "
+        "counters, filtered by OR of postfix "
+        "strings",
         "perf-counters-by-postfix [postfix]...",
         [](const std::vector<std::string> &args) {
             return perf_counters::instance().list_snapshot_by_literal(
@@ -157,6 +162,16 @@ bool perf_counters::remove_counter(const char *full_name)
 
     dinfo("performance counter %s is removed, remaining reference (%d)", full_name, remain_ref);
     return true;
+}
+
+perf_counter_ptr perf_counters::get_counter(const std::string &full_name)
+{
+    utils::auto_write_lock l(_lock);
+    auto it = _counters.find(full_name);
+    if (it != _counters.end())
+        return it->second.counter;
+
+    return nullptr;
 }
 
 perf_counter *perf_counters::new_counter(const char *app,

--- a/src/core/tests/perf_counters_test.cpp
+++ b/src/core/tests/perf_counters_test.cpp
@@ -317,3 +317,36 @@ TEST(perf_counters_test, query_snapshot_by_regexp)
     printf("got timestamp: %s\n", info.timestamp_str.c_str());
     ASSERT_TRUE(info.counters.empty());
 }
+
+TEST(perf_counters_test, get_by_fullname)
+{
+    struct test_case
+    {
+        const char *app;
+        const char *section;
+        const char *name;
+        dsn_perf_counter_type_t type;
+        const char *dsptr;
+        bool create;
+    } tests[] = {{"replica", "eon", "get_by_fullname1", COUNTER_TYPE_NUMBER, "pf1", false},
+                 {"replica", "eon", "get_by_fullname2", COUNTER_TYPE_NUMBER, "pf2", true}};
+
+    for (auto test : tests) {
+        // precondition: make sure the perf counter doesn't exist
+        std::string perf_counter_name;
+        perf_counter::build_full_name(test.app, test.section, test.name, perf_counter_name);
+        perf_counters::instance().remove_counter(perf_counter_name.c_str());
+
+        if (test.create) {
+            // create perf counter
+            perf_counters::instance().get_global_counter(
+                test.app, test.section, test.name, test.type, test.dsptr, true);
+            ASSERT_NE(nullptr, perf_counters::instance().get_counter(perf_counter_name));
+
+            // clean up after execution
+            perf_counters::instance().remove_counter(perf_counter_name.c_str());
+        } else {
+            ASSERT_EQ(nullptr, perf_counters::instance().get_counter(perf_counter_name));
+        }
+    }
+}

--- a/src/core/tests/perf_counters_test.cpp
+++ b/src/core/tests/perf_counters_test.cpp
@@ -339,12 +339,9 @@ TEST(perf_counters_test, get_by_fullname)
 
         if (test.create) {
             // create perf counter
-            perf_counters::instance().get_global_counter(
-                test.app, test.section, test.name, test.type, test.dsptr, true);
+            perf_counter_wrapper counter;
+            counter.init_global_counter(test.app, test.section, test.name, test.type, test.dsptr);
             ASSERT_NE(nullptr, perf_counters::instance().get_counter(perf_counter_name));
-
-            // clean up after execution
-            perf_counters::instance().remove_counter(perf_counter_name.c_str());
         } else {
             ASSERT_EQ(nullptr, perf_counters::instance().get_counter(perf_counter_name));
         }

--- a/src/dist/http/http_server.cpp
+++ b/src/dist/http/http_server.cpp
@@ -10,6 +10,7 @@
 #include "http_message_parser.h"
 #include "root_http_service.h"
 #include "pprof_http_service.h"
+#include "perf_counter_http_service.h"
 
 namespace dsn {
 
@@ -44,6 +45,8 @@ http_server::http_server() : serverlet<http_server>("http_server")
 #ifdef DSN_ENABLE_GPERF
     add_service(new pprof_http_service());
 #endif // DSN_ENABLE_GPERF
+
+    add_service(new perf_counter_http_service());
 }
 
 void http_server::serve(message_ex *msg)

--- a/src/dist/http/perf_counter_http_service.cpp
+++ b/src/dist/http/perf_counter_http_service.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <dsn/utility/output_utils.h>
+#include "perf_counter_http_service.h"
+
+namespace dsn {
+
+void perf_counter_http_service::get_perf_counter_handler(const http_request &req,
+                                                         http_response &resp)
+{
+    std::string perf_counter_name;
+    for (const auto &p : req.query_args) {
+        if ("name" == p.first) {
+            perf_counter_name = p.second;
+        } else {
+            resp.status_code = http_status_code::bad_request;
+            return;
+        }
+    }
+
+    // get perf counter by perf counter name
+    perf_counter_ptr perf_counter = perf_counters::instance().get_counter(perf_counter_name);
+
+    // insert perf counter info into table printer
+    dsn::utils::table_printer tp;
+    if (perf_counter) {
+        tp.add_row_name_and_data("name", perf_counter_name);
+        if (COUNTER_TYPE_NUMBER_PERCENTILES == perf_counter->type()) {
+            tp.add_row_name_and_data("p99", perf_counter->get_percentile(COUNTER_PERCENTILE_99));
+            tp.add_row_name_and_data("p999", perf_counter->get_percentile(COUNTER_PERCENTILE_999));
+        } else {
+            tp.add_row_name_and_data("value", perf_counter->get_value());
+        }
+        tp.add_row_name_and_data("type", perf_counter->type());
+        tp.add_row_name_and_data("descriptor", perf_counter->dsptr());
+    }
+
+    std::ostringstream out;
+    tp.output(out, dsn::utils::table_printer::output_format::kJsonCompact);
+    resp.body = out.str();
+    resp.status_code = http_status_code::ok;
+}
+}

--- a/src/dist/http/perf_counter_http_service.cpp
+++ b/src/dist/http/perf_counter_http_service.cpp
@@ -42,4 +42,4 @@ void perf_counter_http_service::get_perf_counter_handler(const http_request &req
     resp.body = out.str();
     resp.status_code = http_status_code::ok;
 }
-}
+} // namespace dsn

--- a/src/dist/http/perf_counter_http_service.cpp
+++ b/src/dist/http/perf_counter_http_service.cpp
@@ -33,8 +33,8 @@ void perf_counter_http_service::get_perf_counter_handler(const http_request &req
         } else {
             tp.add_row_name_and_data("value", perf_counter->get_value());
         }
-        tp.add_row_name_and_data("type", perf_counter->type());
-        tp.add_row_name_and_data("descriptor", perf_counter->dsptr());
+        tp.add_row_name_and_data("type", dsn_counter_type_to_string(perf_counter->type()));
+        tp.add_row_name_and_data("description", perf_counter->dsptr());
     }
 
     std::ostringstream out;

--- a/src/dist/http/perf_counter_http_service.h
+++ b/src/dist/http/perf_counter_http_service.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <dsn/tool-api/http_server.h>
+
+namespace dsn {
+
+class perf_counter_http_service : public http_service
+{
+public:
+    perf_counter_http_service()
+    {
+        // GET ip:port/perfCounter?name={perf_counter_name}
+        register_handler("",
+                         std::bind(&perf_counter_http_service::get_perf_counter_handler,
+                                   this,
+                                   std::placeholders::_1,
+                                   std::placeholders::_2));
+    }
+
+    std::string path() const override { return "perfCounter"; }
+
+    void get_perf_counter_handler(const http_request &req, http_response &resp);
+};
+}

--- a/src/dist/http/perf_counter_http_service.h
+++ b/src/dist/http/perf_counter_http_service.h
@@ -25,4 +25,4 @@ public:
 
     void get_perf_counter_handler(const http_request &req, http_response &resp);
 };
-}
+} // namespace dsn

--- a/src/dist/http/test/perf_counter_http_service_test.cpp
+++ b/src/dist/http/test/perf_counter_http_service_test.cpp
@@ -32,8 +32,8 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
 
     for (auto test : tests) {
         // create perf counter
-        perf_counters::instance().get_global_counter(
-            test.app, test.section, test.name, test.type, test.dsptr, true);
+        perf_counter_wrapper counter;
+        counter.init_global_counter(test.app, test.section, test.name, test.type, test.dsptr);
 
         std::string perf_counter_name;
         perf_counter::build_full_name(test.app, test.section, test.name, perf_counter_name);
@@ -60,9 +60,6 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
 
         ASSERT_EQ(fake_resp.status_code, http_status_code::ok);
         ASSERT_EQ(fake_resp.body, fake_json);
-
-        // clean up after execution
-        perf_counters::instance().remove_counter(perf_counter_name.c_str());
     }
 }
 } // namespace dsn

--- a/src/dist/http/test/perf_counter_http_service_test.cpp
+++ b/src/dist/http/test/perf_counter_http_service_test.cpp
@@ -12,12 +12,7 @@ namespace dsn {
 class perf_counter_http_service_test : public testing::Test
 {
 public:
-    perf_counter_http_service_test()
-    {
-        _perf_counter_http_service = dsn::make_unique<perf_counter_http_service>();
-    }
-
-    std::unique_ptr<perf_counter_http_service> _perf_counter_http_service;
+    perf_counter_http_service _perf_counter_http_service;
 };
 
 TEST_F(perf_counter_http_service_test, get_perf_counter)
@@ -47,7 +42,7 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
         http_request fake_req;
         http_response fake_resp;
         fake_req.query_args.emplace("name", perf_counter_name);
-        _perf_counter_http_service->get_perf_counter_handler(fake_req, fake_resp);
+        _perf_counter_http_service.get_perf_counter_handler(fake_req, fake_resp);
 
         // get fake json based on the perf counter info which is getting above
         std::string fake_json;
@@ -67,4 +62,4 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
         ASSERT_EQ(fake_resp.body, fake_json);
     }
 }
-}
+} // namespace dsn

--- a/src/dist/http/test/perf_counter_http_service_test.cpp
+++ b/src/dist/http/test/perf_counter_http_service_test.cpp
@@ -48,8 +48,7 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
         std::string fake_json;
         if (COUNTER_TYPE_NUMBER_PERCENTILES == test.type) {
             fake_json = R"({"name":")" + perf_counter_name + R"(",)" +
-                        R"("p99":"0.00",)" +
-                        R"("p999":"0.00",)" +
+                        R"("p99":"0.00","p999":"0.00",)" +
                         R"("type":")" + std::to_string(test.type) + R"(",)" +
                         R"("descriptor":")" + test.dsptr + R"("})" + "\n";
         } else {
@@ -58,8 +57,12 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
                         R"("type":")" + std::to_string(test.type) + R"(",)" +
                         R"("descriptor":")" + test.dsptr + R"("})" + "\n";
         }
+
         ASSERT_EQ(fake_resp.status_code, http_status_code::ok);
         ASSERT_EQ(fake_resp.body, fake_json);
+
+        // clean up after execution
+        perf_counters::instance().remove_counter(perf_counter_name.c_str());
     }
 }
 } // namespace dsn

--- a/src/dist/http/test/perf_counter_http_service_test.cpp
+++ b/src/dist/http/test/perf_counter_http_service_test.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2018, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include <dsn/perf_counter/perf_counters.h>
+#include <dsn/tool-api/http_server.h>
+#include <dist/http/perf_counter_http_service.h>
+
+namespace dsn {
+
+class perf_counter_http_service_test : public testing::Test
+{
+public:
+    perf_counter_http_service_test()
+    {
+        _perf_counter_http_service = dsn::make_unique<perf_counter_http_service>();
+    }
+
+    std::unique_ptr<perf_counter_http_service> _perf_counter_http_service;
+};
+
+TEST_F(perf_counter_http_service_test, get_perf_counter)
+{
+    struct test_case
+    {
+        const char *app;
+        const char *section;
+        const char *name;
+        dsn_perf_counter_type_t type;
+        const char *dsptr;
+    } tests[] = {
+        {"replica", "http", "number", COUNTER_TYPE_NUMBER, "number type"},
+        {"replica", "http", "volatile", COUNTER_TYPE_VOLATILE_NUMBER, "volatile type"},
+        {"replica", "http", "rate", COUNTER_TYPE_RATE, "rate type"},
+        {"replica", "http", "percentline", COUNTER_TYPE_NUMBER_PERCENTILES, "percentline type"}};
+
+    for (auto test : tests) {
+        // create perf counter
+        perf_counters::instance().get_global_counter(
+            test.app, test.section, test.name, test.type, test.dsptr, true);
+
+        std::string perf_counter_name;
+        perf_counter::build_full_name(test.app, test.section, test.name, perf_counter_name);
+
+        // get perf counter info through the http interface
+        http_request fake_req;
+        http_response fake_resp;
+        fake_req.query_args.emplace("name", perf_counter_name);
+        _perf_counter_http_service->get_perf_counter_handler(fake_req, fake_resp);
+
+        // get fake json based on the perf counter info which is getting above
+        std::string fake_json;
+        if (COUNTER_TYPE_NUMBER_PERCENTILES == test.type) {
+            fake_json = R"({"name":")" + perf_counter_name + R"(",)" +
+                        R"("p99":"0.00",)" +
+                        R"("p999":"0.00",)" +
+                        R"("type":")" + std::to_string(test.type) + R"(",)" +
+                        R"("descriptor":")" + test.dsptr + R"("})" + "\n";
+        } else {
+            fake_json = R"({"name":")" + perf_counter_name + R"(",)" +
+                        R"("value":"0.00",)" +
+                        R"("type":")" + std::to_string(test.type) + R"(",)" +
+                        R"("descriptor":")" + test.dsptr + R"("})" + "\n";
+        }
+        ASSERT_EQ(fake_resp.status_code, http_status_code::ok);
+        ASSERT_EQ(fake_resp.body, fake_json);
+    }
+}
+}

--- a/src/dist/http/test/perf_counter_http_service_test.cpp
+++ b/src/dist/http/test/perf_counter_http_service_test.cpp
@@ -23,7 +23,7 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
         const char *section;
         const char *name;
         dsn_perf_counter_type_t type;
-        const char *dsptr;
+        const char *description;
     } tests[] = {
         {"replica", "http", "number", COUNTER_TYPE_NUMBER, "number type"},
         {"replica", "http", "volatile", COUNTER_TYPE_VOLATILE_NUMBER, "volatile type"},
@@ -33,7 +33,7 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
     for (auto test : tests) {
         // create perf counter
         perf_counter_wrapper counter;
-        counter.init_global_counter(test.app, test.section, test.name, test.type, test.dsptr);
+        counter.init_global_counter(test.app, test.section, test.name, test.type, test.description);
 
         std::string perf_counter_name;
         perf_counter::build_full_name(test.app, test.section, test.name, perf_counter_name);
@@ -49,13 +49,13 @@ TEST_F(perf_counter_http_service_test, get_perf_counter)
         if (COUNTER_TYPE_NUMBER_PERCENTILES == test.type) {
             fake_json = R"({"name":")" + perf_counter_name + R"(",)" +
                         R"("p99":"0.00","p999":"0.00",)" +
-                        R"("type":")" + std::to_string(test.type) + R"(",)" +
-                        R"("descriptor":")" + test.dsptr + R"("})" + "\n";
+                        R"("type":")" + dsn_counter_type_to_string(test.type) + R"(",)" +
+                        R"("description":")" + test.description + R"("})" + "\n";
         } else {
             fake_json = R"({"name":")" + perf_counter_name + R"(",)" +
                         R"("value":"0.00",)" +
-                        R"("type":")" + std::to_string(test.type) + R"(",)" +
-                        R"("descriptor":")" + test.dsptr + R"("})" + "\n";
+                        R"("type":")" + dsn_counter_type_to_string(test.type) + R"(",)" +
+                        R"("description":")" + test.description + R"("})" + "\n";
         }
 
         ASSERT_EQ(fake_resp.status_code, http_status_code::ok);


### PR DESCRIPTION
Add a  http interface to get perf counter info by the name of this perf counter.

request url: 
```
http://127.0.0.1:34803/perfCounter?name=replica*eon.replica*table.level.RPC_RRDB_RRDB_PUT.latency(ns)@temp
```

response:
```
{"name":"replica*eon.replica*table.level.RPC_RRDB_RRDB_PUT.latency(ns)@temp","p99":"0.00","p999":"0.00","type":"PERCENTILE","description":"table.level.RPC_RRDB_RRDB_PUT.latency(ns)@temp"}
```