### PR TITLE
fix(asan):  global-buffer-overflow in string_conv_test

### DIFF
--- a/src/core/tests/string_conv_test.cpp
+++ b/src/core/tests/string_conv_test.cpp
@@ -87,7 +87,9 @@ TEST(string_conv, buf2int32)
     ASSERT_FALSE(dsn::buf2int32(std::to_string(std::numeric_limits<int64_t>::min()), result));
     ASSERT_FALSE(dsn::buf2int32(std::to_string(std::numeric_limits<uint64_t>::max()), result));
 
-    std::string str("123\0456", 7);
+    // "\045" is "%", so the string length=5, otherwise(2th argument > 5) it will be reported
+    // "global-buffer-overflow" error under AddressSanitizer check
+    std::string str("123\0456", 5);
     ASSERT_TRUE(dsn::buf2int32(dsn::string_view(str.data(), 2), result));
     ASSERT_EQ(result, 12);
     ASSERT_TRUE(dsn::buf2int32(dsn::string_view(str.data(), 3), result));
@@ -132,7 +134,9 @@ TEST(string_conv, buf2int64)
 
     ASSERT_FALSE(dsn::buf2int64(std::to_string(std::numeric_limits<uint64_t>::max()), result));
 
-    std::string str("123\0456", 7);
+    // "\045" is "%", so the string length=5, otherwise(2th argument > 5) it will be reported
+    // "global-buffer-overflow" error under AddressSanitizer check
+    std::string str("123\0456", 5);
     ASSERT_TRUE(dsn::buf2int64(dsn::string_view(str.data(), 2), result));
     ASSERT_EQ(result, 12);
     ASSERT_TRUE(dsn::buf2int64(dsn::string_view(str.data(), 3), result));
@@ -174,7 +178,9 @@ TEST(string_conv, buf2uint64)
     ASSERT_TRUE(dsn::buf2uint64(std::to_string(std::numeric_limits<uint64_t>::min()), result));
     ASSERT_EQ(result, std::numeric_limits<uint64_t>::min());
 
-    std::string str("123\0456", 7);
+    // "\045" is "%", so the string length=5, otherwise(2th argument > 5) it will be reported
+    // "global-buffer-overflow" error under AddressSanitizer check
+    std::string str("123\0456", 5);
     ASSERT_TRUE(dsn::buf2uint64(dsn::string_view(str.data(), 2), result));
     ASSERT_EQ(result, 12);
     ASSERT_TRUE(dsn::buf2uint64(dsn::string_view(str.data(), 3), result));


### PR DESCRIPTION
## Coredump
```
 ==16642==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00000094dd26 at pc 0x7f073c539935 bp 0x7f072bb8c810 sp 0x7f072bb8bfb8
READ of size 7 at 0x00000094dd26 thread T21 (client.THREAD_P)
    #0 0x7f073c539934 in __asan_memcpy (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x8c934)
    #1 0x63c267 in std::char_traits<char>::copy(char*, char const*, unsigned long) /usr/include/c++/5/bits/char_traits.h:290
    #2 0x63c267 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy(char*, char const*, unsigned long) /usr/include/c++/5/bits/basic_string.h:299
    #3 0x63c267 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy_chars(char*, char*, char*) /usr/include/c++/5/bits/basic_string.h:341
    #4 0x63c267 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) /usr/include/c++/5/bits/basic_string.tcc:229
    #5 0x6444ea in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char const*>(char const*, char const*, std::__false_type) /usr/include/c++/5/bits/basic_string.h:195
    #6 0x6444ea in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*) /usr/include/c++/5/bits/basic_string.h:214
    #7 0x6444ea in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, unsigned long, std::allocator<char> const&) /usr/include/c++/5/bits/basic_string.h:447
    #8 0x6444ea in string_conv_buf2int32_Test::TestBody() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/tests/string_conv_test.cpp:90
    #9 0x6aa81e in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/core/tests/dsn.core.tests+0x6aa81e)
```
## Related code:
Error in line 177:  “\045” is "%", so the string length = 5, 2th argument need <= 5 
https://github.com/XiaoMi/rdsn/blob/54770a2d438a8c4ff8b7afff7f9bd252d9a75f9f/src/core/tests/string_conv_test.cpp#L177-L184
