### PR TITLE
fix(dup): reject add_dup if remote address incorrect

### DIFF
--- a/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
+++ b/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
@@ -154,7 +154,7 @@ void meta_duplication_service::add_duplication(duplication_add_rpc rpc)
     if (std::find(clusters.begin(), clusters.end(), request.remote_cluster_name) ==
         clusters.end()) {
         response.err = ERR_INVALID_PARAMETERS;
-        response.__set_hint("failed to find address of this cluster in config");
+        response.__set_hint("failed to find cluster address in config [pegasus.clusters]");
         return;
     }
 

--- a/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
+++ b/src/dist/replication/meta_server/duplication/meta_duplication_service.cpp
@@ -449,7 +449,7 @@ void meta_duplication_service::do_restore_duplication(dupid_t dup_id,
     // restore duplication info from json
     _meta_svc->get_meta_storage()->get_data(
         std::string(store_path),
-        [dup_id, this, app = std::move(app), store_path](const blob &json) {
+        [ dup_id, this, app = std::move(app), store_path ](const blob &json) {
             zauto_write_lock l(app_lock());
 
             auto dup = duplication_info::decode_from_blob(

--- a/src/dist/replication/test/meta_test/unit_test/config-test.ini
+++ b/src/dist/replication/test/meta_test/unit_test/config-test.ini
@@ -111,7 +111,7 @@ args =
 [duplication-group]
 master-cluster = 1
 slave-cluster  = 2
-cluster_without_address = 3
+cluster_without_address_for_test = 3
 
 [pegasus.clusters]
 master-cluster = 127.0.0.1:34601

--- a/src/dist/replication/test/meta_test/unit_test/config-test.ini
+++ b/src/dist/replication/test/meta_test/unit_test/config-test.ini
@@ -111,3 +111,8 @@ args =
 [duplication-group]
 master-cluster = 1
 slave-cluster  = 2
+cluster_without_address = 3
+
+[pegasus.clusters]
+master-cluster = 127.0.0.1:34601
+slave-cluster  = 127.0.0.1:35601

--- a/src/dist/replication/test/meta_test/unit_test/meta_duplication_service_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_duplication_service_test.cpp
@@ -309,7 +309,7 @@ public:
         std::string invalid_remote = "test-invalid-remote";
         std::string ok_remote = "slave-cluster";
 
-        std::string cluster_without_address = "cluster_without_address";
+        std::string cluster_without_address = "cluster_without_address_for_test";
 
         create_app(test_app);
 

--- a/src/dist/replication/test/meta_test/unit_test/meta_duplication_service_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_duplication_service_test.cpp
@@ -309,6 +309,8 @@ public:
         std::string invalid_remote = "test-invalid-remote";
         std::string ok_remote = "slave-cluster";
 
+        std::string cluster_without_address = "cluster_without_address";
+
         create_app(test_app);
 
         create_app(test_app_invalid_ver);
@@ -328,6 +330,8 @@ public:
             {test_app, invalid_remote, ERR_INVALID_PARAMETERS},
 
             {test_app, get_current_cluster_name(), ERR_INVALID_PARAMETERS},
+
+            {test_app, cluster_without_address, ERR_INVALID_PARAMETERS},
         };
 
         for (auto tt : tests) {


### PR DESCRIPTION
This fix is to ensure the robustness when the remote cluster address of `add_dup` was misconfigured.