### PR TITLE
fix: sanitizer options don't take effect 

### DIFF
--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -301,7 +301,7 @@ function(dsn_setup_thirdparty_libs)
 endfunction(dsn_setup_thirdparty_libs)
 
 function(dsn_common_setup)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(notdir $(abspath $<))\"'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(notdir $(abspath $<))\"'" CACHE STRING "" FORCE)
 
     if(NOT (UNIX))
         message(FATAL_ERROR "Only Unix are supported.")

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -173,7 +173,6 @@ endfunction()
 function(dsn_setup_compiler_flags)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_definitions(-DDSN_BUILD_TYPE=Debug)
-        # for sanitizer
         add_definitions(-g)
     else()
         add_definitions(-g)

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -173,7 +173,7 @@ endfunction()
 function(dsn_setup_compiler_flags)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_definitions(-DDSN_BUILD_TYPE=Debug)
-        #for sanitizer
+        # for sanitizer
         add_definitions(-g)
     else()
         add_definitions(-g)

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -186,10 +186,7 @@ function(dsn_setup_compiler_flags)
     # We want access to the PRI* print format macros.
     add_definitions(-D__STDC_FORMAT_MACROS)
 
-    # -fno-omit-frame-pointer
-    #   use frame pointers to allow simple stack frame walking for backtraces.
-    #   This has a small perf hit but worth it for the ability to profile in production
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-omit-frame-pointer" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y" CACHE STRING "" FORCE)
 
     #  -Wall: Enable all warnings.
     add_compile_options(-Wall)
@@ -203,6 +200,10 @@ function(dsn_setup_compiler_flags)
     add_compile_options(-Wno-deprecated-declarations)
     add_compile_options(-Wno-inconsistent-missing-override)
     add_compile_options(-Wno-attributes)
+    # -fno-omit-frame-pointer
+    #   use frame pointers to allow simple stack frame walking for backtraces.
+    #   This has a small perf hit but worth it for the ability to profile in production
+    add_compile_options( -fno-omit-frame-pointer)
 
     find_program(CCACHE_FOUND ccache)
     if(CCACHE_FOUND)
@@ -222,8 +223,8 @@ function(dsn_setup_compiler_flags)
         endif()
 
         message(STATUS "Running cmake with sanitizer=${SANITIZER}")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZER}")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZER}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZER}" CACHE STRING "" FORCE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZER}" CACHE STRING "" FORCE)
     endif()
 
     set(CMAKE_EXE_LINKER_FLAGS

--- a/run.sh
+++ b/run.sh
@@ -65,7 +65,8 @@ function usage_build()
 }
 function run_build()
 {
-    #NOTE(jiashuo1): No memory check mode, because MemorySanitizer is only available in Clang for Linux x86_64 targets
+    # NOTE(jiashuo1): No "memory" check mode, because MemorySanitizer is only available in Clang for Linux x86_64 targets
+    # https://www.jetbrains.com/help/clion/google-sanitizers.html
     SANITIZERS=("address" "leak" "thread" "undefined")
 
     C_COMPILER="gcc"


### PR DESCRIPTION
In #359 add the sanitizer support, but in commit [e80446f](https://github.com/XiaoMi/rdsn/pull/359/commits/e80446faa6fe716bfa144368bdc72aac160c186c), the code
```
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZER}" )
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZER}" )
```
was moved into `dsn_setup_compiler_flags`  function and it don't take effect because `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` change to local variable. The pr change the code to:
```
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZER}" CACHE STRING "" FORCE)
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZER}" CACHE STRING "" FORCE)
```