### PR TITLE
fix(asan): heap-buffer-overflow in meta_test_base.h

### DIFF
--- a/src/dist/replication/test/meta_test/unit_test/meta_test_base.h
+++ b/src/dist/replication/test/meta_test/unit_test/meta_test_base.h
@@ -22,7 +22,9 @@ public:
         _ms = make_unique<fake_receiver_meta_service>();
         _ms->_failure_detector.reset(new meta_server_failure_detector(_ms.get()));
         _ms->_balancer.reset(utils::factory_store<server_load_balancer>::create(
-            _ms->_meta_opts._lb_opts.server_load_balancer_type.c_str(), PROVIDER_TYPE_MAIN, this));
+            _ms->_meta_opts._lb_opts.server_load_balancer_type.c_str(),
+            PROVIDER_TYPE_MAIN,
+            _ms.get()));
         ASSERT_EQ(_ms->remote_storage_initialize(), ERR_OK);
         _ms->initialize_duplication_service();
         ASSERT_TRUE(_ms->_dup_svc);


### PR DESCRIPTION
## Related issue
#376 
## Reason
The 3th argument  of `utils::factory_store<server_load_balancer>::create(const char *name, ::dsn::provider_type type, T1 t1)` is set to `meta_test_base` type in line 24 of `meta_test_base.h`. 
https://github.com/XiaoMi/rdsn/blob/7b370383ba111bf5171c82b0e0ab323794aadee8/src/dist/replication/test/meta_test/unit_test/meta_test_base.h#L21-L29
Therefore, It will be illegally cast to `meta_service` type in line 60 of `server_load_balancer.h` and report `heap-buffer-overflow` in line 235. 

https://github.com/XiaoMi/rdsn/blob/7b370383ba111bf5171c82b0e0ab323794aadee8/src/dist/replication/meta_server/server_load_balancer.h#L54-L61

https://github.com/XiaoMi/rdsn/blob/7b370383ba111bf5171c82b0e0ab323794aadee8/src/dist/replication/meta_server/server_load_balancer.h#L230-L240
The root cause is that  `meta_test_base` object don’t malloc matching address with `meta_service` type, and then, it will be report `heap-buffer-overflow` when visiting the `meta_service` class member via Illegal address.

## Solution
The 3th argument  of `utils::factory_store<server_load_balancer>::create(const char *name, ::dsn::provider_type type, T1 t1)` is set to `meta_service` type:
```
_ms = make_unique<fake_receiver_meta_service>();
        _ms->_failure_detector.reset(new meta_server_failure_detector(_ms.get()));
        _ms->_balancer.reset(utils::factory_store<server_load_balancer>::create(
            _ms->_meta_opts._lb_opts.server_load_balancer_type.c_str(),
            PROVIDER_TYPE_MAIN,
            _ms.get())); // this-> _ms.get()
```