### PR TITLE
refactor: remove aspects for dsn runtime

### DIFF
--- a/include/dsn/tool-api/global_config.h
+++ b/include/dsn/tool-api/global_config.h
@@ -161,16 +161,6 @@ struct service_spec
     std::string nfs_factory_name;
     std::string logging_factory_name;
 
-    std::list<std::string> network_aspects; // toollets compatible to the above network main
-                                            // providers in network configs
-    std::list<std::string> aio_aspects;     // toollets compatible to main aio provider
-    std::list<std::string> env_aspects;
-    std::list<std::string> timer_aspects;
-    std::list<std::string> lock_aspects;
-    std::list<std::string> lock_nr_aspects;
-    std::list<std::string> rwlock_nr_aspects;
-    std::list<std::string> semaphore_aspects;
-
     network_client_configs network_default_client_cfs; // default network configed by tools
     network_server_configs network_default_server_cfs; // default network configed by tools
     std::vector<threadpool_spec> threadpool_specs;
@@ -207,17 +197,6 @@ CONFIG_FLD_STRING(rwlock_nr_factory_name, "", "non-recurisve rwlock provider")
 CONFIG_FLD_STRING(semaphore_factory_name, "", "semaphore provider")
 CONFIG_FLD_STRING(nfs_factory_name, "", "nfs provider")
 CONFIG_FLD_STRING(logging_factory_name, "", "logging provider")
-
-CONFIG_FLD_STRING_LIST(network_aspects, "network aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(aio_aspects, "aio aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(timer_aspects, "timer service aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(env_aspects, "environment aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(lock_aspects, "recursive lock aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(lock_nr_aspects,
-                       "non-recurisve lock aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(rwlock_nr_aspects,
-                       "non-recursive rwlock aspect providers, usually for tooling purpose")
-CONFIG_FLD_STRING_LIST(semaphore_aspects, "semaphore aspect providers, usually for tooling purpose")
 CONFIG_END
 
 enum sys_exit_type
@@ -234,4 +213,4 @@ ENUM_REG(SYS_EXIT_NORMAL)
 ENUM_REG(SYS_EXIT_BREAK)
 ENUM_REG(SYS_EXIT_EXCEPTION)
 ENUM_END(sys_exit_type)
-}
+} // namespace dsn

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -419,15 +419,9 @@ network *rpc_engine::create_network(const network_server_config &netcs,
                                     bool client_only,
                                     network_header_format client_hdr_format)
 {
-    const service_spec &spec = service_engine::instance().spec();
     network *net = utils::factory_store<network>::create(
         netcs.factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, this, nullptr);
     net->reset_parser_attr(client_hdr_format, netcs.message_buffer_block_size);
-
-    for (auto it = spec.network_aspects.begin(); it != spec.network_aspects.end(); it++) {
-        net = utils::factory_store<network>::create(
-            it->c_str(), ::dsn::PROVIDER_TYPE_ASPECT, this, net);
-    }
 
     // start the net
     error_code ret = net->start(netcs.channel, netcs.port, client_only);

--- a/src/core/core/service_engine.cpp
+++ b/src/core/core/service_engine.cpp
@@ -63,10 +63,6 @@ error_code service_node::init_io_engine()
     _node_io.disk = make_unique<disk_engine>(this);
     aio_provider *aio = factory_store<aio_provider>::create(
         spec.aio_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, _node_io.disk.get(), nullptr);
-    for (auto it = spec.aio_aspects.begin(); it != spec.aio_aspects.end(); it++) {
-        aio = factory_store<aio_provider>::create(
-            it->c_str(), PROVIDER_TYPE_ASPECT, _node_io.disk.get(), aio);
-    }
     _node_io.aio.reset(aio);
 
     // init rpc engine
@@ -77,7 +73,6 @@ error_code service_node::init_io_engine()
 
 error_code service_node::start_io_engine_in_main()
 {
-    auto &spec = service_engine::instance().spec();
     error_code err = ERR_OK;
 
     // start disk engine
@@ -239,9 +234,6 @@ void service_engine::init_after_toollets()
     // init common providers (second half)
     _env = factory_store<env_provider>::create(
         _spec.env_factory_name.c_str(), PROVIDER_TYPE_MAIN, nullptr);
-    for (auto it = _spec.env_aspects.begin(); it != _spec.env_aspects.end(); it++) {
-        _env = factory_store<env_provider>::create(it->c_str(), PROVIDER_TYPE_ASPECT, _env);
-    }
     tls_dsn.env = _env;
 }
 

--- a/src/core/core/task_engine.cpp
+++ b/src/core/core/task_engine.cpp
@@ -73,10 +73,6 @@ void task_worker_pool::create()
             PROVIDER_TYPE_MAIN,
             _node,
             nullptr);
-        for (auto &s : service_engine::instance().spec().timer_aspects) {
-            tsvc =
-                factory_store<timer_service>::create(s.c_str(), PROVIDER_TYPE_ASPECT, _node, tsvc);
-        }
         _per_queue_timer_svcs.push_back(tsvc);
     }
 

--- a/src/core/core/zlocks.cpp
+++ b/src/core/core/zlocks.cpp
@@ -63,7 +63,7 @@ void check_dangling_lock()
               zlock_shared_count);
     }
 }
-}
+} // namespace lock_checker
 
 zlock::zlock(bool recursive)
 {
@@ -72,26 +72,12 @@ zlock::zlock(bool recursive)
             dsn::service_engine::instance().spec().lock_factory_name.c_str(),
             dsn::PROVIDER_TYPE_MAIN,
             nullptr);
-
-        // TODO: perf opt by saving the func ptrs somewhere
-        for (auto &s : dsn::service_engine::instance().spec().lock_aspects) {
-            last = utils::factory_store<::dsn::lock_provider>::create(
-                s.c_str(), ::dsn::PROVIDER_TYPE_ASPECT, last);
-        }
-
         _h = last;
     } else {
         lock_nr_provider *last = utils::factory_store<lock_nr_provider>::create(
             dsn::service_engine::instance().spec().lock_nr_factory_name.c_str(),
             dsn::PROVIDER_TYPE_MAIN,
             nullptr);
-
-        // TODO: perf opt by saving the func ptrs somewhere
-        for (auto &s : dsn::service_engine::instance().spec().lock_nr_aspects) {
-            last = utils::factory_store<::dsn::lock_nr_provider>::create(
-                s.c_str(), ::dsn::PROVIDER_TYPE_ASPECT, last);
-        }
-
         _h = last;
     }
 }
@@ -125,13 +111,6 @@ zrwlock_nr::zrwlock_nr()
         service_engine::instance().spec().rwlock_nr_factory_name.c_str(),
         dsn::PROVIDER_TYPE_MAIN,
         nullptr);
-
-    // TODO: perf opt by saving the func ptrs somewhere
-    for (auto &s : service_engine::instance().spec().rwlock_nr_aspects) {
-        last = utils::factory_store<rwlock_nr_provider>::create(
-            s.c_str(), dsn::PROVIDER_TYPE_ASPECT, last);
-    }
-
     _h = last;
 }
 
@@ -184,12 +163,6 @@ zsemaphore::zsemaphore(int initial_count)
         PROVIDER_TYPE_MAIN,
         initial_count,
         nullptr);
-
-    // TODO: perf opt by saving the func ptrs somewhere
-    for (auto &s : service_engine::instance().spec().semaphore_aspects) {
-        last = utils::factory_store<::dsn::semaphore_provider>::create(
-            s.c_str(), dsn::PROVIDER_TYPE_ASPECT, initial_count, last);
-    }
     _h = last;
 }
 
@@ -255,4 +228,4 @@ bool zevent::wait(int timeout_milliseconds)
         return std::atomic_compare_exchange_strong(&_signaled, &signaled, false);
     }
 }
-}
+} // namespace dsn


### PR DESCRIPTION
rDSN provides several pluggable components that can be customized via `aspects`: https://github.com/microsoft/rDSN/blob/8aee3ac874e7d6fe2a90b01aceae39c0002f305d/src/plugins/apps.echo/config.ini#L119. However they are never used in our system, and they are rather complicated.

They are confirmed not used in our production environment. This refactoring is safe.