### PR TITLE
refactor: move log-block-writing-related codes from mutation_log to log_block

### DIFF
--- a/src/dist/replication/lib/log_block.h
+++ b/src/dist/replication/lib/log_block.h
@@ -26,8 +26,14 @@ class log_block
 {
     std::vector<blob> _data; // the first blob is log_block_header
     size_t _size{0};         // total data size of all blobs
+    std::vector<mutation_ptr> _mutations;
+    std::vector<aio_task_ptr> _callbacks;
+    int64_t _start_offset{0};
+
 public:
     log_block();
+
+    explicit log_block(int64_t start_offset);
 
     // get all blobs in the block
     const std::vector<blob> &data() const { return _data; }
@@ -54,11 +60,21 @@ public:
         _data.push_back(bb);
     }
 
+    void append_mutation(const mutation_ptr &mu, const aio_task_ptr &cb);
+
+    const std::vector<mutation_ptr> &mutations() const { return _mutations; }
+
+    const std::vector<aio_task_ptr> &callbacks() const { return _callbacks; }
+
     // return total data size in the block
     size_t size() const { return _size; }
+
+    // global offset to start writting this block
+    int64_t start_offset() const { return _start_offset; }
 
 private:
     void init();
 };
+
 } // namespace replication
 } // namespace dsn

--- a/src/dist/replication/lib/mutation_log.cpp
+++ b/src/dist/replication/lib/mutation_log.cpp
@@ -54,23 +54,9 @@ namespace replication {
 
     // init pending buffer
     if (nullptr == _pending_write) {
-        _pending_write.reset(new log_block());
-        _pending_write_callbacks.reset(new callbacks());
-        _pending_write_mutations.reset(new mutations());
-        _pending_write_start_offset = mark_new_offset(0, true).second;
+        _pending_write = make_unique<log_block>(mark_new_offset(0, true).second);
     }
-
-    // save mutations
-    _pending_write_mutations->push_back(mu);
-
-    // save cb for pinning buffer
-    if (cb) {
-        _pending_write_callbacks->push_back(cb);
-    }
-
-    // write mutation to pending buffer
-    mu->data.header.log_offset = _pending_write_start_offset + _pending_write->size();
-    mu->write_to([this](blob bb) { _pending_write->add(bb); });
+    _pending_write->append_mutation(mu, cb);
 
     // update meta
     update_max_decree(mu->data.header.pid, d);
@@ -125,19 +111,13 @@ void mutation_log_shared::write_pending_mutations(bool release_lock_required)
     dassert(_pending_write != nullptr, "");
     dassert(_pending_write->size() > 0, "pending write size = %d", (int)_pending_write->size());
     auto pr = mark_new_offset(_pending_write->size(), false);
-    dassert(pr.second == _pending_write_start_offset,
-            "%" PRId64 " VS %" PRId64 "",
-            pr.second,
-            _pending_write_start_offset);
+    dcheck_eq(pr.second, _pending_write->start_offset());
 
     _is_writing.store(true, std::memory_order_release);
 
     // move or reset pending variables
     std::shared_ptr<log_block> blk = std::move(_pending_write);
-    std::shared_ptr<callbacks> pwu = std::move(_pending_write_callbacks);
-    std::shared_ptr<mutations> pmu = std::move(_pending_write_mutations);
-    int64_t start_offset = _pending_write_start_offset;
-    _pending_write_start_offset = 0;
+    int64_t start_offset = blk->start_offset();
 
     // seperate commit_log_block from within the lock
     _slock.unlock();
@@ -147,13 +127,7 @@ void mutation_log_shared::write_pending_mutations(bool release_lock_required)
         start_offset,
         LPC_WRITE_REPLICATION_LOG_SHARED,
         &_tracker,
-        [
-          this,
-          lf = pr.first,
-          block = blk,
-          callbacks = std::move(pwu),
-          mutations = std::move(pmu)
-        ](error_code err, size_t sz) mutable {
+        [ this, lf = pr.first, block = blk ](error_code err, size_t sz) mutable {
             dassert(_is_writing.load(std::memory_order_relaxed), "");
 
             auto hdr = (log_block_header *)block->front().data();
@@ -192,7 +166,7 @@ void mutation_log_shared::write_pending_mutations(bool release_lock_required)
 
             // notify the callbacks
             // ATTENTION: callback may be called before this code block executed done.
-            for (auto &c : *callbacks) {
+            for (auto &c : block->callbacks()) {
                 c->enqueue(err, sz);
             }
 
@@ -241,18 +215,10 @@ mutation_log_private::mutation_log_private(const std::string &dir,
 
     // init pending buffer
     if (nullptr == _pending_write) {
-        _pending_write.reset(new log_block());
-        _pending_write_mutations.reset(new mutations());
-        _pending_write_start_offset = mark_new_offset(0, true).second;
+        _pending_write = make_unique<log_block>(mark_new_offset(0, true).second);
         _pending_write_start_time_ms = dsn_now_ms();
     }
-
-    // save mu for pinning buffer
-    _pending_write_mutations->push_back(mu);
-
-    // write mutation to pending buffer
-    mu->data.header.log_offset = _pending_write_start_offset + _pending_write->size();
-    mu->write_to([this](blob bb) { _pending_write->add(bb); });
+    _pending_write->append_mutation(mu, nullptr);
 
     // update meta
     _pending_write_max_commit =
@@ -281,22 +247,22 @@ mutation_log_private::mutation_log_private(const std::string &dir,
 bool mutation_log_private::get_learn_state_in_memory(decree start_decree,
                                                      binary_writer &writer) const
 {
-    std::shared_ptr<mutations> issued_mutations;
+    std::shared_ptr<log_block> emitted_block;
     mutations pending_mutations;
     {
         zauto_lock l(_plock);
 
-        issued_mutations = _issued_write_mutations.lock();
+        emitted_block = _emitted_block.lock();
 
-        if (_pending_write_mutations) {
-            pending_mutations = *_pending_write_mutations;
+        if (_pending_write) {
+            pending_mutations = _pending_write->mutations();
         }
     }
 
     int learned_count = 0;
 
-    if (issued_mutations) {
-        for (auto &mu : *issued_mutations) {
+    if (emitted_block) {
+        for (auto &mu : emitted_block->mutations()) {
             if (mu->get_decree() >= start_decree) {
                 mu->write_to(writer, nullptr);
                 learned_count++;
@@ -318,18 +284,18 @@ void mutation_log_private::get_in_memory_mutations(decree start_decree,
                                                    ballot start_ballot,
                                                    std::vector<mutation_ptr> &mutation_list) const
 {
-    std::shared_ptr<mutations> issued_mutations;
+    std::shared_ptr<log_block> emitted_block;
     mutations pending_mutations;
     {
         zauto_lock l(_plock);
-        issued_mutations = _issued_write_mutations.lock();
-        if (_pending_write_mutations) {
-            pending_mutations = *_pending_write_mutations;
+        emitted_block = _emitted_block.lock();
+        if (_pending_write) {
+            pending_mutations = _pending_write->mutations();
         }
     }
 
-    if (issued_mutations) {
-        for (auto &mu : *issued_mutations) {
+    if (emitted_block) {
+        for (auto &mu : emitted_block->mutations()) {
             // if start_ballot is invalid or equal to mu.ballot, check decree
             // otherwise check ballot
             ballot current_ballot =
@@ -386,10 +352,8 @@ void mutation_log_private::init_states()
     mutation_log::init_states();
 
     _is_writing.store(false, std::memory_order_release);
-    _issued_write_mutations.reset();
+    _emitted_block.reset();
     _pending_write = nullptr;
-    _pending_write_mutations = nullptr;
-    _pending_write_start_offset = 0;
     _pending_write_start_time_ms = 0;
     _pending_write_max_commit = 0;
     _pending_write_max_decree = 0;
@@ -402,7 +366,7 @@ void mutation_log_private::write_pending_mutations(bool release_lock_required)
     dassert(_pending_write != nullptr, "");
     dassert(_pending_write->size() > 0, "pending write size = %d", (int)_pending_write->size());
     auto pr = mark_new_offset(_pending_write->size(), false);
-    dcheck_eq_replica(pr.second, _pending_write_start_offset);
+    dcheck_eq_replica(pr.second, _pending_write->start_offset());
 
     _is_writing.store(true, std::memory_order_release);
 
@@ -410,16 +374,15 @@ void mutation_log_private::write_pending_mutations(bool release_lock_required)
 
     // move or reset pending variables
     std::shared_ptr<log_block> blk = std::move(_pending_write);
-    _issued_write_mutations = _pending_write_mutations;
-    std::shared_ptr<mutations> pwu = std::move(_pending_write_mutations);
-    int64_t start_offset = _pending_write_start_offset;
-    _pending_write_start_offset = 0;
+    _emitted_block = blk;
+    int64_t start_offset = blk->start_offset();
     _pending_write_start_time_ms = 0;
     decree max_commit = _pending_write_max_commit;
     _pending_write_max_commit = 0;
     _pending_write_max_decree = 0;
 
-    // seperate commit_log_block from within the lock
+    // Free plog from lock during committing log block, in the meantime
+    // new mutations can still be appended.
     _plock.unlock();
 
     pr.first->commit_log_block(
@@ -427,8 +390,7 @@ void mutation_log_private::write_pending_mutations(bool release_lock_required)
         start_offset,
         LPC_WRITE_REPLICATION_LOG_PRIVATE,
         &_tracker,
-        [ this, lf = pr.first, block = blk, mutations = std::move(pwu), max_commit ](
-            error_code err, size_t sz) mutable {
+        [ this, lf = pr.first, block = blk, max_commit ](error_code err, size_t sz) mutable {
             dassert(_is_writing.load(std::memory_order_relaxed), "");
 
             auto hdr = (log_block_header *)block->front().data();

--- a/src/dist/replication/lib/mutation_log.h
+++ b/src/dist/replication/lib/mutation_log.h
@@ -430,7 +430,6 @@ public:
                         perf_counter_wrapper *write_size_counter = nullptr)
         : mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr),
           _is_writing(false),
-          _pending_write(new log_block()),
           _force_flush(force_flush),
           _write_size_counter(write_size_counter)
     {
@@ -469,7 +468,7 @@ private:
     // bufferring - only one concurrent write is allowed
     mutable zlock _slock;
     std::atomic_bool _is_writing;
-    std::unique_ptr<log_block> _pending_write;
+    std::shared_ptr<log_block> _pending_write;
 
     bool _force_flush;
     perf_counter_wrapper *_write_size_counter;
@@ -540,11 +539,11 @@ private:
     // bufferring - only one concurrent write is allowed
     typedef std::vector<mutation_ptr> mutations;
     std::atomic_bool _is_writing;
-    std::shared_ptr<log_block> _pending_write;
     // Writes that are emitted to `commit_log_block` but are not completely written.
     // The weak_ptr used here is a trick. Once the pointer freed, ie.
     // `_issued_write.lock() == nullptr`, it means the emitted writes all finished.
     std::weak_ptr<log_block> _issued_write;
+    std::shared_ptr<log_block> _pending_write;
     uint64_t _pending_write_start_time_ms;
     decree _pending_write_max_commit;
     decree _pending_write_max_decree;

--- a/src/dist/replication/lib/mutation_log.h
+++ b/src/dist/replication/lib/mutation_log.h
@@ -543,8 +543,8 @@ private:
     std::shared_ptr<log_block> _pending_write;
     // Writes that are emitted to `commit_log_block` but are not completely written.
     // The weak_ptr used here is a trick. Once the pointer freed, ie.
-    // `_emitted_block.lock() == nullptr`, it means the emitted writes all finished.
-    std::weak_ptr<log_block> _emitted_block;
+    // `_issued_write.lock() == nullptr`, it means the emitted writes all finished.
+    std::weak_ptr<log_block> _issued_write;
     uint64_t _pending_write_start_time_ms;
     decree _pending_write_max_commit;
     decree _pending_write_max_decree;

--- a/src/dist/replication/lib/mutation_log.h
+++ b/src/dist/replication/lib/mutation_log.h
@@ -430,7 +430,7 @@ public:
                         perf_counter_wrapper *write_size_counter = nullptr)
         : mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr),
           _is_writing(false),
-          _pending_write_start_offset(0),
+          _pending_write(new log_block()),
           _force_flush(force_flush),
           _write_size_counter(write_size_counter)
     {
@@ -467,14 +467,9 @@ private:
 
 private:
     // bufferring - only one concurrent write is allowed
-    typedef std::vector<aio_task_ptr> callbacks;
-    typedef std::vector<mutation_ptr> mutations;
     mutable zlock _slock;
     std::atomic_bool _is_writing;
-    std::shared_ptr<log_block> _pending_write;
-    std::shared_ptr<callbacks> _pending_write_callbacks;
-    std::shared_ptr<mutations> _pending_write_mutations;
-    int64_t _pending_write_start_offset;
+    std::unique_ptr<log_block> _pending_write;
 
     bool _force_flush;
     perf_counter_wrapper *_write_size_counter;
@@ -545,10 +540,11 @@ private:
     // bufferring - only one concurrent write is allowed
     typedef std::vector<mutation_ptr> mutations;
     std::atomic_bool _is_writing;
-    std::weak_ptr<mutations> _issued_write_mutations;
     std::shared_ptr<log_block> _pending_write;
-    std::shared_ptr<mutations> _pending_write_mutations;
-    int64_t _pending_write_start_offset;
+    // Writes that are emitted to `commit_log_block` but are not completely written.
+    // The weak_ptr used here is a trick. Once the pointer freed, ie.
+    // `_emitted_block.lock() == nullptr`, it means the emitted writes all finished.
+    std::weak_ptr<log_block> _emitted_block;
     uint64_t _pending_write_start_time_ms;
     decree _pending_write_max_commit;
     decree _pending_write_max_decree;

--- a/src/dist/replication/test/replica_test/unit_test/log_block_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/log_block_test.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "replica_test_base.h"
+
+namespace dsn {
+namespace replication {
+
+class log_block_test : public replica_test_base
+{
+};
+
+TEST_F(log_block_test, constructor)
+{
+    log_block block(1);
+    ASSERT_EQ(block.data().size(), 1);
+    ASSERT_EQ(block.size(), 16);
+    ASSERT_EQ(block.mutations().size(), 0);
+    ASSERT_EQ(block.callbacks().size(), 0);
+    ASSERT_EQ(block.start_offset(), 1);
+}
+
+TEST_F(log_block_test, append_mutation)
+{
+    log_block block(10);
+    for (int i = 0; i < 5; i++) {
+        block.append_mutation(create_test_mutation(1 + i, "test"), nullptr);
+    }
+    ASSERT_EQ(block.start_offset(), 10);
+    ASSERT_EQ(block.mutations().size(), 5);
+    ASSERT_EQ(block.callbacks().size(), 0);
+
+    // each mutation occupies 2 blobs, one for mutation header, one for mutation data.
+    ASSERT_EQ(block.data().size(), 1 + 5 * 2);
+}
+} // namespace replication
+} // namespace dsn


### PR DESCRIPTION
To write a mutation, the mutation_log first appends it to `_pending write`, which is a `log_block`, then flush this block to disk by `commit_log_block`.

Throughout the procedure, some variables are participated, for shared log:

```cpp
    std::shared_ptr<log_block> _pending_write;
    std::shared_ptr<callbacks> _pending_write_callbacks;
    std::shared_ptr<mutations> _pending_write_mutations;
    int64_t _pending_write_start_offset;
```

For private log:

```cpp
    std::shared_ptr<log_block> _pending_write;
    std::shared_ptr<mutations> _pending_write_mutations;
    int64_t _pending_write_start_offset;
    uint64_t _pending_write_start_time_ms;
    decree _pending_write_max_commit;
    decree _pending_write_max_decree;
```

Apparently, some codes and variables are repeated in both private log and shared log that we can wrap into `log_block`. Take `log_block::append_mutation` as an example:

```cpp
mutation_log_shared::append(mutation_ptr &mu) {
    ...
    // save mutations
    _pending_write_mutations->push_back(mu);

    // save cb for pinning buffer
    if (cb) {
        _pending_write_callbacks->push_back(cb);
    }

    // write mutation to pending buffer
    mu->data.header.log_offset = _pending_write_start_offset + _pending_write->size();
    mu->write_to([this](blob bb) { _pending_write->add(bb); });
```

```cpp
mutation_log_private::append(mutation_ptr &mu) {
    ...
    // save mu for pinning buffer
    _pending_write_mutations->push_back(mu);

    // write mutation to pending buffer
    mu->data.header.log_offset = _pending_write_start_offset + _pending_write->size();
    mu->write_to([this](blob bb) { _pending_write->add(bb); });
```

The repeated codes can both be eliminated by using `log_block::append_mutation` now.