### PR TITLE
fix(dup): multiple fixes on replica duplication

### DIFF
--- a/src/dist/replication/lib/duplication/duplication_pipeline.cpp
+++ b/src/dist/replication/lib/duplication/duplication_pipeline.cpp
@@ -55,7 +55,7 @@ void ship_mutation::ship(mutation_tuple_set &&in)
 {
     _mutation_duplicator->duplicate(std::move(in), [this](size_t total_shipped_size) mutable {
         update_progress();
-        _stub->_counter_dup_shipped_bytes_rate->add(total_shipped_size);
+        _counter_dup_shipped_bytes_rate->add(total_shipped_size);
         step_down_next_stage();
     });
 }
@@ -93,6 +93,11 @@ ship_mutation::ship_mutation(replica_duplicator *duplicator)
     _mutation_duplicator = new_mutation_duplicator(
         duplicator, _duplicator->remote_cluster_name(), _replica->get_app_info()->app_name);
     _mutation_duplicator->set_task_environment(duplicator);
+
+    _counter_dup_shipped_bytes_rate.init_app_counter("eon.replica_stub",
+                                                     "dup.shipped_bytes_rate",
+                                                     COUNTER_TYPE_RATE,
+                                                     "shipping rate of private log in bytes");
 }
 
 } // namespace replication

--- a/src/dist/replication/lib/duplication/duplication_pipeline.h
+++ b/src/dist/replication/lib/duplication/duplication_pipeline.h
@@ -70,6 +70,8 @@ private:
     replica_stub *_stub;
 
     decree _last_decree{invalid_decree};
+
+    perf_counter_wrapper _counter_dup_shipped_bytes_rate;
 };
 
 } // namespace replication

--- a/src/dist/replication/lib/duplication/load_from_private_log.h
+++ b/src/dist/replication/lib/duplication/load_from_private_log.h
@@ -7,6 +7,7 @@
 #include <dsn/cpp/pipeline.h>
 #include <dsn/utility/errors.h>
 #include <dsn/dist/replication/mutation_duplicator.h>
+#include <gtest/gtest_prod.h>
 
 #include "dist/replication/lib/mutation_log.h"
 #include "mutation_batch.h"
@@ -48,6 +49,12 @@ public:
 
     void start_from_log_file(log_file_ptr f);
 
+    void TEST_set_repeat_delay(std::chrono::milliseconds delay)
+    {
+        const_cast<std::chrono::milliseconds &>(_repeat_delay) = delay;
+    }
+    static constexpr int MAX_ALLOWED_BLOCK_REPEATS{3};
+
 private:
     friend class load_from_private_log_test;
 
@@ -61,10 +68,14 @@ private:
     int64_t _current_global_end_offset{0};
     mutation_batch _mutation_batch;
 
-    // How many times it repeats reading from _start_offset but failed.
-    int _err_repeats_num{0};
+    // How many times it repeats reading from current block but failed.
+    int _err_block_repeats_num{0};
 
     decree _start_decree{0};
+
+    perf_counter_wrapper _counter_dup_load_file_failed_count;
+    perf_counter_wrapper _counter_dup_log_read_bytes_rate;
+    perf_counter_wrapper _counter_dup_log_read_mutations_rate;
 
     std::chrono::milliseconds _repeat_delay{10_s};
 };

--- a/src/dist/replication/lib/duplication/replica_duplicator.cpp
+++ b/src/dist/replication/lib/duplication/replica_duplicator.cpp
@@ -64,11 +64,13 @@ void replica_duplicator::pause_dup()
     ddebug_replica("pausing duplication: {}", to_string());
 
     pause();
-    wait_all();
+    cancel_all();
 
     _load.reset();
     _ship.reset();
     _load_private.reset();
+
+    ddebug_replica("duplication paused: {}", to_string());
 }
 
 std::string replica_duplicator::to_string() const

--- a/src/dist/replication/lib/duplication/replica_duplicator.h
+++ b/src/dist/replication/lib/duplication/replica_duplicator.h
@@ -108,6 +108,7 @@ private:
     friend class replica_duplicator_test;
     friend class duplication_sync_timer_test;
     friend class load_from_private_log_test;
+    friend class ship_mutation_test;
 
     friend class load_mutation;
     friend class ship_mutation;

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -228,19 +228,6 @@ void replica_stub::install_perf_counters()
 
     // <- Duplication Metrics ->
 
-    _counter_dup_log_read_bytes_rate.init_app_counter("eon.replica_stub",
-                                                      "dup.log_read_bytes_rate",
-                                                      COUNTER_TYPE_RATE,
-                                                      "reading rate of private log in bytes");
-    _counter_dup_log_read_mutations_rate.init_app_counter(
-        "eon.replica_stub",
-        "dup.log_read_mutations_rate",
-        COUNTER_TYPE_RATE,
-        "reading rate of mutations from private log");
-    _counter_dup_shipped_bytes_rate.init_app_counter("eon.replica_stub",
-                                                     "dup.shipped_bytes_rate",
-                                                     COUNTER_TYPE_RATE,
-                                                     "shipping rate of private log in bytes");
     _counter_dup_confirmed_rate.init_app_counter("eon.replica_stub",
                                                  "dup.confirmed_rate",
                                                  COUNTER_TYPE_RATE,

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -273,8 +273,6 @@ private:
     friend class ::dsn::replication::potential_secondary_context;
     friend class ::dsn::replication::cold_backup_context;
 
-    friend class load_from_private_log;
-    friend class ship_mutation;
     friend class replica_duplicator;
     friend class replica_http_service;
 
@@ -393,9 +391,6 @@ private:
     // <- Duplication Metrics ->
     // TODO(wutao1): calculate the counters independently for each remote cluster
     //               if we need to duplicate to multiple clusters someday.
-    perf_counter_wrapper _counter_dup_log_read_bytes_rate;
-    perf_counter_wrapper _counter_dup_log_read_mutations_rate;
-    perf_counter_wrapper _counter_dup_shipped_bytes_rate;
     perf_counter_wrapper _counter_dup_confirmed_rate;
     perf_counter_wrapper _counter_dup_pending_mutations_count;
     perf_counter_wrapper _counter_dup_time_lag;


### PR DESCRIPTION
1. Some duplication perf-counters are moved  from `replica_stub` to where they are updated:

  - `_counter_dup_shipped_bytes_rate` to `ship_mutattion`
  - `_counter_dup_log_read_mutations_rate` to `load_from_private_log`
  - `_counter_dup_log_read_bytes_rate` to `load_from_private_log`

One advantage is when duplication is paused, these perf-counters will be immediately removed, due to destruction of the duplication pipeline. Therefore we can ensure these counters are accurate after pause_dup.

Another advantage is the improved modularity by separating duplication metrics from `replica_stub`, reduce its code complexity.

2. Uses `cancel_all` instead of `wait_all` for pause_dup. (replica_duplicator.h)

Formerly duplication may not be able to pause in some bad cases, for example, where the remote cluster is shutdown, "wait_all" keeps waiting indefinitely. So I change to `cancel_all`, which cancels the retrying RPCs during pause_dup.

This modification has passed unit test `ship_mutation_test.pause`.

3. Add monitoring for failures of log loading (load_from_private_log.h)

I assume data corruption in log file is probable, so log loading may fail infinitely in this edge case.
I add a new perf-counter "eon.replica_stub dup.load_file_failed_count", incremented each time the log block reading failed 3 times. Because when it happens, human interference is necessary.This perf-counter is useful for alerting to ops.
