### PR TITLE
feat: tcmalloc memory release improvements

### DIFF
--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2480,6 +2480,7 @@ static int64_t get_tcmalloc_numeric_property(const char *prop)
 
 void replica_stub::gc_tcmalloc_memory()
 {
+    int64_t tcmalloc_released_bytes = 0;
     if (_release_tcmalloc_memory) {
         int64_t total_allocated_bytes =
             get_tcmalloc_numeric_property("generic.current_allocated_bytes");
@@ -2492,7 +2493,7 @@ void replica_stub::gc_tcmalloc_memory()
             total_allocated_bytes * _mem_release_max_reserved_mem_percentage / 100.0;
         if (reserved_bytes > max_reserved_bytes) {
             int64_t release_bytes = reserved_bytes - max_reserved_bytes;
-            _counter_tcmalloc_release_memory_size->set(release_bytes);
+            tcmalloc_released_bytes = release_bytes;
             ddebug_f("Memory release started, almost {} bytes will be released", release_bytes);
             while (release_bytes > 0) {
                 // tcmalloc releasing memory will lock page heap, release 1MB at a time to avoid
@@ -2503,6 +2504,7 @@ void replica_stub::gc_tcmalloc_memory()
             }
         }
     }
+    _counter_tcmalloc_release_memory_size->set(tcmalloc_released_bytes);
 }
 #endif
 

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2504,8 +2504,7 @@ void replica_stub::gc_tcmalloc_memory()
         tcmalloc_released_bytes = release_bytes;
         ddebug_f("Memory release started, almost {} bytes will be released", release_bytes);
         while (release_bytes > 0) {
-            // tcmalloc releasing memory will lock page heap, release 1MB at a time to avoid
-            // locking
+            // tcmalloc releasing memory will lock page heap, release 1MB at a time to avoid locking
             // page heap for long time
             ::MallocExtension::instance()->ReleaseToSystem(1024 * 1024);
             release_bytes -= 1024 * 1024;

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -69,12 +69,14 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
       _query_compact_command(nullptr),
       _query_app_envs_command(nullptr),
       _useless_dir_reserve_seconds_command(nullptr),
+      _release_tcmalloc_memory_command(nullptr),
       _max_reserved_memory_percentage_command(nullptr),
       _deny_client(false),
       _verbose_client_log(false),
       _verbose_commit_log(false),
       _gc_disk_error_replica_interval_seconds(3600),
       _gc_disk_garbage_replica_interval_seconds(3600),
+      _release_tcmalloc_memory(false),
       _mem_release_max_reserved_mem_percentage(10),
       _learn_app_concurrent_count(0),
       _fs_manager(false)
@@ -323,6 +325,13 @@ void replica_stub::install_perf_counters()
         "recent_write_size_exceed_threshold_count",
         COUNTER_TYPE_VOLATILE_NUMBER,
         "write size exceed threshold count in the recent period");
+
+#ifdef DSN_ENABLE_GPERF
+    _counter_tcmalloc_release_memory_size.init_app_counter("eon.replica_stub",
+                                                           "tcmalloc.release.memory.size",
+                                                           COUNTER_TYPE_NUMBER,
+                                                           "current tcmalloc release memory size");
+#endif
 }
 
 void replica_stub::initialize(bool clear /* = false*/)
@@ -352,6 +361,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     _verbose_commit_log = _options.verbose_commit_log_on_start;
     _gc_disk_error_replica_interval_seconds = _options.gc_disk_error_replica_interval_seconds;
     _gc_disk_garbage_replica_interval_seconds = _options.gc_disk_garbage_replica_interval_seconds;
+    _release_tcmalloc_memory = _options.mem_release_enabled;
     _mem_release_max_reserved_mem_percentage = _options.mem_release_max_reserved_mem_percentage;
 
     // clear dirs if need
@@ -673,15 +683,13 @@ void replica_stub::initialize_start()
     }
 
 #ifdef DSN_ENABLE_GPERF
-    if (_options.mem_release_enabled) {
-        _mem_release_timer_task = tasking::enqueue_timer(
-            LPC_MEM_RELEASE,
-            &_tracker,
-            std::bind(&replica_stub::gc_tcmalloc_memory, this),
-            std::chrono::milliseconds(_options.mem_release_check_interval_ms),
-            0,
-            std::chrono::milliseconds(_options.mem_release_check_interval_ms));
-    }
+    _mem_release_timer_task =
+        tasking::enqueue_timer(LPC_MEM_RELEASE,
+                               &_tracker,
+                               std::bind(&replica_stub::gc_tcmalloc_memory, this),
+                               std::chrono::milliseconds(_options.mem_release_check_interval_ms),
+                               0,
+                               std::chrono::milliseconds(_options.mem_release_check_interval_ms));
 #endif
 
     if (_options.duplication_enabled) {
@@ -2158,6 +2166,15 @@ void replica_stub::open_service()
         });
 
 #ifdef DSN_ENABLE_GPERF
+    _release_tcmalloc_memory_command = ::dsn::command_manager::instance().register_app_command(
+        {"release-tcmalloc-memory"},
+        "release-tcmalloc-memory <true|false>",
+        "release-tcmalloc-memory - control if try to release tcmalloc memory",
+        [this](const std::vector<std::string> &args) {
+            return remote_command_set_bool_flag(
+                _release_tcmalloc_memory, "release-tcmalloc-memory", args);
+        });
+
     _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_app_command(
         {"mem-release-max-reserved-percentage"},
         "mem-release-max-reserved-percentage [num | DEFAULT]",
@@ -2177,7 +2194,7 @@ void replica_stub::open_service()
                 return result;
             }
             int32_t percentage = 0;
-            if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 || percentage >= 100) {
+            if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 || percentage > 100) {
                 result = std::string("ERR: invalid arguments");
             } else {
                 _mem_release_max_reserved_mem_percentage = percentage;
@@ -2311,6 +2328,7 @@ void replica_stub::close()
     dsn::command_manager::instance().deregister_command(_query_app_envs_command);
     dsn::command_manager::instance().deregister_command(_useless_dir_reserve_seconds_command);
 #ifdef DSN_ENABLE_GPERF
+    dsn::command_manager::instance().deregister_command(_release_tcmalloc_memory_command);
     dsn::command_manager::instance().deregister_command(_max_reserved_memory_percentage_command);
 #endif
 
@@ -2322,6 +2340,7 @@ void replica_stub::close()
     _query_compact_command = nullptr;
     _query_app_envs_command = nullptr;
     _useless_dir_reserve_seconds_command = nullptr;
+    _release_tcmalloc_memory_command = nullptr;
     _max_reserved_memory_percentage_command = nullptr;
 
     if (_config_sync_timer_task != nullptr) {
@@ -2461,23 +2480,27 @@ static int64_t get_tcmalloc_numeric_property(const char *prop)
 
 void replica_stub::gc_tcmalloc_memory()
 {
-    int64_t total_allocated_bytes =
-        get_tcmalloc_numeric_property("generic.current_allocated_bytes");
-    int64_t reserved_bytes = get_tcmalloc_numeric_property("tcmalloc.pageheap_free_bytes");
-    if (total_allocated_bytes == -1 || reserved_bytes == -1) {
-        return;
-    }
+    if (_release_tcmalloc_memory) {
+        int64_t total_allocated_bytes =
+            get_tcmalloc_numeric_property("generic.current_allocated_bytes");
+        int64_t reserved_bytes = get_tcmalloc_numeric_property("tcmalloc.pageheap_free_bytes");
+        if (total_allocated_bytes == -1 || reserved_bytes == -1) {
+            return;
+        }
 
-    int64_t max_reserved_bytes =
-        total_allocated_bytes * _mem_release_max_reserved_mem_percentage / 100.0;
-    if (reserved_bytes > max_reserved_bytes) {
-        int64_t release_bytes = reserved_bytes - max_reserved_bytes;
-        ddebug_f("Memory release started, almost {} bytes will be released", release_bytes);
-        while (release_bytes > 0) {
-            // tcmalloc releasing memory will lock page heap, release 1MB at a time to avoid locking
-            // page heap for long time
-            ::MallocExtension::instance()->ReleaseToSystem(1024 * 1024);
-            release_bytes -= 1024 * 1024;
+        int64_t max_reserved_bytes =
+            total_allocated_bytes * _mem_release_max_reserved_mem_percentage / 100.0;
+        if (reserved_bytes > max_reserved_bytes) {
+            int64_t release_bytes = reserved_bytes - max_reserved_bytes;
+            _counter_tcmalloc_release_memory_size->set(release_bytes);
+            ddebug_f("Memory release started, almost {} bytes will be released", release_bytes);
+            while (release_bytes > 0) {
+                // tcmalloc releasing memory will lock page heap, release 1MB at a time to avoid
+                // locking
+                // page heap for long time
+                ::MallocExtension::instance()->ReleaseToSystem(1024 * 1024);
+                release_bytes -= 1024 * 1024;
+            }
         }
     }
 }

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -328,8 +328,10 @@ private:
     dsn_handle_t _query_compact_command;
     dsn_handle_t _query_app_envs_command;
     dsn_handle_t _useless_dir_reserve_seconds_command;
+#ifdef DSN_ENABLE_GPERF
     dsn_handle_t _release_tcmalloc_memory_command;
     dsn_handle_t _max_reserved_memory_percentage_command;
+#endif
 
     bool _deny_client;
     bool _verbose_client_log;

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -328,6 +328,7 @@ private:
     dsn_handle_t _query_compact_command;
     dsn_handle_t _query_app_envs_command;
     dsn_handle_t _useless_dir_reserve_seconds_command;
+    dsn_handle_t _release_tcmalloc_memory_command;
     dsn_handle_t _max_reserved_memory_percentage_command;
 
     bool _deny_client;
@@ -335,6 +336,7 @@ private:
     bool _verbose_commit_log;
     int32_t _gc_disk_error_replica_interval_seconds;
     int32_t _gc_disk_garbage_replica_interval_seconds;
+    bool _release_tcmalloc_memory;
     int32_t _mem_release_max_reserved_mem_percentage;
 
     // we limit LT_APP max concurrent count, because nfs service implementation is
@@ -415,6 +417,9 @@ private:
 
     perf_counter_wrapper _counter_recent_write_size_exceed_threshold_count;
 
+#ifdef DSN_ENABLE_GPERF
+    perf_counter_wrapper _counter_tcmalloc_release_memory_size;
+#endif
     dsn::task_tracker _tracker;
 };
 } // namespace replication


### PR DESCRIPTION
## What is this pull request solved
In pull request #343 , we optimize tcmalloc release memory. Based on the former implementation, this pull request add more improvements about it:
1. Add a new perf-counter to record tcmalloc release memory
2. Add a new remote command to control release memory or not
3. Fix percentage range check from (0, 100) to (0, 100]

## New perf-counter
`replica*eon.replica_stub*tcmalloc.release.memory.size`

This perf-counter has a **problem** that it will only be updated every interval time. For example, if tcmalloc memory release time interval is one hour, one server releases 1G memory at 10:00, the value won't change until 11:00. As a result, the monitor graph will be like a trapezoid.
If you have a better way to solve this problem, please comment this pull request or discuss with me offline.

## New remote command
command help: `replica.release-tcmalloc-memory <true|false>`

Usage sample:

```
// query current value
>>> remote_command -t replica-server replica.release-tcmalloc-memory
COMMAND: replica.release-tcmalloc-memory

CALL [replica-server] [ip1: port1] succeed: true
CALL [replica-server] [ip2: port2] succeed: true
CALL [replica-server] [ip3: port3] succeed: true

Succeed count: 3
Failed count: 0

// not release memory
>>> remote_command -t replica-server replica.release-tcmalloc-memory false
COMMAND: replica.release-tcmalloc-memory false

CALL [replica-server] [ip1: port1] succeed: OK
CALL [replica-server] [ip2: port2] succeed: OK
CALL [replica-server] [ip3: port3] succeed: OK

Succeed count: 3
Failed count: 0

```