### PR TITLE
feat(dup): optimize time-lag by reducing repeat delay

### DIFF
--- a/src/dist/replication/lib/duplication/duplication_pipeline.cpp
+++ b/src/dist/replication/lib/duplication/duplication_pipeline.cpp
@@ -29,8 +29,8 @@ void load_mutation::run()
     decree last_decree = _duplicator->progress().last_decree;
     _start_decree = last_decree + 1;
     if (_replica->private_log()->max_commit_on_disk() < _start_decree) {
-        // wait 10 seconds for next try if no mutation was added.
-        repeat(10_s);
+        // wait 100ms for next try if no mutation was added.
+        repeat(100_ms);
         return;
     }
 

--- a/src/dist/replication/lib/duplication/load_from_private_log.h
+++ b/src/dist/replication/lib/duplication/load_from_private_log.h
@@ -52,10 +52,8 @@ public:
     bool will_fail_skip() const;
     bool will_fail_fast() const;
 
-    void TEST_set_repeat_delay(std::chrono::milliseconds delay)
-    {
-        const_cast<std::chrono::milliseconds &>(_repeat_delay) = delay;
-    }
+    void TEST_set_repeat_delay(std::chrono::milliseconds delay) { _repeat_delay = delay; }
+
     static constexpr int MAX_ALLOWED_BLOCK_REPEATS{3};
     static constexpr int MAX_ALLOWED_FILE_REPEATS{10};
 


### PR DESCRIPTION
# What problem did this PR solve?

Previously, the time-lag between master and slave was 10+seconds. It's unacceptable for most of our users. After listening for their requirement I found a **1-second-time-lag** is mostly satisfying for them. So here I did some optimization experiments:

1. Reduce the repeat delay time when one replica finds no committed mutations on disk:

```diff
    if (_replica->private_log()->max_commit_on_disk() < _start_decree) {
-        // wait 10 seconds for next try if no mutation was added.
-        repeat(10_s);
+        // wait 100ms for next try if no mutation was added.
+        repeat(100_ms);
        return;
    }
```

This optimization greatly decreases the time lag to 1s. 

![image](https://user-images.githubusercontent.com/6970676/80586362-6af56680-8a47-11ea-8922-80dd78ce4f96.png)

2. Another optimization is based on that `load_from_private_log` will sleep 10s when it is unable to read more from plog. One naive implementation is to retry at a shorter period (200ms e.g.). But the server load may increase due to more retries.

```cpp
void load_from_private_log::replay_log_block()
{
  error_s err = mutation_log::replay_block();
  if (!err.is_ok()) {
    repeat(10_s); // optimize: =>200ms
    return;
  }
}
```

I made a test to see if this optimization works:

- repeat delay: 200ms

![image](https://user-images.githubusercontent.com/6970676/80587209-bb20f880-8a48-11ea-9297-f1d2c6765b70.png)

- repeat delay: 10s

![image](https://user-images.githubusercontent.com/6970676/80587065-80b75b80-8a48-11ea-8565-2eb0f735c82a.png)

![image](https://user-images.githubusercontent.com/6970676/80587264-cd029b80-8a48-11ea-9ba3-aefec673c302.png)

As we can see, this opt makes no diff (1K Write-QPS) on bytes-read and time-lag, which means there was completely no failure retry during the above tests. I believe retry is also rare in real-world cases. So I abandon this optimization in this PR.
