### PR TITLE
feat(bulk-load): bulk load download part4 - replica report download status and progress

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -431,7 +431,7 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
         return;
     }
 
-    if (report_metadata && _metadata.files.size() > 0) {
+    if (report_metadata && !_metadata.files.empty()) {
         response.__set_metadata(_metadata);
     }
 
@@ -459,25 +459,28 @@ void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_respo
         return;
     }
 
-    partition_bulk_load_state p_state;
-    p_state.__set_download_progress(_download_progress.load());
-    p_state.__set_download_status(_download_status.load());
-    response.group_bulk_load_state[_replica->_primary_states.membership.primary] = p_state;
+    partition_bulk_load_state primary_state;
+    primary_state.__set_download_progress(_download_progress.load());
+    primary_state.__set_download_status(_download_status.load());
+    response.group_bulk_load_state[_replica->_primary_states.membership.primary] = primary_state;
     ddebug_replica("primary = {}, download progress = {}%, status = {}",
                    _replica->_primary_states.membership.primary.to_string(),
-                   p_state.download_progress,
-                   p_state.download_status);
+                   primary_state.download_progress,
+                   primary_state.download_status);
 
-    int32_t total_progress = p_state.download_progress;
+    int32_t total_progress = primary_state.download_progress;
     for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
-        const auto &s_state = _replica->_primary_states.secondary_bulk_load_states[target_address];
-        int32_t s_progress = s_state.__isset.download_progress ? s_state.download_progress : 0;
-        error_code s_status = s_state.__isset.download_status ? s_state.download_status : ERR_OK;
+        const auto &secondary_state =
+            _replica->_primary_states.secondary_bulk_load_states[target_address];
+        int32_t s_progress =
+            secondary_state.__isset.download_progress ? secondary_state.download_progress : 0;
+        error_code s_status =
+            secondary_state.__isset.download_status ? secondary_state.download_status : ERR_OK;
         ddebug_replica("secondary = {}, download progress = {}%, status={}",
                        target_address.to_string(),
                        s_progress,
                        s_status);
-        response.group_bulk_load_state[target_address] = s_state;
+        response.group_bulk_load_state[target_address] = secondary_state;
         total_progress += s_progress;
     }
 

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -426,14 +426,91 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
                                                           bool report_metadata,
                                                           /*out*/ bulk_load_response &response)
 {
-    // TODO(heyuchen): TBD
+    if (status() != partition_status::PS_PRIMARY) {
+        response.err = ERR_INVALID_STATE;
+        return;
+    }
+
+    if (report_metadata && _metadata.files.size() > 0) {
+        response.__set_metadata(_metadata);
+    }
+
+    switch (remote_status) {
+    case bulk_load_status::BLS_DOWNLOADING:
+    case bulk_load_status::BLS_DOWNLOADED:
+        report_group_download_progress(response);
+        break;
+    // TODO(heyuchen): add other status
+    default:
+        break;
+    }
+
+    response.primary_bulk_load_status = _status;
 }
 
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_response &response)
+{
+    if (status() != partition_status::PS_PRIMARY) {
+        dwarn_replica("replica status={}, should be {}",
+                      enum_to_string(status()),
+                      enum_to_string(partition_status::PS_PRIMARY));
+        response.err = ERR_INVALID_STATE;
+        return;
+    }
+
+    partition_bulk_load_state p_state;
+    p_state.__set_download_progress(_download_progress.load());
+    p_state.__set_download_status(_download_status.load());
+    response.group_bulk_load_state[_replica->_primary_states.membership.primary] = p_state;
+    ddebug_replica("primary = {}, download progress = {}%, status = {}",
+                   _replica->_primary_states.membership.primary.to_string(),
+                   p_state.download_progress,
+                   p_state.download_status);
+
+    int32_t total_progress = p_state.download_progress;
+    for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
+        const auto &s_state = _replica->_primary_states.secondary_bulk_load_states[target_address];
+        int32_t s_progress = s_state.__isset.download_progress ? s_state.download_progress : 0;
+        error_code s_status = s_state.__isset.download_status ? s_state.download_status : ERR_OK;
+        ddebug_replica("secondary = {}, download progress = {}%, status={}",
+                       target_address.to_string(),
+                       s_progress,
+                       s_status);
+        response.group_bulk_load_state[target_address] = s_state;
+        total_progress += s_progress;
+    }
+
+    total_progress /= _replica->_primary_states.membership.max_replica_count;
+    ddebug_replica("total download progress = {}%", total_progress);
+    response.__set_total_download_progress(total_progress);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::report_bulk_load_states_to_primary(
     bulk_load_status::type remote_status,
     /*out*/ group_bulk_load_response &response)
 {
-    // TODO(heyuchen): TBD
+    if (status() != partition_status::PS_SECONDARY) {
+        response.err = ERR_INVALID_STATE;
+        return;
+    }
+
+    partition_bulk_load_state bulk_load_state;
+    auto local_status = _status;
+    switch (remote_status) {
+    case bulk_load_status::BLS_DOWNLOADING:
+    case bulk_load_status::BLS_DOWNLOADED:
+        bulk_load_state.__set_download_progress(_download_progress.load());
+        bulk_load_state.__set_download_status(_download_status.load());
+        break;
+    // TODO(heyuchen): add other status
+    default:
+        break;
+    }
+
+    response.status = local_status;
+    response.bulk_load_state = bulk_load_state;
 }
 
 } // namespace replication

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -69,6 +69,8 @@ private:
     void report_bulk_load_states_to_meta(bulk_load_status::type remote_status,
                                          bool report_metadata,
                                          /*out*/ bulk_load_response &response);
+    void report_group_download_progress(/*out*/ bulk_load_response &response);
+
     void report_bulk_load_states_to_primary(bulk_load_status::type remote_status,
                                             /*out*/ group_bulk_load_response &response);
 

--- a/src/dist/replication/lib/replica_context.cpp
+++ b/src/dist/replication/lib/replica_context.cpp
@@ -159,6 +159,8 @@ void primary_context::cleanup_bulk_load_states()
     // TODO(heyuchen): TBD
     // primary will save bulk load states reported from secondaries, this function is to cleanup
     // those states
+    secondary_bulk_load_states.erase(secondary_bulk_load_states.begin(),
+                                     secondary_bulk_load_states.end());
 }
 
 bool secondary_context::cleanup(bool force)

--- a/src/dist/replication/lib/replica_context.h
+++ b/src/dist/replication/lib/replica_context.h
@@ -152,6 +152,8 @@ public:
     // Used for bulk load
     // group bulk_load response tasks of RPC_GROUP_BULK_LOAD for each secondary replica
     node_tasks group_bulk_load_pending_replies;
+    // bulk_load_state of secondary replicas
+    std::unordered_map<rpc_address, partition_bulk_load_state> secondary_bulk_load_states;
 };
 
 class secondary_context

--- a/src/dist/replication/test/replica_test/unit_test/mock_utils.h
+++ b/src/dist/replication/test/replica_test/unit_test/mock_utils.h
@@ -141,8 +141,15 @@ public:
     void prepare_list_commit_hard(decree d) { _prepare_list->commit(d, COMMIT_TO_DECREE_HARD); }
     decree get_app_last_committed_decree() { return _app->last_committed_decree(); }
     void set_app_last_committed_decree(decree d) { _app->_last_committed_decree = d; }
-    primary_context get_primary_context() { return _primary_states; }
-    void set_primary_context(primary_context context) { _primary_states = context; }
+    void set_primary_partition_configuration(partition_configuration &pconfig)
+    {
+        _primary_states.membership = pconfig;
+    }
+    void set_secondary_bulk_load_state(const rpc_address &node,
+                                       const partition_bulk_load_state &state)
+    {
+        _primary_states.secondary_bulk_load_states[node] = state;
+    }
 
 private:
     decree _max_gced_decree{invalid_decree - 1};


### PR DESCRIPTION
The whole bulk load download process is like:
1. meta server set app and all partitions bulk load status is downloading #454
2. meta server send request to primary to download files #457
3. primary download files #465 #471 #475 
4. primary broadcast request to secondary #460
5. secondary download files #465 #471 #475 
6. **secondary report download progress and status to primary**
7. **primary report group download progress and status to meta server**
8. meta receive download progress
    - if all replicas of the group finish download all files, meta set this partition status as downloaded, and if all partitions are downloaded, app status will be set as downloaded, otherwise, meta will resend request to primary

This pull request is about replica report download status and progress, step 6 and step 7 above.
