### PR TITLE
refactor: move max_allowed_write_size to replication_common.h

### DIFF
--- a/src/dist/replication/common/replication_common.cpp
+++ b/src/dist/replication/common/replication_common.cpp
@@ -109,6 +109,8 @@ replication_options::replication_options()
     learn_app_max_concurrent_count = 5;
 
     max_concurrent_uploading_file_count = 10;
+
+    max_allowed_write_size = 1 << 20;
 }
 
 replication_options::~replication_options() {}
@@ -511,6 +513,13 @@ void replication_options::initialize()
                                              "max_concurrent_uploading_file_count",
                                              max_concurrent_uploading_file_count,
                                              "concurrent uploading file count");
+
+    max_allowed_write_size = dsn_config_get_value_uint64("replication",
+                                                         "max_allowed_write_size",
+                                                         max_allowed_write_size,
+                                                         "write operation exceed this "
+                                                         "threshold will be logged and reject, "
+                                                         "default is 1MB, 0 means no check");
 
     replica_helper::load_meta_servers(meta_servers);
 

--- a/src/dist/replication/common/replication_common.h
+++ b/src/dist/replication/common/replication_common.h
@@ -114,6 +114,10 @@ public:
     std::string cold_backup_root;
     int32_t max_concurrent_uploading_file_count;
 
+    // write body size exceed this threshold will be logged and reject, 0 means no check, default
+    // 1MB
+    uint64_t max_allowed_write_size;
+
 public:
     replication_options();
     void initialize();

--- a/src/dist/replication/lib/replica_2pc.cpp
+++ b/src/dist/replication/lib/replica_2pc.cpp
@@ -45,13 +45,13 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
         return;
     }
 
-    if (dsn_unlikely(_stub->_max_allowed_write_size &&
-                     request->body_size() > _stub->_max_allowed_write_size)) {
+    if (dsn_unlikely(_options->max_allowed_write_size &&
+                     request->body_size() > _options->max_allowed_write_size)) {
         dwarn_replica("client from {} write request body size exceed threshold, request_body_size "
                       "= {}, max_allowed_write_size = {}, it will be rejected!",
                       request->header->from_address.to_string(),
                       request->body_size(),
-                      _stub->_max_allowed_write_size);
+                      _options->max_allowed_write_size);
         _stub->_counter_recent_write_size_exceed_threshold_count->increment();
         response_client_write(request, ERR_INVALID_DATA);
         return;

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -85,13 +85,6 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
     _log = nullptr;
     _primary_address_str[0] = '\0';
     install_perf_counters();
-
-    _max_allowed_write_size = dsn_config_get_value_uint64("replication",
-                                                          "max_allowed_write_size",
-                                                          1 << 20,
-                                                          "write operation exceed this "
-                                                          "threshold will be logged and reject, "
-                                                          "default is 1MB, 0 means no check");
 }
 
 replica_stub::~replica_stub(void) { close(); }

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -346,9 +346,6 @@ private:
     // cli service
     std::unique_ptr<dsn::cli_service> _cli_service;
 
-    // write body size exceed this threshold will be logged and reject, 0 means no check
-    uint64_t _max_allowed_write_size;
-
     // performance counters
     perf_counter_wrapper _counter_replicas_count;
     perf_counter_wrapper _counter_replicas_opening_count;


### PR DESCRIPTION
https://github.com/XiaoMi/rdsn/pull/414 use inappropriate way to init `max_allowed_write_size`. Actualy, rdsn use `replication_options` in `replication_common.h` to manage replica config. This pr move it to `replication_options`.