### PR TITLE
feat(dup): respond with hint when add_dup failed

### DIFF
--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -4738,10 +4738,11 @@ inline std::ostream &operator<<(std::ostream &out, const duplication_add_request
 
 typedef struct _duplication_add_response__isset
 {
-    _duplication_add_response__isset() : err(false), appid(false), dupid(false) {}
+    _duplication_add_response__isset() : err(false), appid(false), dupid(false), hint(false) {}
     bool err : 1;
     bool appid : 1;
     bool dupid : 1;
+    bool hint : 1;
 } _duplication_add_response__isset;
 
 class duplication_add_response
@@ -4751,12 +4752,13 @@ public:
     duplication_add_response(duplication_add_response &&);
     duplication_add_response &operator=(const duplication_add_response &);
     duplication_add_response &operator=(duplication_add_response &&);
-    duplication_add_response() : appid(0), dupid(0) {}
+    duplication_add_response() : appid(0), dupid(0), hint() {}
 
     virtual ~duplication_add_response() throw();
     ::dsn::error_code err;
     int32_t appid;
     int32_t dupid;
+    std::string hint;
 
     _duplication_add_response__isset __isset;
 
@@ -4766,6 +4768,8 @@ public:
 
     void __set_dupid(const int32_t val);
 
+    void __set_hint(const std::string &val);
+
     bool operator==(const duplication_add_response &rhs) const
     {
         if (!(err == rhs.err))
@@ -4773,6 +4777,10 @@ public:
         if (!(appid == rhs.appid))
             return false;
         if (!(dupid == rhs.dupid))
+            return false;
+        if (__isset.hint != rhs.__isset.hint)
+            return false;
+        else if (__isset.hint && !(hint == rhs.hint))
             return false;
         return true;
     }

--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -49,7 +49,7 @@ replication_options::replication_options()
     delay_for_fd_timeout_on_start = false;
     empty_write_disabled = false;
     allow_non_idempotent_write = false;
-    duplication_enabled = false;
+    duplication_enabled = true;
 
     prepare_timeout_ms_for_secondaries = 1000;
     prepare_timeout_ms_for_potential_secondaries = 3000;

--- a/src/dist/replication/common/replication_types.cpp
+++ b/src/dist/replication/common/replication_types.cpp
@@ -11012,6 +11012,12 @@ void duplication_add_response::__set_appid(const int32_t val) { this->appid = va
 
 void duplication_add_response::__set_dupid(const int32_t val) { this->dupid = val; }
 
+void duplication_add_response::__set_hint(const std::string &val)
+{
+    this->hint = val;
+    __isset.hint = true;
+}
+
 uint32_t duplication_add_response::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -11055,6 +11061,14 @@ uint32_t duplication_add_response::read(::apache::thrift::protocol::TProtocol *i
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 4:
+            if (ftype == ::apache::thrift::protocol::T_STRING) {
+                xfer += iprot->readString(this->hint);
+                this->__isset.hint = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -11085,6 +11099,11 @@ uint32_t duplication_add_response::write(::apache::thrift::protocol::TProtocol *
     xfer += oprot->writeI32(this->dupid);
     xfer += oprot->writeFieldEnd();
 
+    if (this->__isset.hint) {
+        xfer += oprot->writeFieldBegin("hint", ::apache::thrift::protocol::T_STRING, 4);
+        xfer += oprot->writeString(this->hint);
+        xfer += oprot->writeFieldEnd();
+    }
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -11096,6 +11115,7 @@ void swap(duplication_add_response &a, duplication_add_response &b)
     swap(a.err, b.err);
     swap(a.appid, b.appid);
     swap(a.dupid, b.dupid);
+    swap(a.hint, b.hint);
     swap(a.__isset, b.__isset);
 }
 
@@ -11104,6 +11124,7 @@ duplication_add_response::duplication_add_response(const duplication_add_respons
     err = other460.err;
     appid = other460.appid;
     dupid = other460.dupid;
+    hint = other460.hint;
     __isset = other460.__isset;
 }
 duplication_add_response::duplication_add_response(duplication_add_response &&other461)
@@ -11111,6 +11132,7 @@ duplication_add_response::duplication_add_response(duplication_add_response &&ot
     err = std::move(other461.err);
     appid = std::move(other461.appid);
     dupid = std::move(other461.dupid);
+    hint = std::move(other461.hint);
     __isset = std::move(other461.__isset);
 }
 duplication_add_response &duplication_add_response::
@@ -11119,6 +11141,7 @@ operator=(const duplication_add_response &other462)
     err = other462.err;
     appid = other462.appid;
     dupid = other462.dupid;
+    hint = other462.hint;
     __isset = other462.__isset;
     return *this;
 }
@@ -11127,6 +11150,7 @@ duplication_add_response &duplication_add_response::operator=(duplication_add_re
     err = std::move(other463.err);
     appid = std::move(other463.appid);
     dupid = std::move(other463.dupid);
+    hint = std::move(other463.hint);
     __isset = std::move(other463.__isset);
     return *this;
 }
@@ -11139,6 +11163,9 @@ void duplication_add_response::printTo(std::ostream &out) const
         << "appid=" << to_string(appid);
     out << ", "
         << "dupid=" << to_string(dupid);
+    out << ", "
+        << "hint=";
+    (__isset.hint ? (out << to_string(hint)) : (out << "<null>"));
     out << ")";
 }
 

--- a/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
+++ b/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
@@ -133,17 +133,17 @@ void meta_duplication_service::add_duplication(duplication_add_rpc rpc)
     response.err = ERR_OK;
 
     if (request.remote_cluster_name == get_current_cluster_name()) {
-        dwarn("illegal operation: adding duplication to itself");
         response.err = ERR_INVALID_PARAMETERS;
+        response.__set_hint("illegal operation: adding duplication to itself");
         return;
     }
 
     auto remote_cluster_id = get_duplication_cluster_id(request.remote_cluster_name);
     if (!remote_cluster_id.is_ok()) {
-        dwarn_f("get_duplication_cluster_id({}) failed, error: {}",
-                request.remote_cluster_name,
-                remote_cluster_id.get_error());
         response.err = ERR_INVALID_PARAMETERS;
+        response.__set_hint(fmt::format("get_duplication_cluster_id({}) failed, error: {}",
+                                        request.remote_cluster_name,
+                                        remote_cluster_id.get_error()));
         return;
     }
 

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -648,6 +648,7 @@ struct duplication_add_response
     1:dsn.error_code   err;
     2:i32              appid;
     3:i32              dupid;
+    4:optional string  hint;
 }
 
 // This request is sent from client to meta.


### PR DESCRIPTION
add_dup previously used error code to identify the failure. In most cases this is enough. 
However, error code may be ambiguous, ERR_INVALID_ARGUMENT for example:

```cpp
    if (request.remote_cluster_name == get_current_cluster_name()) {
        response.err = ERR_INVALID_PARAMETERS;
        response.__set_hint("illegal operation: adding duplication to itself");
        return;
    }

    auto remote_cluster_id = get_duplication_cluster_id(request.remote_cluster_name);
    if (!remote_cluster_id.is_ok()) {
        response.err = ERR_INVALID_PARAMETERS;
        response.__set_hint(fmt::format("get_duplication_cluster_id({}) failed, error: {}",
                                        request.remote_cluster_name,
                                        remote_cluster_id.get_error()));
        return;
    }
```

Between the above two cases, we still need a hint to determine the cause.

When the error code is self-descriptive, ERR_APP_NOT_EXIST for example, we provide no hint.