### PR TITLE
fix(asan): fix heap-use-after-free in replica_split_test

### DIFF
--- a/src/dist/replication/test/replica_test/unit_test/replica_split_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_split_test.cpp
@@ -202,6 +202,7 @@ TEST_F(replica_split_test, add_child_succeed)
 
     test_on_add_child();
     ASSERT_NE(_stub->get_replica(_child_pid), nullptr);
+    _stub->get_replica(_child_pid)->tracker()->wait_outstanding_tasks();
 
     fail::teardown();
 }


### PR DESCRIPTION
## Coredump
```
==28319==ERROR: AddressSanitizer: heap-use-after-free on address 0x60c000011cc8 at pc 0x7f9bd911df10 bp 0x7f9bc21db080 sp 0x7f9bc21db070
READ of size 4 at 0x60c000011cc8 thread T29 (replica.replica)
[       OK ] replica_split_test.add_child_succeed (1 ms)
[----------] 1 test from replica_split_test (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1 ms total)
[  PASSED  ] 1 test.
    #0 0x7f9bd911df0f in dsn::fail::fail_point::eval[abi:cxx11]() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point.cpp:140
    #1 0x7f9bd911e1a1 in dsn::fail::eval[abi:cxx11](dsn::string_view) /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point.cpp:37
    #2 0x7f9bd8eb8d7e in dsn::replication::replica::child_init_replica(dsn::gpid, dsn::rpc_address, long) /home/mi/work/PegasusDB/pegasus/rdsn/src/dist/replication/lib/replica_split.cpp:81
    #3 0x7f9bd8ef856d in void std::_Mem_fn_base<void (dsn::replication::replica::*)(dsn::gpid, dsn::rpc_address, long), true>::_M_call<dsn::ref_ptr<dsn::replication::replica>&, dsn::gpid&, dsn::rpc_address&, long&>(dsn::ref_ptr<dsn::replication::replica>&, void const volatile*, dsn::gpid&, dsn::rpc_address&, long&) const /usr/include/c++/5/functional:634
    #4 0x7f9bd8ef856d in void std::_Mem_fn_base<void (dsn::replication::replica::*)(dsn::gpid, dsn::rpc_address, long), true>::operator()<dsn::ref_ptr<dsn::replication::replica>&, dsn::gpid&, dsn::rpc_address&, long&, void>(dsn::ref_ptr<dsn::replication::replica>&, dsn::gpid&, dsn::rpc_address&, long&) const /usr/include/c++/5/functional:610
    #5 0x7f9bd8ef856d in void std::_Bind<std::_Mem_fn<void (dsn::replication::replica::*)(dsn::gpid, dsn::rpc_address, long)> (dsn::ref_ptr<dsn::replication::replica>, dsn::gpid, dsn::rpc_address, long)>::__call<void, , 0ul, 1ul, 2ul, 3ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/include/c++/5/functional:1074
    #6 0x7f9bd8ef856d in void std::_Bind<std::_Mem_fn<void (dsn::replication::replica::*)(dsn::gpid, dsn::rpc_address, long)> (dsn::ref_ptr<dsn::replication::replica>, dsn::gpid, dsn::rpc_address, long)>::operator()<, void>() /usr/include/c++/5/functional:1133
    #7 0x7f9bd8ef856d in std::_Function_handler<void (), std::_Bind<std::_Mem_fn<void (dsn::replication::replica::*)(dsn::gpid, dsn::rpc_address, long)> (dsn::ref_ptr<dsn::replication::replica>, dsn::gpid, dsn::rpc_address, long)> >::_M_invoke(std::_Any_data const&) /usr/include/c++/5/functional:1871
    #8 0x7f9bda749a3f in dsn::task::exec_internal() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task.cpp:180
    #9 0x7f9bda77c207 in dsn::task_worker::loop() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task_worker.cpp:211
    #10 0x7f9bda77c98b in dsn::task_worker::run_internal() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task_worker.cpp:191
    #11 0x7f9bd7d74c7f  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xb8c7f)
    #12 0x7f9bd80456b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
    #13 0x7f9bd77e341c in clone (/lib/x86_64-linux-gnu/libc.so.6+0x10741c)

0x60c000011cc8 is located 72 bytes inside of 128-byte region [0x60c000011c80,0x60c000011d00)
freed by thread T23 (replica.default) here:
    #0 0x7f9bdb1ebb2a in operator delete(void*) (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x99b2a)
    #1 0x7f9bd9125627 in __gnu_cxx::new_allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> >::deallocate(std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true>*, unsigned long) /usr/include/c++/5/ext/new_allocator.h:110
    #2 0x7f9bd9125627 in std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> > >::deallocate(std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> >&, std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true>*, unsigned long) /usr/include/c++/5/bits/alloc_traits.h:517
    #3 0x7f9bd9125627 in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true>*) /usr/include/c++/5/bits/hashtable_policy.h:1975
    #4 0x7f9bd9125627 in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> > >::_M_deallocate_nodes(std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true>*) /usr/include/c++/5/bits/hashtable_policy.h:1986
    #5 0x7f9bd9125627 in std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::clear() /usr/include/c++/5/bits/hashtable.h:1914
    #6 0x7f9bd911df5d in std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, dsn::fail::fail_point, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point> > >::clear() /usr/include/c++/5/bits/unordered_map.h:568
    #7 0x7f9bd911df5d in dsn::fail::fail_point_registry::clear() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point_impl.h:102
    #8 0x7f9bd911df5d in dsn::fail::teardown() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point.cpp:73
    #9 0x49a53f in dsn::replication::replica_split_test_add_child_succeed_Test::TestBody() /home/mi/work/PegasusDB/pegasus/rdsn/src/dist/replication/test/replica_test/unit_test/replica_split_test.cpp:206
    #10 0x4df6a6 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4df6a6)
    #11 0x4d8c26 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4d8c26)
    #12 0x4bc065 in testing::Test::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4bc065)
    #13 0x4bc9fd in testing::TestInfo::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4bc9fd)
    #14 0x4bd0f0 in testing::TestCase::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4bd0f0)
    #15 0x4c4237 in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4c4237)
    #16 0x4e0c7e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4e0c7e)
    #17 0x4d9a68 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4d9a68)
    #18 0x4c2cd3 in testing::UnitTest::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4c2cd3)
    #19 0x4626d0 in RUN_ALL_TESTS() /home/mi/work/PegasusDB/pegasus/rdsn/thirdparty/output/include/gtest/gtest.h:2233
    #20 0x4626d0 in replication_service_test_app::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /home/mi/work/PegasusDB/pegasus/rdsn/src/dist/replication/test/replica_test/unit_test/main.cpp:33
    #21 0x7f9bda72c540 in dsn::service_node::start_app() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/service_engine.cpp:94
    #22 0x7f9bda7848f5 in dsn::service_control_task::exec() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/tool_api.cpp:60
    #23 0x7f9bda749a3f in dsn::task::exec_internal() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task.cpp:180
    #24 0x7f9bda77c207 in dsn::task_worker::loop() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task_worker.cpp:211
    #25 0x7f9bda77c98b in dsn::task_worker::run_internal() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task_worker.cpp:191
    #26 0x7f9bd7d74c7f  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xb8c7f)

previously allocated by thread T23 (replica.default) here:
    #0 0x7f9bdb1eb532 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x99532)
    #1 0x7f9bd911f94c in __gnu_cxx::new_allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> >::allocate(unsigned long, void const*) /usr/include/c++/5/ext/new_allocator.h:104
    #2 0x7f9bd911f94c in std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> > >::allocate(std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> >&, unsigned long) /usr/include/c++/5/bits/alloc_traits.h:491
    #3 0x7f9bd911f94c in std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true>* std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, true> > >::_M_allocate_node<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, dsn::fail::fail_point>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, dsn::fail::fail_point&&) /usr/include/c++/5/bits/hashtable_policy.h:1949
    #4 0x7f9bd911f94c in std::pair<std::__detail::_Node_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, false, true>, bool> std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_emplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, dsn::fail::fail_point>(std::integral_constant<bool, true>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, dsn::fail::fail_point&&) /usr/include/c++/5/bits/hashtable.h:1526
    #5 0x7f9bd911f94c in std::pair<std::__detail::_Node_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, false, true>, bool> std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::emplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, dsn::fail::fail_point>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, dsn::fail::fail_point&&) /usr/include/c++/5/bits/hashtable.h:726
    #6 0x7f9bd911f94c in std::pair<std::__detail::_Node_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point>, false, true>, bool> std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, dsn::fail::fail_point, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::fail::fail_point> > >::emplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, dsn::fail::fail_point>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, dsn::fail::fail_point&&) /usr/include/c++/5/bits/unordered_map.h:380
    #7 0x7f9bd911f94c in dsn::fail::fail_point_registry::create_if_not_exists(dsn::string_view) /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point_impl.h:84
    #8 0x7f9bd911f94c in dsn::fail::cfg(dsn::string_view, dsn::string_view) /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point.cpp:57
    #9 0x49a3ef in dsn::replication::replica_split_test_add_child_succeed_Test::TestBody() /home/mi/work/PegasusDB/pegasus/rdsn/src/dist/replication/test/replica_test/unit_test/replica_split_test.cpp:201
    #10 0x4df6a6 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4df6a6)
    #11 0x4d8c26 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4d8c26)
    #12 0x4bc065 in testing::Test::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4bc065)
    #13 0x4bc9fd in testing::TestInfo::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4bc9fd)
    #14 0x4bd0f0 in testing::TestCase::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4bd0f0)
    #15 0x4c4237 in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4c4237)
    #16 0x4e0c7e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4e0c7e)
    #17 0x4d9a68 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4d9a68)
    #18 0x4c2cd3 in testing::UnitTest::Run() (/home/mi/work/PegasusDB/pegasus/rdsn/builder/src/dist/replication/test/replica_test/unit_test/dsn.replica.test+0x4c2cd3)
    #19 0x4626d0 in RUN_ALL_TESTS() /home/mi/work/PegasusDB/pegasus/rdsn/thirdparty/output/include/gtest/gtest.h:2233
    #20 0x4626d0 in replication_service_test_app::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /home/mi/work/PegasusDB/pegasus/rdsn/src/dist/replication/test/replica_test/unit_test/main.cpp:33
    #21 0x7f9bda72c540 in dsn::service_node::start_app() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/service_engine.cpp:94
    #22 0x7f9bda7848f5 in dsn::service_control_task::exec() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/tool_api.cpp:60
    #23 0x7f9bda749a3f in dsn::task::exec_internal() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task.cpp:180
    #24 0x7f9bda77c207 in dsn::task_worker::loop() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task_worker.cpp:211
    #25 0x7f9bda77c98b in dsn::task_worker::run_internal() /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/task_worker.cpp:191
    #26 0x7f9bd7d74c7f  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xb8c7f)

Thread T29 (replica.replica) created by T0 here:
    #0 0x7f9bdb188253 in pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x36253)
    #1 0x7f9bd7d74dc2 in std::thread::_M_start_thread(std::shared_ptr<std::thread::_Impl_base>, void (*)()) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xb8dc2)

Thread T23 (replica.default) created by T0 here:
    #0 0x7f9bdb188253 in pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x36253)
    #1 0x7f9bd7d74dc2 in std::thread::_M_start_thread(std::shared_ptr<std::thread::_Impl_base>, void (*)()) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xb8dc2)

SUMMARY: AddressSanitizer: heap-use-after-free /home/mi/work/PegasusDB/pegasus/rdsn/src/core/core/fail_point.cpp:140 
```
## Related code
https://github.com/XiaoMi/rdsn/blob/da71dbdf3bc5581c55ef80508866ca809c66b960/src/dist/replication/test/replica_test/unit_test/replica_split_test.cpp#L197-L207

## Reason
`test_on_add_child()` in line 203 is asynchronous, so it will still use the `fail_point` after freed by `fail::teardown()` in line 206

## Solution
adding `_stub->get_replica(_child_pid)->tracker()->wait_outstanding_tasks();`  to wait the `test_on_add_child()` complete.