### PR TITLE
fix(asan): pointer used after free in autoref_ptr_test

### DIFF
--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -120,7 +120,8 @@ public:
             _obj->add_ref();
     }
 
-    template <typename U>
+    template <typename U,
+              typename = typename std::enable_if<std::is_convertible<U *, T *>::value>::type>
     ref_ptr(const ref_ptr<U> &r)
     {
         _obj = r.get();
@@ -130,7 +131,8 @@ public:
 
     ref_ptr(ref_ptr<T> &&r) : _obj(r._obj) { r._obj = nullptr; }
 
-    template <typename U>
+    template <typename U,
+              typename = typename std::enable_if<std::is_convertible<U *, T *>::value>::type>
     ref_ptr(ref_ptr<U> &&r) : _obj(r._obj)
     {
         r._obj = nullptr;
@@ -143,85 +145,15 @@ public:
         }
     }
 
-    ref_ptr<T> &operator=(T *obj)
+    ref_ptr<T> &operator=(T *obj) { return *this = ref_ptr(obj); }
+
+    ref_ptr &operator=(ref_ptr r) noexcept
     {
-        if (_obj == obj)
-            return *this;
-
-        T *old = _obj;
-        _obj = obj;
-
-        if (_obj != nullptr) {
-            _obj->add_ref();
-        }
-
-        if (old != nullptr) {
-            old->release_ref();
-        }
-
+        swap(r);
         return *this;
     }
 
-    template <typename U>
-    ref_ptr<T> &operator=(U *obj)
-    {
-        if (_obj == obj)
-            return *this;
-
-        T *old = _obj;
-        _obj = obj;
-
-        if (_obj != nullptr) {
-            _obj->add_ref();
-        }
-
-        if (old != nullptr) {
-            old->release_ref();
-        }
-
-        return *this;
-    }
-
-    ref_ptr<T> &operator=(const ref_ptr<T> &obj) { return operator=(obj._obj); }
-
-    template <typename U>
-    ref_ptr<T> &operator=(const ref_ptr<U> &obj)
-    {
-        return operator=(obj._obj);
-    }
-
-    ref_ptr<T> &operator=(ref_ptr<T> &&obj)
-    {
-        if (this == &obj) {
-            return *this;
-        }
-
-        T *old = _obj;
-
-        _obj = obj._obj;
-        obj._obj = nullptr;
-
-        if (old != nullptr) {
-            old->release_ref();
-        }
-
-        return *this;
-    }
-
-    template <typename U>
-    ref_ptr<T> &operator=(ref_ptr<U> &&obj)
-    {
-        T *old = _obj;
-
-        _obj = obj._obj;
-        obj._obj = nullptr;
-
-        if (old != nullptr) {
-            old->release_ref();
-        }
-
-        return *this;
-    }
+    void swap(ref_ptr &r) noexcept { std::swap(_obj, r._obj); }
 
     T *get() const { return _obj; }
 

--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -35,10 +35,10 @@
 
 #pragma once
 
-#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <type_traits>
+#include <utility>
 
 namespace dsn {
 class ref_counter

--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -148,14 +148,15 @@ public:
         if (_obj == obj)
             return *this;
 
-        if (nullptr != _obj) {
-            _obj->release_ref();
-        }
-
+        T *old = _obj;
         _obj = obj;
 
-        if (obj != nullptr) {
+        if (_obj != nullptr) {
             _obj->add_ref();
+        }
+
+        if (old != nullptr) {
+            old->release_ref();
         }
 
         return *this;
@@ -166,13 +167,18 @@ public:
     {
         if (_obj == obj)
             return *this;
-        if (nullptr != _obj) {
-            _obj->release_ref();
-        }
+
+        T *old = _obj;
         _obj = obj;
+
         if (_obj != nullptr) {
             _obj->add_ref();
         }
+
+        if (old != nullptr) {
+            old->release_ref();
+        }
+
         return *this;
     }
 
@@ -190,23 +196,30 @@ public:
             return *this;
         }
 
-        if (nullptr != _obj) {
-            _obj->release_ref();
-        }
+        T *old = _obj;
 
         _obj = obj._obj;
         obj._obj = nullptr;
+
+        if (old != nullptr) {
+            old->release_ref();
+        }
+
         return *this;
     }
 
     template <typename U>
     ref_ptr<T> &operator=(ref_ptr<U> &&obj)
     {
-        if (nullptr != _obj) {
-            _obj->release_ref();
-        }
+        T *old = _obj;
+
         _obj = obj._obj;
         obj._obj = nullptr;
+
+        if (old != nullptr) {
+            old->release_ref();
+        }
+
         return *this;
     }
 

--- a/src/core/tests/autoref_ptr_test.cpp
+++ b/src/core/tests/autoref_ptr_test.cpp
@@ -40,7 +40,6 @@ public:
 
     static void reset_was_destroyed() { was_destroyed_ = false; }
 
-
 private:
     friend class dsn::ref_counter;
     ~ScopedRefPtrToSelf() { was_destroyed_ = true; }

--- a/src/core/tests/autoref_ptr_test.cpp
+++ b/src/core/tests/autoref_ptr_test.cpp
@@ -34,11 +34,13 @@ private:
 class ScopedRefPtrToSelf : public dsn::ref_counter
 {
 public:
-    ScopedRefPtrToSelf() {}
+    ScopedRefPtrToSelf() : self_ptr_(this) {}
 
     static bool was_destroyed() { return was_destroyed_; }
 
     static void reset_was_destroyed() { was_destroyed_ = false; }
+
+    dsn::ref_ptr<ScopedRefPtrToSelf> self_ptr_;
 
 private:
     friend class dsn::ref_counter;
@@ -150,9 +152,9 @@ TEST(RefCountedUnitTest, ScopedRefPtrToSelfPointerAssignment)
 {
     ScopedRefPtrToSelf::reset_was_destroyed();
 
-    dsn::ref_ptr<ScopedRefPtrToSelf> check(new ScopedRefPtrToSelf());
+    ScopedRefPtrToSelf *check = new ScopedRefPtrToSelf();
     EXPECT_FALSE(ScopedRefPtrToSelf::was_destroyed());
-    check = nullptr;
+    check->self_ptr_ = nullptr;
     EXPECT_TRUE(ScopedRefPtrToSelf::was_destroyed());
 }
 
@@ -160,12 +162,12 @@ TEST(RefCountedUnitTest, ScopedRefPtrToSelfMoveAssignment)
 {
     ScopedRefPtrToSelf::reset_was_destroyed();
 
-    dsn::ref_ptr<ScopedRefPtrToSelf> check(new ScopedRefPtrToSelf());
+    ScopedRefPtrToSelf *check = new ScopedRefPtrToSelf();
     EXPECT_FALSE(ScopedRefPtrToSelf::was_destroyed());
     // Releasing |check->self_ptr_| will delete |check|.
     // The move assignment operator must assign |check->self_ptr_| first then
     // release |check->self_ptr_|.
-    check = dsn::ref_ptr<ScopedRefPtrToSelf>();
+    check->self_ptr_ = dsn::ref_ptr<ScopedRefPtrToSelf>();
     EXPECT_TRUE(ScopedRefPtrToSelf::was_destroyed());
 }
 

--- a/src/core/tests/autoref_ptr_test.cpp
+++ b/src/core/tests/autoref_ptr_test.cpp
@@ -34,13 +34,12 @@ private:
 class ScopedRefPtrToSelf : public dsn::ref_counter
 {
 public:
-    ScopedRefPtrToSelf() : self_ptr_(this) {}
+    ScopedRefPtrToSelf() {}
 
     static bool was_destroyed() { return was_destroyed_; }
 
     static void reset_was_destroyed() { was_destroyed_ = false; }
 
-    dsn::ref_ptr<ScopedRefPtrToSelf> self_ptr_;
 
 private:
     friend class dsn::ref_counter;
@@ -152,9 +151,9 @@ TEST(RefCountedUnitTest, ScopedRefPtrToSelfPointerAssignment)
 {
     ScopedRefPtrToSelf::reset_was_destroyed();
 
-    ScopedRefPtrToSelf *check = new ScopedRefPtrToSelf();
+    dsn::ref_ptr<ScopedRefPtrToSelf> check(new ScopedRefPtrToSelf());
     EXPECT_FALSE(ScopedRefPtrToSelf::was_destroyed());
-    check->self_ptr_ = nullptr;
+    check = nullptr;
     EXPECT_TRUE(ScopedRefPtrToSelf::was_destroyed());
 }
 
@@ -162,12 +161,12 @@ TEST(RefCountedUnitTest, ScopedRefPtrToSelfMoveAssignment)
 {
     ScopedRefPtrToSelf::reset_was_destroyed();
 
-    ScopedRefPtrToSelf *check = new ScopedRefPtrToSelf();
+    dsn::ref_ptr<ScopedRefPtrToSelf> check(new ScopedRefPtrToSelf());
     EXPECT_FALSE(ScopedRefPtrToSelf::was_destroyed());
     // Releasing |check->self_ptr_| will delete |check|.
     // The move assignment operator must assign |check->self_ptr_| first then
     // release |check->self_ptr_|.
-    check->self_ptr_ = dsn::ref_ptr<ScopedRefPtrToSelf>();
+    check = dsn::ref_ptr<ScopedRefPtrToSelf>();
     EXPECT_TRUE(ScopedRefPtrToSelf::was_destroyed());
 }
 


### PR DESCRIPTION
It reports ` heap-use-after-free`  error that the pointer `self_ptr_` is used after free in `autoref_ptr_test.ScopedRefPtrToSelfPointerAssignment` when run test with [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) tool.

## Coredump:

```
#0 0x4cfb64 in operator= /home/mi/work/PegasusDB/pegasus/rdsn/include/dsn/utility/autoref_ptr.h:155
#1 0x4cfb64 in RefCountedUnitTest_ScopedRefPtrToSelfPointerAssignment_Test::TestBody() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/tests/autoref_ptr_test.cpp:157
#2 0x6aab1e in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/core/tests/dsn.core.tests+0x6aab1e)
```

## Related code:

https://github.com/XiaoMi/rdsn/blob/b35cf26999c3155aeec7aacaac7b03f22ae35c44/src/core/tests/autoref_ptr_test.cpp#L157

```cpp
TEST(RefCountedUnitTest, ScopedRefPtrToSelfPointerAssignment)
{
    ScopedRefPtrToSelf::reset_was_destroyed();

    ScopedRefPtrToSelf *check = new ScopedRefPtrToSelf();
    EXPECT_FALSE(ScopedRefPtrToSelf::was_destroyed());
    check->self_ptr_ = nullptr;
    EXPECT_TRUE(ScopedRefPtrToSelf::was_destroyed());
}
```

https://github.com/XiaoMi/rdsn/blob/8095786262560324f871ac2a831acbdbb138d0df/include/dsn/utility/autoref_ptr.h#L155

```cpp
 146     ref_ptr<T> &operator=(T *obj)
 147     {
 148         if (_obj == obj)
 149             return *this;
 150 
 151         if (nullptr != _obj) {
 152             _obj->release_ref(); // Call ~ScopedRefPtrToSelf, then call ~ref_ptr(). `this` is freed.
 153         }
 154 
 155         _obj = obj; // `this` was freed, memory of _obj was freed, it's illegal to be accessed now.
 156 
 157         if (obj != nullptr) {
 158             _obj->add_ref();
 159         }
 160 
 161         return *this;
 162     }
```

## Solution

In the semantic of `shared_ptr::operator=`, ScopedRefPtrToSelf should be deleted after the call.

> `std::shared_ptr<T>::operator=`
> If *this already owns an object and it is the last shared_ptr owning it, and r is not the same as *this, the object is destroyed through the owned deleter.

Therefore we should not use `this` pointer after we call `release_ref`, until the last line `return *this`, because C++ compiler will run RVO to eliminate the return.
