### PR TITLE
feat: append mlog in fixed-size blocks using log_appender

### DIFF
--- a/src/dist/replication/lib/log_block.cpp
+++ b/src/dist/replication/lib/log_block.cpp
@@ -27,8 +27,6 @@ void log_appender::append_mutation(const mutation_ptr &mu, const aio_task_ptr &c
         _callbacks.push_back(cb);
     }
     log_block *blk = &_blocks.back();
-    mu->data.header.log_offset = start_offset() + size();
-    mu->write_to([blk](const blob &bb) { blk->add(bb); });
     if (blk->size() > DEFAULT_MAX_BLOCK_BYTES) {
         _full_blocks_size += blk->size();
         _full_blocks_blob_cnt += blk->data().size();
@@ -36,6 +34,8 @@ void log_appender::append_mutation(const mutation_ptr &mu, const aio_task_ptr &c
         _blocks.emplace_back(new_block_start_offset);
         blk = &_blocks.back();
     }
+    mu->data.header.log_offset = blk->start_offset() + blk->size();
+    mu->write_to([blk](const blob &bb) { blk->add(bb); });
 }
 
 } // namespace replication

--- a/src/dist/replication/lib/log_block.cpp
+++ b/src/dist/replication/lib/log_block.cpp
@@ -20,14 +20,22 @@ void log_block::init()
     add(temp_writer.get_buffer());
 }
 
-void log_block::append_mutation(const mutation_ptr &mu, const aio_task_ptr &cb)
+void log_appender::append_mutation(const mutation_ptr &mu, const aio_task_ptr &cb)
 {
     _mutations.push_back(mu);
     if (cb) {
         _callbacks.push_back(cb);
     }
-    mu->data.header.log_offset = _start_offset + size();
-    mu->write_to([this](const blob &bb) { add(bb); });
+    log_block *blk = &_blocks.back();
+    mu->data.header.log_offset = blk->start_offset() + size();
+    mu->write_to([blk](const blob &bb) { blk->add(bb); });
+    if (blk->size() > DEFAULT_MAX_BLOCK_BYTES) {
+        _full_blocks_size += blk->size();
+        _full_blocks_blob_cnt += blk->data().size();
+        int64_t new_block_start_offset = blk->start_offset() + blk->size();
+        _blocks.emplace_back(new_block_start_offset);
+        blk = &_blocks.back();
+    }
 }
 
 } // namespace replication

--- a/src/dist/replication/lib/log_block.cpp
+++ b/src/dist/replication/lib/log_block.cpp
@@ -27,7 +27,7 @@ void log_appender::append_mutation(const mutation_ptr &mu, const aio_task_ptr &c
         _callbacks.push_back(cb);
     }
     log_block *blk = &_blocks.back();
-    mu->data.header.log_offset = blk->start_offset() + size();
+    mu->data.header.log_offset = start_offset() + size();
     mu->write_to([blk](const blob &bb) { blk->add(bb); });
     if (blk->size() > DEFAULT_MAX_BLOCK_BYTES) {
         _full_blocks_size += blk->size();

--- a/src/dist/replication/test/replica_test/unit_test/log_block_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/log_block_test.cpp
@@ -18,23 +18,91 @@ TEST_F(log_block_test, constructor)
     log_block block(1);
     ASSERT_EQ(block.data().size(), 1);
     ASSERT_EQ(block.size(), 16);
-    ASSERT_EQ(block.mutations().size(), 0);
-    ASSERT_EQ(block.callbacks().size(), 0);
     ASSERT_EQ(block.start_offset(), 1);
 }
 
-TEST_F(log_block_test, append_mutation)
+TEST_F(log_block_test, log_block_header)
 {
     log_block block(10);
+    auto hdr = (log_block_header *)block.front().data();
+    ASSERT_EQ(hdr->magic, 0xdeadbeef);
+    ASSERT_EQ(hdr->length, 0);
+    ASSERT_EQ(hdr->body_crc, 0);
+}
+
+class log_appender_test : public replica_test_base
+{
+};
+
+TEST_F(log_appender_test, constructor)
+{
+    log_block block;
+    binary_writer temp_writer;
+    temp_writer.write(8);
+    block.add(temp_writer.get_buffer());
+
+    log_appender appender(10, block);
+    ASSERT_EQ(appender.start_offset(), 10);
+    ASSERT_EQ(appender.blob_count(), 2);
+    ASSERT_EQ(appender.all_blocks().size(), 1);
+    ASSERT_EQ(appender.mutations().size(), 0);
+    ASSERT_EQ(appender.callbacks().size(), 0);
+}
+
+TEST_F(log_appender_test, append_mutation)
+{
+    log_appender appender(10);
     for (int i = 0; i < 5; i++) {
-        block.append_mutation(create_test_mutation(1 + i, "test"), nullptr);
+        appender.append_mutation(create_test_mutation(1 + i, "test"), nullptr);
     }
-    ASSERT_EQ(block.start_offset(), 10);
-    ASSERT_EQ(block.mutations().size(), 5);
-    ASSERT_EQ(block.callbacks().size(), 0);
+    ASSERT_EQ(appender.start_offset(), 10);
+    ASSERT_EQ(appender.mutations().size(), 5);
 
     // each mutation occupies 2 blobs, one for mutation header, one for mutation data.
+    ASSERT_EQ(appender.blob_count(), 1 + 5 * 2);
+}
+
+TEST_F(log_appender_test, log_block_not_full)
+{
+    log_appender appender(10);
+    for (int i = 0; i < 5; i++) {
+        appender.append_mutation(create_test_mutation(1 + i, "test"), nullptr);
+    }
+    ASSERT_EQ(appender.mutations().size(), 5);
+    ASSERT_EQ(appender.blob_count(), 1 + 5 * 2);
+    ASSERT_EQ(appender.start_offset(), 10);
+    ASSERT_EQ(appender.all_blocks().size(), 1);
+    ASSERT_EQ(appender.callbacks().size(), 0);
+    ASSERT_EQ(appender.mutations().size(), 5);
+
+    auto block = appender.all_blocks()[0];
+    ASSERT_EQ(block.start_offset(), 10);
     ASSERT_EQ(block.data().size(), 1 + 5 * 2);
 }
+
+TEST_F(log_appender_test, log_block_full)
+{
+    log_appender appender(10);
+    for (int i = 0; i < 1024; i++) { // more than DEFAULT_MAX_BLOCK_BYTES
+        appender.append_mutation(create_test_mutation(1 + i, std::string(1024, 'a')), nullptr);
+    }
+    ASSERT_EQ(appender.mutations().size(), 1024);
+    // two log_block_header blobs
+    ASSERT_EQ(appender.blob_count(), 2 + 1024 * 2);
+    // the first block's start offset
+    ASSERT_EQ(appender.start_offset(), 10);
+    // two log_blocks
+    ASSERT_EQ(appender.all_blocks().size(), 2);
+
+    size_t sz = 0;
+    size_t start_offset = 10;
+    for (const log_block &blk : appender.all_blocks()) {
+        ASSERT_EQ(start_offset, blk.start_offset());
+        sz += blk.size();
+        start_offset += blk.size();
+    }
+    ASSERT_EQ(sz, appender.size());
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/dist/replication/test/replica_test/unit_test/log_file_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/log_file_test.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "replica_test_base.h"
+
+namespace dsn {
+namespace replication {
+
+class log_file_test : public replica_test_base
+{
+public:
+    void SetUp() override
+    {
+        utils::filesystem::create_directory(_log_dir);
+        _logf = log_file::create_write(_log_dir.c_str(), 1, _start_offset);
+    }
+
+    void TearDown() override
+    {
+        _logf->close();
+        utils::filesystem::remove_path(_log_dir);
+    }
+
+protected:
+    log_file_ptr _logf;
+    size_t _start_offset{10};
+};
+
+TEST_F(log_file_test, commit_log_blocks)
+{
+    // write one block
+    auto appender = std::make_shared<log_appender>(_start_offset);
+    for (int i = 0; i < 5; i++) {
+        appender->append_mutation(create_test_mutation(1 + i, "test"), nullptr);
+    }
+    auto tsk = _logf->commit_log_blocks(*appender,
+                                        LPC_WRITE_REPLICATION_LOG_PRIVATE,
+                                        nullptr,
+                                        [&](error_code err, size_t sz) {
+                                            ASSERT_EQ(err, ERR_OK);
+                                            ASSERT_EQ(sz, appender->size());
+                                        },
+                                        0);
+    tsk->wait();
+    ASSERT_EQ(tsk->get_aio_context()->buffer_size, appender->size());
+    ASSERT_EQ(tsk->get_aio_context()->file_offset,
+              appender->start_offset() - _start_offset); // local offset
+
+    // write multiple blocks
+    size_t written_sz = appender->size();
+    appender = std::make_shared<log_appender>(_start_offset + written_sz);
+    for (int i = 0; i < 1024; i++) { // more than DEFAULT_MAX_BLOCK_BYTES
+        appender->append_mutation(create_test_mutation(1 + i, std::string(1024, 'a')), nullptr);
+    }
+    ASSERT_GT(appender->all_blocks().size(), 1);
+    tsk = _logf->commit_log_blocks(*appender,
+                                   LPC_WRITE_REPLICATION_LOG_PRIVATE,
+                                   nullptr,
+                                   [&](error_code err, size_t sz) {
+                                       ASSERT_EQ(err, ERR_OK);
+                                       ASSERT_EQ(sz, appender->size());
+                                   },
+                                   0);
+    tsk->wait();
+    ASSERT_EQ(tsk->get_aio_context()->buffer_size, appender->size());
+    ASSERT_EQ(tsk->get_aio_context()->file_offset, appender->start_offset() - _start_offset);
+}
+
+} // namespace replication
+} // namespace dsn


### PR DESCRIPTION
The current `mutation_log` implementation is unfriendly with such case:

There're some writes being flushed into the disk, in the meantime, new incoming writes are pending in the `log_block` waiting to be flushed.

As the pending `log_block` grows, it could be considerably large (like tens of MB) which is unfriendly for both replica recovery and duplication. I've met a bug while testing duplication that reading a large log block may cause tcmalloc to allocate an inaccessible memory.

This PR limits the log block to 1MB using `log_appender`, reduces the possibility of large block related bug.

`log_appender` is a buffer for multiple log blocks. This PR doesn't change the behavior that **all the pending writes** will be flushed to disk (`mutation_log::commit_pending_mutations`), **no matter how large the size is**. What changed is only the size of the log-block, so that reading the log block can be more smooth, without allocating large memory buffer.

While the buffered writes went flushed (which blocks another flush), the incoming writes will be buffered in a new `log_appender`. The old `log_appender` will be removed.