### PR TITLE
improvement(third-party): Update the concurrentqueue to a stable release version

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -50,7 +50,7 @@ mkdir -p $TP_OUTPUT/bin
 
 # build concurrentqueue
 if [ ! -d $TP_OUTPUT/include/concurrentqueue ]; then
-    cd $TP_SRC/concurrentqueue-1.0.0-beta
+    cd $TP_SRC/concurrentqueue-1.0.1
     mkdir -p $TP_OUTPUT/include/concurrentqueue
     cp -R blockingconcurrentqueue.h concurrentqueue.h internal/ $TP_OUTPUT/include/concurrentqueue
     cd $TP_DIR

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -52,7 +52,7 @@ mkdir -p $TP_OUTPUT/bin
 if [ ! -d $TP_OUTPUT/include/concurrentqueue ]; then
     cd $TP_SRC/concurrentqueue-1.0.1
     mkdir -p $TP_OUTPUT/include/concurrentqueue
-    cp -R blockingconcurrentqueue.h concurrentqueue.h internal/ $TP_OUTPUT/include/concurrentqueue
+    cp -R blockingconcurrentqueue.h concurrentqueue.h lightweightsemaphore.h internal/ $TP_OUTPUT/include/concurrentqueue
     cd $TP_DIR
     exit_if_fail "concurrentqueue" $?
 else

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -120,12 +120,12 @@ fi
 cd $TP_SRC
 
 # concurrent queue
-# from: https://codeload.github.com/cameron314/concurrentqueue/tar.gz/v1.0.0-beta
-CONCURRENT_QUEUE_NAME=concurrentqueue-1.0.0-beta
+# from: https://codeload.github.com/cameron314/concurrentqueue/tar.gz/v1.0.1
+CONCURRENT_QUEUE_NAME=concurrentqueue-1.0.1
 CONCURRENT_QUEUE_PKG=${CONCURRENT_QUEUE_NAME}.tar.gz
 check_and_download "${CONCURRENT_QUEUE_PKG}"\
     "${OSS_URL_PREFIX}/${CONCURRENT_QUEUE_PKG}"\
-    "761446e2392942aa342f437697ddb72e"\
+    "80016b584fddffd67073349efd7b8958"\
     "${CONCURRENT_QUEUE_NAME}"
 exit_if_fail $?
 


### PR DESCRIPTION
According to https://github.com/cameron314/concurrentqueue/releases, `concurrentqueue` has a stable version, so I update it.