### PR TITLE
feat(dup): add init_duplicating on replica init info

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -49,10 +49,13 @@ public:
     decree init_durable_decree;
     int64_t init_offset_in_shared_log;
     int64_t init_offset_in_private_log;
+    bool init_duplicating;
+
     DEFINE_JSON_SERIALIZATION(init_ballot,
                               init_durable_decree,
                               init_offset_in_shared_log,
-                              init_offset_in_private_log)
+                              init_offset_in_private_log,
+                              init_duplicating)
 
 public:
     replica_init_info() { memset((void *)this, 0, sizeof(*this)); }
@@ -247,11 +250,16 @@ private:
     open_new_internal(replica *r, int64_t shared_log_start, int64_t private_log_start);
 
     const replica_init_info &init_info() const { return _info; }
+
     ::dsn::error_code update_init_info(replica *r,
                                        int64_t shared_log_offset,
                                        int64_t private_log_offset,
-                                       int64_t durable_decree);
+                                       int64_t durable_decree,
+                                       bool duplicating);
+
     ::dsn::error_code update_init_info_ballot_and_decree(replica *r);
+
+    ::dsn::error_code update_init_info_duplicating(bool duplicating);
 
 protected:
     std::string _dir_data;   // ${replica_dir}/data

--- a/src/dist/replication/lib/replica_config.cpp
+++ b/src/dist/replication/lib/replica_config.cpp
@@ -976,6 +976,7 @@ void replica::on_config_sync(const app_info &info, const partition_configuration
         return;
 
     update_app_envs(info.envs);
+    update_init_info_duplicating(info.duplicating);
 
     if (status() == partition_status::PS_PRIMARY ||
         nullptr != _primary_states.reconfiguration_task) {

--- a/src/dist/replication/lib/replica_duplicate.cpp
+++ b/src/dist/replication/lib/replica_duplicate.cpp
@@ -35,9 +35,20 @@ namespace replication {
 // of changing app_info as less as possible, we store it in .init_info
 // instead.
 
-void replica::update_init_info_duplicating(bool duplicating) { /*TBD*/}
+void replica::update_init_info_duplicating(bool duplicating)
+{
+    if (duplicating) {
+        if (!_app->init_info().init_duplicating) {
+            _app->update_init_info_duplicating(true);
+        }
+    } else {
+        if (_app->init_info().init_duplicating) {
+            _app->update_init_info_duplicating(false);
+        }
+    }
+}
 
-bool replica::is_duplicating() const { /*TBD*/ return false; }
+bool replica::is_duplicating() const { return _app->init_info().init_duplicating; }
 
 } // namespace replication
 } // namespace dsn

--- a/src/dist/replication/lib/replica_learn.cpp
+++ b/src/dist/replication/lib/replica_learn.cpp
@@ -724,7 +724,8 @@ void replica::on_learn_reply(error_code err, learn_request &&req, learn_response
             this,
             _stub->_log->on_partition_reset(get_gpid(), _app->last_committed_decree()),
             _private_log->on_partition_reset(get_gpid(), _app->last_committed_decree()),
-            _app->last_committed_decree());
+            _app->last_committed_decree(),
+            _app->init_info().init_duplicating);
 
         // switch private log to make learning easier
         _private_log->demand_switch_file();

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -948,13 +948,14 @@ void replica_stub::on_group_check(const group_check_request &request,
     }
 
     ddebug("%s@%s: received group check, primary = %s, ballot = %" PRId64
-           ", status = %s, last_committed_decree = %" PRId64,
+           ", status = %s, last_committed_decree = %" PRId64 ", confirmed_decree = %" PRId64,
            request.config.pid.to_string(),
            _primary_address_str,
            request.config.primary.to_string(),
            request.config.ballot,
            enum_to_string(request.config.status),
-           request.last_committed_decree);
+           request.last_committed_decree,
+           request.confirmed_decree);
 
     replica_ptr rep = get_replica(request.config.pid);
     if (rep != nullptr) {
@@ -1023,13 +1024,14 @@ void replica_stub::on_add_learner(const group_check_request &request)
     }
 
     ddebug("%s@%s: received add learner, primary = %s, ballot = %" PRId64
-           ", status = %s, last_committed_decree = %" PRId64,
+           ", status = %s, last_committed_decree = %" PRId64 ", confirmed_decree = %" PRId64,
            request.config.pid.to_string(),
            _primary_address_str,
            request.config.primary.to_string(),
            request.config.ballot,
            enum_to_string(request.config.status),
-           request.last_committed_decree);
+           request.last_committed_decree,
+           request.confirmed_decree);
 
     replica_ptr rep = get_replica(request.config.pid);
     if (rep != nullptr) {
@@ -2223,6 +2225,11 @@ void replica_stub::close()
     if (_config_sync_timer_task != nullptr) {
         _config_sync_timer_task->cancel(true);
         _config_sync_timer_task = nullptr;
+    }
+
+    if (_duplication_sync_timer != nullptr) {
+        _duplication_sync_timer->close();
+        _duplication_sync_timer = nullptr;
     }
 
     if (_config_query_task != nullptr) {


### PR DESCRIPTION
Duplication requires mutation-logs never being cleaned until duplicated to ensure data consistency and safety. However, when replica re-bootstraps it may lose the memory and forget if it's in duplication.
Therefore, we should add a mark when duplication is assigned on each replica, and this mark should be persisted on disk for recovery.

```cpp
class replica_init_info
{
public:
    ...
    bool init_duplicating;

```

So when this mark is used:

```cpp
bool replica::is_duplicating() const { return _app->init_info().init_duplicating; }

void replica::on_checkpoint_timer()
    decree min_confirmed_decree = _duplication_mgr->min_confirmed_decree();
    decree cleanable_decree = last_durable_decree;
    if (min_confirmed_decree >= 0) {
        if (min_confirmed_decree < last_durable_decree) {
            cleanable_decree = min_confirmed_decree;
        }
    } else {
        // protect the logs from being truncated
        // if this app is in duplication
        if (is_duplicating()) {
            // unsure if the logs can be dropped, because min_confirmed_decree
            // is currently unavailable
            return;
        }
    }
}
```

And when this mark is set:

```cpp
void replica_duplicator_manager::update_confirmed_decree_if_secondary(decree confirmed)
{
    ...
    _replica->update_init_info_duplicating(confirmed >= 0);
}
```