### PR TITLE
fix(asan): heap-use-after-free in simple_lb_cure_test.cpp

### DIFF
--- a/src/dist/replication/test/meta_test/unit_test/meta_load_balance_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_load_balance_test.cpp
@@ -458,9 +458,9 @@ void meta_load_balance_test::simple_lb_cure_test()
         EXPECT_FALSE(is_secondary(pc, update_req->node));
         EXPECT_EQ(target, pc.primary);
 
+        proposal_sent = true;
         svc->set_node_state({pc.primary}, false);
         svc->set_filter(default_filter);
-        proposal_sent = true;
         return nullptr;
     });
 
@@ -491,9 +491,9 @@ void meta_load_balance_test::simple_lb_cure_test()
         EXPECT_EQ(update_req->node, nodes[2]);
         EXPECT_EQ(target, nodes[2]);
 
+        proposal_sent = true;
         svc->set_filter(default_filter);
         apply_update_request(*update_req);
-        proposal_sent = true;
         return update_req;
     });
 
@@ -556,9 +556,9 @@ void meta_load_balance_test::simple_lb_cure_test()
         EXPECT_EQ(update_req->node, nodes[1]);
         EXPECT_EQ(target, nodes[1]);
 
+        proposal_sent = true;
         svc->set_filter(default_filter);
         apply_update_request(*update_req);
-        proposal_sent = true;
         return update_req;
     });
 
@@ -650,9 +650,9 @@ void meta_load_balance_test::simple_lb_cure_test()
         EXPECT_EQ(update_req->node, nodes[1]);
         EXPECT_EQ(target, nodes[1]);
 
+        proposal_sent = true;
         svc->set_filter(default_filter);
         apply_update_request(*update_req);
-        proposal_sent = true;
         return update_req;
     });
 
@@ -676,9 +676,9 @@ void meta_load_balance_test::simple_lb_cure_test()
         EXPECT_EQ(update_req->node, nodes[0]);
         EXPECT_EQ(target, nodes[0]);
 
+        proposal_sent = true;
         svc->set_filter(default_filter);
         apply_update_request(*update_req);
-        proposal_sent = true;
         return update_req;
     });
 


### PR DESCRIPTION
Related issue: #364 

The reason is `svc->set_filter(default_filter)` free the heap which is located by `svc->set_filter([&](const dsn::rpc_address &target, dsn::message_ex *req) -> cur_ptr {...});`, and the variable `proposal_sent` is also freed, however, it is still used in L435.
# Related code:
https://github.com/XiaoMi/rdsn/blob/1e5d529eb0c7a96965c885a0de2c80f76580ed89/src/dist/replication/test/meta_test/unit_test/simple_lb_cure_test.cpp#L435

https://github.com/XiaoMi/rdsn/blob/1e5d529eb0c7a96965c885a0de2c80f76580ed89/src/dist/replication/test/meta_test/unit_test/simple_lb_cure_test.cpp#L423-L437
# Solution
`proposal_sent=true` before `svc->set_filter(default_filter)`