### PR TITLE
feat: add perf-counter for backup request

### DIFF
--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -82,8 +82,8 @@ replica::replica(
     // init table level latency perf counters
     init_table_level_latency_counters();
 
-    counter_str = fmt::format("table_level_backup_request_qps@{}", _app_info.app_name);
-    _counter_table_level_backup_request_qps.init_app_counter(
+    counter_str = fmt::format("backup_request_qps@{}", _app_info.app_name);
+    _counter_backup_request_qps.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_RATE, counter_str.c_str());
 
     if (need_restore) {
@@ -171,7 +171,7 @@ void replica::on_client_read(dsn::message_ex *request)
             return;
         }
     } else {
-        _counter_table_level_backup_request_qps->increment();
+        _counter_backup_request_qps->increment();
     }
 
     uint64_t start_time_ns = dsn_now_ns();

--- a/src/dist/replication/lib/replica.cpp
+++ b/src/dist/replication/lib/replica.cpp
@@ -82,6 +82,10 @@ replica::replica(
     // init table level latency perf counters
     init_table_level_latency_counters();
 
+    counter_str = fmt::format("table_level_backup_request_qps@{}", _app_info.app_name);
+    _counter_table_level_backup_request_qps.init_app_counter(
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_RATE, counter_str.c_str());
+
     if (need_restore) {
         // add an extra env for restore
         _extra_envs.insert(
@@ -166,6 +170,8 @@ void replica::on_client_read(dsn::message_ex *request)
             response_client_read(request, ERR_INVALID_STATE);
             return;
         }
+    } else {
+        _counter_table_level_backup_request_qps->increment();
     }
 
     uint64_t start_time_ns = dsn_now_ns();

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -512,7 +512,7 @@ private:
     perf_counter_wrapper _counter_recent_write_throttling_delay_count;
     perf_counter_wrapper _counter_recent_write_throttling_reject_count;
     std::vector<perf_counter *> _counters_table_level_latency;
-    perf_counter_wrapper _counter_table_level_backup_request_qps;
+    perf_counter_wrapper _counter_backup_request_qps;
 
     dsn::task_tracker _tracker;
     // the thread access checker

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -420,6 +420,7 @@ private:
     friend class replica_duplicator_manager;
     friend class load_mutation;
     friend class replica_split_test;
+    friend class replica_test;
 
     // replica configuration, updated by update_local_configuration ONLY
     replica_configuration _config;
@@ -511,6 +512,7 @@ private:
     perf_counter_wrapper _counter_recent_write_throttling_delay_count;
     perf_counter_wrapper _counter_recent_write_throttling_reject_count;
     std::vector<perf_counter *> _counters_table_level_latency;
+    perf_counter_wrapper _counter_table_level_backup_request_qps;
 
     dsn::task_tracker _tracker;
     // the thread access checker

--- a/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
@@ -68,10 +68,9 @@ TEST_F(replica_test, write_size_limited)
 TEST_F(replica_test, backup_request_qps)
 {
     // create backup request
-    message_ptr backup_request = dsn::message_ex::create_request(task_code());
-    auto cleanup = dsn::defer([=]() { delete backup_request; });
     struct dsn::message_header header;
     header.context.u.is_backup_request = true;
+    message_ptr backup_request = dsn::message_ex::create_request(task_code());
     backup_request->header = &header;
 
     _mock_replica->on_client_read(backup_request);

--- a/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
@@ -16,18 +16,24 @@ class replica_test : public replica_test_base
 public:
     dsn::app_info _app_info;
     dsn::gpid pid = gpid(2, 1);
+    mock_replica_ptr _mock_replica;
 
 public:
     void SetUp() override
     {
         stub->install_perf_counters();
         mock_app_info();
-        stub->generate_replica(_app_info, pid, partition_status::PS_PRIMARY, 1);
+        _mock_replica = stub->generate_replica(_app_info, pid, partition_status::PS_PRIMARY, 1);
     }
 
     int get_write_size_exceed_threshold_count()
     {
         return stub->_counter_recent_write_size_exceed_threshold_count->get_value();
+    }
+
+    int get_table_level_backup_request_qps()
+    {
+        return _mock_replica->_counter_table_level_backup_request_qps->get_integer_value();
     }
 
     void mock_app_info()
@@ -57,6 +63,23 @@ TEST_F(replica_test, write_size_limited)
     }
 
     ASSERT_EQ(get_write_size_exceed_threshold_count(), count);
+}
+
+TEST_F(replica_test, backup_request_qps)
+{
+    // create backup request
+    auto backup_request = dsn::message_ex::create_request(task_code());
+    auto cleanup = dsn::defer([=]() { delete backup_request; });
+    struct dsn::message_header header;
+    header.context.u.is_backup_request = true;
+    backup_request->header = &header;
+
+    _mock_replica->on_client_read(backup_request);
+
+    // we have to sleep >= 0.1s, or the value this perf-counter will be 0, according to the
+    // implementation of perf-counter which type is COUNTER_TYPE_RATE.
+    usleep(1e5);
+    ASSERT_GT(get_table_level_backup_request_qps(), 0);
 }
 
 } // namespace replication

--- a/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
@@ -33,7 +33,7 @@ public:
 
     int get_table_level_backup_request_qps()
     {
-        return _mock_replica->_counter_table_level_backup_request_qps->get_integer_value();
+        return _mock_replica->_counter_backup_request_qps->get_integer_value();
     }
 
     void mock_app_info()

--- a/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
@@ -68,7 +68,7 @@ TEST_F(replica_test, write_size_limited)
 TEST_F(replica_test, backup_request_qps)
 {
     // create backup request
-    auto backup_request = dsn::message_ex::create_request(task_code());
+    message_ptr backup_request = dsn::message_ex::create_request(task_code());
     auto cleanup = dsn::defer([=]() { delete backup_request; });
     struct dsn::message_header header;
     header.context.u.is_backup_request = true;

--- a/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_test.cpp
@@ -76,7 +76,7 @@ TEST_F(replica_test, backup_request_qps)
 
     _mock_replica->on_client_read(backup_request);
 
-    // we have to sleep >= 0.1s, or the value this perf-counter will be 0, according to the
+    // We have to sleep >= 0.1s, or the value this perf-counter will be 0, according to the
     // implementation of perf-counter which type is COUNTER_TYPE_RATE.
     usleep(1e5);
     ASSERT_GT(get_table_level_backup_request_qps(), 0);


### PR DESCRIPTION
Add a perf-counter to statistics the qps of backup request for each app.

Related issue: https://github.com/XiaoMi/pegasus/issues/251