### PR TITLE
fix(thrift): add start_time_ns for structure mutation_update in thrift file

### DIFF
--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -416,10 +416,14 @@ inline std::ostream &operator<<(std::ostream &out, const mutation_header &obj)
 
 typedef struct _mutation_update__isset
 {
-    _mutation_update__isset() : code(false), serialization_type(false), data(false) {}
+    _mutation_update__isset()
+        : code(false), serialization_type(false), data(false), start_time_ns(false)
+    {
+    }
     bool code : 1;
     bool serialization_type : 1;
     bool data : 1;
+    bool start_time_ns : 1;
 } _mutation_update__isset;
 
 class mutation_update
@@ -429,14 +433,13 @@ public:
     mutation_update(mutation_update &&);
     mutation_update &operator=(const mutation_update &);
     mutation_update &operator=(mutation_update &&);
-    mutation_update() : serialization_type(0), start_time_ns(dsn_now_ns()) {}
+    mutation_update() : serialization_type(0), start_time_ns(0) {}
 
     virtual ~mutation_update() throw();
     ::dsn::task_code code;
     int32_t serialization_type;
     ::dsn::blob data;
-    // start_time_ns doesn't need to serialization, because we only use it on local node
-    uint64_t start_time_ns;
+    int64_t start_time_ns;
 
     _mutation_update__isset __isset;
 
@@ -445,6 +448,8 @@ public:
     void __set_serialization_type(const int32_t val);
 
     void __set_data(const ::dsn::blob &val);
+
+    void __set_start_time_ns(const int64_t val);
 
     bool operator==(const mutation_update &rhs) const
     {

--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -459,7 +459,9 @@ public:
             return false;
         if (!(data == rhs.data))
             return false;
-        if (!(start_time_ns == rhs.start_time_ns))
+        if (__isset.start_time_ns != rhs.__isset.start_time_ns)
+            return false;
+        else if (__isset.start_time_ns && !(start_time_ns == rhs.start_time_ns))
             return false;
         return true;
     }

--- a/src/dist/replication/common/replication_types.cpp
+++ b/src/dist/replication/common/replication_types.cpp
@@ -351,6 +351,8 @@ void mutation_update::__set_serialization_type(const int32_t val)
 
 void mutation_update::__set_data(const ::dsn::blob &val) { this->data = val; }
 
+void mutation_update::__set_start_time_ns(const int64_t val) { this->start_time_ns = val; }
+
 uint32_t mutation_update::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -394,6 +396,14 @@ uint32_t mutation_update::read(::apache::thrift::protocol::TProtocol *iprot)
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 4:
+            if (ftype == ::apache::thrift::protocol::T_I64) {
+                xfer += iprot->readI64(this->start_time_ns);
+                this->__isset.start_time_ns = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -422,6 +432,10 @@ uint32_t mutation_update::write(::apache::thrift::protocol::TProtocol *oprot) co
 
     xfer += oprot->writeFieldBegin("data", ::apache::thrift::protocol::T_STRUCT, 3);
     xfer += this->data.write(oprot);
+    xfer += oprot->writeFieldEnd();
+
+    xfer += oprot->writeFieldBegin("start_time_ns", ::apache::thrift::protocol::T_I64, 4);
+    xfer += oprot->writeI64(this->start_time_ns);
     xfer += oprot->writeFieldEnd();
 
     xfer += oprot->writeFieldStop();

--- a/src/dist/replication/common/replication_types.cpp
+++ b/src/dist/replication/common/replication_types.cpp
@@ -351,7 +351,11 @@ void mutation_update::__set_serialization_type(const int32_t val)
 
 void mutation_update::__set_data(const ::dsn::blob &val) { this->data = val; }
 
-void mutation_update::__set_start_time_ns(const int64_t val) { this->start_time_ns = val; }
+void mutation_update::__set_start_time_ns(const int64_t val)
+{
+    this->start_time_ns = val;
+    __isset.start_time_ns = true;
+}
 
 uint32_t mutation_update::read(::apache::thrift::protocol::TProtocol *iprot)
 {
@@ -434,10 +438,11 @@ uint32_t mutation_update::write(::apache::thrift::protocol::TProtocol *oprot) co
     xfer += this->data.write(oprot);
     xfer += oprot->writeFieldEnd();
 
-    xfer += oprot->writeFieldBegin("start_time_ns", ::apache::thrift::protocol::T_I64, 4);
-    xfer += oprot->writeI64(this->start_time_ns);
-    xfer += oprot->writeFieldEnd();
-
+    if (this->__isset.start_time_ns) {
+        xfer += oprot->writeFieldBegin("start_time_ns", ::apache::thrift::protocol::T_I64, 4);
+        xfer += oprot->writeI64(this->start_time_ns);
+        xfer += oprot->writeFieldEnd();
+    }
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -497,7 +502,8 @@ void mutation_update::printTo(std::ostream &out) const
     out << ", "
         << "data=" << to_string(data);
     out << ", "
-        << "start_time_ns=" << to_string(start_time_ns);
+        << "start_time_ns=";
+    (__isset.start_time_ns ? (out << to_string(start_time_ns)) : (out << "<null>"));
     out << ")";
 }
 

--- a/src/dist/replication/lib/mutation.cpp
+++ b/src/dist/replication/lib/mutation.cpp
@@ -143,7 +143,7 @@ void mutation::add_client_request(task_code code, dsn::message_ex *request)
         update.code = code;
         update.serialization_type =
             (dsn_msg_serialize_format)request->header->context.u.serialize_format;
-        update.start_time_ns = dsn_now_ns();
+        update.__set_start_time_ns(dsn_now_ns());
         request->add_ref(); // released on dctor
 
         void *ptr;

--- a/src/dist/replication/lib/mutation.cpp
+++ b/src/dist/replication/lib/mutation.cpp
@@ -143,6 +143,7 @@ void mutation::add_client_request(task_code code, dsn::message_ex *request)
         update.code = code;
         update.serialization_type =
             (dsn_msg_serialize_format)request->header->context.u.serialize_format;
+	update.start_time_ns = dsn_now_ns();
         request->add_ref(); // released on dctor
 
         void *ptr;

--- a/src/dist/replication/lib/mutation.cpp
+++ b/src/dist/replication/lib/mutation.cpp
@@ -143,7 +143,7 @@ void mutation::add_client_request(task_code code, dsn::message_ex *request)
         update.code = code;
         update.serialization_type =
             (dsn_msg_serialize_format)request->header->context.u.serialize_format;
-	update.start_time_ns = dsn_now_ns();
+        update.start_time_ns = dsn_now_ns();
         request->add_ref(); // released on dctor
 
         void *ptr;

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -20,7 +20,7 @@ struct mutation_update
     //the serialization type of data, this need to store in log and replicate to secondaries by primary
     2:i32            serialization_type;
     3:dsn.blob       data;
-    4:i64	      start_time_ns;
+    4:i64            start_time_ns;
 }
 
 struct mutation_data

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -20,7 +20,7 @@ struct mutation_update
     //the serialization type of data, this need to store in log and replicate to secondaries by primary
     2:i32            serialization_type;
     3:dsn.blob       data;
-    4:i64            start_time_ns;
+    4:optional i64   start_time_ns;
 }
 
 struct mutation_data

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -20,6 +20,7 @@ struct mutation_update
     //the serialization type of data, this need to store in log and replicate to secondaries by primary
     2:i32            serialization_type;
     3:dsn.blob       data;
+    4:i64	      start_time_ns;
 }
 
 struct mutation_data


### PR DESCRIPTION
Pull request #336 added a new filed called `start_time_ns` for structure `mutation_update`. `mutation_update` is defined in `replication.thrift`, and we generate `.h` and `.cpp` files atomically by thrift. However, original pr directly added this filed in `.h` and `.cpp` file, which might be difficult to maintain. 

This pr add a new filed `start_time_ns` for structure `mutation_update` in thrift file, and initialize it when creating this structure in function `add_client_request`.