### PR TITLE
fix: fix the bug that threads don't stop when shared_io_service is released

### DIFF
--- a/src/core/tools/common/shared_io_service.h
+++ b/src/core/tools/common/shared_io_service.h
@@ -69,8 +69,8 @@ public:
     ~shared_io_service()
     {
         ios.stop();
-        for (int i = 0; i < _io_service_worker_count; i++) {
-            _workers[i]->join();
+        for (auto worker : _workers) {
+            worker->join();
         }
     }
 

--- a/src/core/tools/common/shared_io_service.h
+++ b/src/core/tools/common/shared_io_service.h
@@ -66,6 +66,14 @@ public:
         }
     }
 
+    ~shared_io_service()
+    {
+        ios.stop();
+        for (int i = 0; i < _io_service_worker_count; i++) {
+            _workers[i]->join();
+        }
+    }
+
     boost::asio::io_service ios;
 
 private:


### PR DESCRIPTION
In shared_io_service, there are some threads running. But shared_io_service doesn't have a destructor, so these threads can't be stopped.
So this pull request add a destructor for it to stop these threads.