### PR TITLE
refactor: use rpc holder to reimplement rpc interface of replica server

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -13,8 +13,6 @@
 namespace dsn {
 namespace replication {
 
-typedef rpc_holder<group_bulk_load_request, group_bulk_load_response> group_bulk_load_rpc;
-
 replica_bulk_loader::replica_bulk_loader(replica *r)
     : replica_base(r), _replica(r), _stub(r->get_replica_stub())
 {

--- a/src/dist/replication/lib/replica_split.cpp
+++ b/src/dist/replication/lib/replica_split.cpp
@@ -14,8 +14,6 @@
 namespace dsn {
 namespace replication {
 
-typedef rpc_holder<notify_catch_up_request, notify_cacth_up_response> notify_catch_up_rpc;
-
 // ThreadPool: THREAD_POOL_REPLICATION
 void replica::on_add_child(const group_check_request &request) // on parent partition
 {

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -871,9 +871,9 @@ void replica_stub::on_query_decree(query_replica_decree_rpc rpc)
     }
 }
 
-void replica_stub::on_query_replica_info(const query_replica_info_request &req,
-                                         /*out*/ query_replica_info_response &resp)
+void replica_stub::on_query_replica_info(query_replica_info_rpc rpc)
 {
+    query_replica_info_response &resp = rpc.response();
     std::set<gpid> visited_replicas;
     {
         zauto_read_lock l(_replicas_lock);
@@ -2037,7 +2037,6 @@ void replica_stub::handle_log_failure(error_code err)
 void replica_stub::open_service()
 {
     register_rpc_handler(RPC_CONFIG_PROPOSAL, "ProposeConfig", &replica_stub::on_config_proposal);
-
     register_rpc_handler(RPC_PREPARE, "prepare", &replica_stub::on_prepare);
     register_rpc_handler(RPC_LEARN, "Learn", &replica_stub::on_learn);
     register_rpc_handler(RPC_LEARN_COMPLETION_NOTIFY,
@@ -2049,7 +2048,7 @@ void replica_stub::open_service()
         RPC_GROUP_CHECK, "GroupCheck", &replica_stub::on_group_check);
     register_rpc_handler_with_rpc_holder(
         RPC_QUERY_PN_DECREE, "query_decree", &replica_stub::on_query_decree);
-    register_rpc_handler(
+    register_rpc_handler_with_rpc_holder(
         RPC_QUERY_REPLICA_INFO, "query_replica_info", &replica_stub::on_query_replica_info);
     register_rpc_handler(
         RPC_REPLICA_COPY_LAST_CHECKPOINT, "copy_checkpoint", &replica_stub::on_copy_checkpoint);

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -958,9 +958,11 @@ void replica_stub::on_query_disk_info(query_disk_info_rpc rpc)
     resp.err = ERR_OK;
 }
 
-void replica_stub::on_query_app_info(const query_app_info_request &req,
-                                     query_app_info_response &resp)
+void replica_stub::on_query_app_info(query_app_info_rpc rpc)
 {
+    const query_app_info_request &req = rpc.request();
+    query_app_info_response &resp = rpc.response();
+
     ddebug("got query app info request from (%s)", req.meta_server.to_string());
     resp.err = dsn::ERR_OK;
     std::set<app_id> visited_apps;
@@ -2058,7 +2060,8 @@ void replica_stub::open_service()
         RPC_REPLICA_COPY_LAST_CHECKPOINT, "copy_checkpoint", &replica_stub::on_copy_checkpoint);
     register_rpc_handler_with_rpc_holder(
         RPC_QUERY_DISK_INFO, "query_disk_info", &replica_stub::on_query_disk_info);
-    register_rpc_handler(RPC_QUERY_APP_INFO, "query_app_info", &replica_stub::on_query_app_info);
+    register_rpc_handler_with_rpc_holder(
+        RPC_QUERY_APP_INFO, "query_app_info", &replica_stub::on_query_app_info);
     register_rpc_handler(RPC_COLD_BACKUP, "cold_backup", &replica_stub::on_cold_backup);
     register_rpc_handler(
         RPC_CLEAR_COLD_BACKUP, "clear_cold_backup", &replica_stub::on_clear_cold_backup);

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -993,8 +993,11 @@ void replica_stub::on_query_app_info(query_app_info_rpc rpc)
     }
 }
 
-void replica_stub::on_cold_backup(const backup_request &request, /*out*/ backup_response &response)
+void replica_stub::on_cold_backup(backup_rpc rpc)
 {
+    const backup_request &request = rpc.request();
+    backup_response &response = rpc.response();
+
     ddebug("received cold backup request: backup{%s.%s.%" PRId64 "}",
            request.pid.to_string(),
            request.policy.policy_name.c_str(),
@@ -2062,7 +2065,8 @@ void replica_stub::open_service()
         RPC_QUERY_DISK_INFO, "query_disk_info", &replica_stub::on_query_disk_info);
     register_rpc_handler_with_rpc_holder(
         RPC_QUERY_APP_INFO, "query_app_info", &replica_stub::on_query_app_info);
-    register_rpc_handler(RPC_COLD_BACKUP, "cold_backup", &replica_stub::on_cold_backup);
+    register_rpc_handler_with_rpc_holder(
+        RPC_COLD_BACKUP, "cold_backup", &replica_stub::on_cold_backup);
     register_rpc_handler(
         RPC_CLEAR_COLD_BACKUP, "clear_cold_backup", &replica_stub::on_clear_cold_backup);
     register_rpc_handler(RPC_SPLIT_NOTIFY_CATCH_UP,

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2069,9 +2069,9 @@ void replica_stub::open_service()
         RPC_COLD_BACKUP, "cold_backup", &replica_stub::on_cold_backup);
     register_rpc_handler(
         RPC_CLEAR_COLD_BACKUP, "clear_cold_backup", &replica_stub::on_clear_cold_backup);
-    register_rpc_handler(RPC_SPLIT_NOTIFY_CATCH_UP,
-                         "child_notify_catch_up",
-                         &replica_stub::on_notify_primary_split_catch_up);
+    register_rpc_handler_with_rpc_holder(RPC_SPLIT_NOTIFY_CATCH_UP,
+                                         "child_notify_catch_up",
+                                         &replica_stub::on_notify_primary_split_catch_up);
     register_rpc_handler(RPC_BULK_LOAD, "bulk_load", &replica_stub::on_bulk_load);
     register_rpc_handler(RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
 
@@ -2653,9 +2653,10 @@ replica_stub::split_replica_exec(dsn::task_code code, gpid pid, local_execution 
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica_stub::on_notify_primary_split_catch_up(const notify_catch_up_request &request,
-                                                    notify_cacth_up_response &response)
+void replica_stub::on_notify_primary_split_catch_up(notify_catch_up_rpc rpc)
 {
+    const notify_catch_up_request &request = rpc.request();
+    notify_cacth_up_response &response = rpc.response();
     replica_ptr replica = get_replica(request.parent_gpid);
     if (replica != nullptr) {
         replica->parent_handle_child_catch_up(request, response);

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2073,7 +2073,8 @@ void replica_stub::open_service()
                                          "child_notify_catch_up",
                                          &replica_stub::on_notify_primary_split_catch_up);
     register_rpc_handler_with_rpc_holder(RPC_BULK_LOAD, "bulk_load", &replica_stub::on_bulk_load);
-    register_rpc_handler(RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
+    register_rpc_handler_with_rpc_holder(
+        RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
 
     _kill_partition_command = ::dsn::command_manager::instance().register_app_command(
         {"kill_partition"},
@@ -2704,9 +2705,11 @@ void replica_stub::on_bulk_load(bulk_load_rpc rpc)
     }
 }
 
-void replica_stub::on_group_bulk_load(const group_bulk_load_request &request,
-                                      /*out*/ group_bulk_load_response &response)
+void replica_stub::on_group_bulk_load(group_bulk_load_rpc rpc)
 {
+    const group_bulk_load_request &request = rpc.request();
+    group_bulk_load_response &response = rpc.response();
+
     ddebug_f("[{}@{}]: received group bulk load request, primary = {}, ballot = {}, "
              "meta_bulk_load_status = {}",
              request.config.pid,

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2072,7 +2072,7 @@ void replica_stub::open_service()
     register_rpc_handler_with_rpc_holder(RPC_SPLIT_NOTIFY_CATCH_UP,
                                          "child_notify_catch_up",
                                          &replica_stub::on_notify_primary_split_catch_up);
-    register_rpc_handler(RPC_BULK_LOAD, "bulk_load", &replica_stub::on_bulk_load);
+    register_rpc_handler_with_rpc_holder(RPC_BULK_LOAD, "bulk_load", &replica_stub::on_bulk_load);
     register_rpc_handler(RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
 
     _kill_partition_command = ::dsn::command_manager::instance().register_app_command(
@@ -2689,8 +2689,11 @@ void replica_stub::update_disk_holding_replicas()
     }
 }
 
-void replica_stub::on_bulk_load(const bulk_load_request &request, bulk_load_response &response)
+void replica_stub::on_bulk_load(bulk_load_rpc rpc)
 {
+    const bulk_load_request &request = rpc.request();
+    bulk_load_response &response = rpc.response();
+
     ddebug_f("[{}@{}]: receive bulk load request", request.pid, _primary_address_str);
     replica_ptr rep = get_replica(request.pid);
     if (rep != nullptr) {

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -850,9 +850,11 @@ void replica_stub::on_config_proposal(const configuration_update_request &propos
     }
 }
 
-void replica_stub::on_query_decree(const query_replica_decree_request &req,
-                                   /*out*/ query_replica_decree_response &resp)
+void replica_stub::on_query_decree(query_replica_decree_rpc rpc)
 {
+    const query_replica_decree_request &req = rpc.request();
+    query_replica_decree_response &resp = rpc.response();
+
     replica_ptr rep = get_replica(req.pid);
     if (rep != nullptr) {
         resp.err = ERR_OK;
@@ -1047,9 +1049,10 @@ void replica_stub::on_prepare(dsn::message_ex *request)
     }
 }
 
-void replica_stub::on_group_check(const group_check_request &request,
-                                  /*out*/ group_check_response &response)
+void replica_stub::on_group_check(group_check_rpc rpc)
 {
+    const group_check_request &request = rpc.request();
+    group_check_response &response = rpc.response();
     if (!is_connected()) {
         dwarn("%s@%s: received group check: not connected, ignore",
               request.config.pid.to_string(),
@@ -2042,8 +2045,10 @@ void replica_stub::open_service()
                          &replica_stub::on_learn_completion_notification);
     register_rpc_handler(RPC_LEARN_ADD_LEARNER, "LearnAdd", &replica_stub::on_add_learner);
     register_rpc_handler(RPC_REMOVE_REPLICA, "remove", &replica_stub::on_remove);
-    register_rpc_handler(RPC_GROUP_CHECK, "GroupCheck", &replica_stub::on_group_check);
-    register_rpc_handler(RPC_QUERY_PN_DECREE, "query_decree", &replica_stub::on_query_decree);
+    register_rpc_handler_with_rpc_holder(
+        RPC_GROUP_CHECK, "GroupCheck", &replica_stub::on_group_check);
+    register_rpc_handler_with_rpc_holder(
+        RPC_QUERY_PN_DECREE, "query_decree", &replica_stub::on_query_decree);
     register_rpc_handler(
         RPC_QUERY_REPLICA_INFO, "query_replica_info", &replica_stub::on_query_replica_info);
     register_rpc_handler(

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -905,9 +905,10 @@ void replica_stub::on_query_replica_info(query_replica_info_rpc rpc)
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT
-void replica_stub::on_query_disk_info(const query_disk_info_request &req,
-                                      /*out*/ query_disk_info_response &resp)
+void replica_stub::on_query_disk_info(query_disk_info_rpc rpc)
 {
+    const query_disk_info_request &req = rpc.request();
+    query_disk_info_response &resp = rpc.response();
     int app_id = 0;
     if (!req.app_name.empty()) {
         zauto_read_lock l(_replicas_lock);
@@ -1114,9 +1115,10 @@ void replica_stub::on_copy_checkpoint(copy_checkpoint_rpc rpc)
     }
 }
 
-void replica_stub::on_learn_completion_notification(const group_check_response &report,
-                                                    /*out*/ learn_notify_response &response)
+void replica_stub::on_learn_completion_notification(learn_completion_notification_rpc rpc)
 {
+    const group_check_response &report = rpc.request();
+    learn_notify_response &response = rpc.response();
     response.pid = report.pid;
     response.signature = report.learner_signature;
     replica_ptr rep = get_replica(report.pid);
@@ -2041,9 +2043,9 @@ void replica_stub::open_service()
     register_rpc_handler(RPC_CONFIG_PROPOSAL, "ProposeConfig", &replica_stub::on_config_proposal);
     register_rpc_handler(RPC_PREPARE, "prepare", &replica_stub::on_prepare);
     register_rpc_handler(RPC_LEARN, "Learn", &replica_stub::on_learn);
-    register_rpc_handler(RPC_LEARN_COMPLETION_NOTIFY,
-                         "LearnNotify",
-                         &replica_stub::on_learn_completion_notification);
+    register_rpc_handler_with_rpc_holder(RPC_LEARN_COMPLETION_NOTIFY,
+                                         "LearnNotify",
+                                         &replica_stub::on_learn_completion_notification);
     register_rpc_handler(RPC_LEARN_ADD_LEARNER, "LearnAdd", &replica_stub::on_add_learner);
     register_rpc_handler(RPC_REMOVE_REPLICA, "remove", &replica_stub::on_remove);
     register_rpc_handler_with_rpc_holder(
@@ -2054,7 +2056,8 @@ void replica_stub::open_service()
         RPC_QUERY_REPLICA_INFO, "query_replica_info", &replica_stub::on_query_replica_info);
     register_rpc_handler_with_rpc_holder(
         RPC_REPLICA_COPY_LAST_CHECKPOINT, "copy_checkpoint", &replica_stub::on_copy_checkpoint);
-    register_rpc_handler(RPC_QUERY_DISK_INFO, "query_disk_info", &replica_stub::on_query_disk_info);
+    register_rpc_handler_with_rpc_holder(
+        RPC_QUERY_DISK_INFO, "query_disk_info", &replica_stub::on_query_disk_info);
     register_rpc_handler(RPC_QUERY_APP_INFO, "query_app_info", &replica_stub::on_query_app_info);
     register_rpc_handler(RPC_COLD_BACKUP, "cold_backup", &replica_stub::on_cold_backup);
     register_rpc_handler(

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -1101,9 +1101,11 @@ void replica_stub::on_learn(dsn::message_ex *msg)
     }
 }
 
-void replica_stub::on_copy_checkpoint(const replica_configuration &request,
-                                      /*out*/ learn_response &response)
+void replica_stub::on_copy_checkpoint(copy_checkpoint_rpc rpc)
 {
+    const replica_configuration &request = rpc.request();
+    learn_response &response = rpc.response();
+
     replica_ptr rep = get_replica(request.pid);
     if (rep != nullptr) {
         rep->on_copy_checkpoint(request, response);
@@ -2050,7 +2052,7 @@ void replica_stub::open_service()
         RPC_QUERY_PN_DECREE, "query_decree", &replica_stub::on_query_decree);
     register_rpc_handler_with_rpc_holder(
         RPC_QUERY_REPLICA_INFO, "query_replica_info", &replica_stub::on_query_replica_info);
-    register_rpc_handler(
+    register_rpc_handler_with_rpc_holder(
         RPC_REPLICA_COPY_LAST_CHECKPOINT, "copy_checkpoint", &replica_stub::on_copy_checkpoint);
     register_rpc_handler(RPC_QUERY_DISK_INFO, "query_disk_info", &replica_stub::on_query_disk_info);
     register_rpc_handler(RPC_QUERY_APP_INFO, "query_app_info", &replica_stub::on_query_app_info);

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -49,6 +49,7 @@ namespace replication {
 typedef rpc_holder<group_check_request, group_check_response> group_check_rpc;
 typedef rpc_holder<query_replica_decree_request, query_replica_decree_response>
     query_replica_decree_rpc;
+typedef rpc_holder<query_replica_info_request, query_replica_info_response> query_replica_info_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -96,8 +97,7 @@ public:
     //
     void on_config_proposal(const configuration_update_request &proposal);
     void on_query_decree(query_replica_decree_rpc rpc);
-    void on_query_replica_info(const query_replica_info_request &req,
-                               /*out*/ query_replica_info_response &resp);
+    void on_query_replica_info(query_replica_info_rpc rpc);
     void on_query_disk_info(const query_disk_info_request &req,
                             /*out*/ query_disk_info_response &resp);
     void on_query_app_info(const query_app_info_request &req,

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -56,6 +56,7 @@ typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk
 typedef rpc_holder<query_app_info_request, query_app_info_response> query_app_info_rpc;
 typedef rpc_holder<backup_request, backup_response> backup_rpc;
 typedef rpc_holder<notify_catch_up_request, notify_cacth_up_response> notify_catch_up_rpc;
+typedef rpc_holder<bulk_load_request, bulk_load_response> bulk_load_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -108,7 +109,7 @@ public:
     void on_query_app_info(query_app_info_rpc rpc);
     void on_cold_backup(backup_rpc rpc);
     void on_clear_cold_backup(const backup_clear_request &request);
-    void on_bulk_load(const bulk_load_request &request, /*out*/ bulk_load_response &response);
+    void on_bulk_load(bulk_load_rpc rpc);
 
     //
     //    messages from peers (primary or secondary)

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -46,11 +46,13 @@
 namespace dsn {
 namespace replication {
 
+typedef rpc_holder<group_check_response, learn_notify_response> learn_completion_notification_rpc;
 typedef rpc_holder<group_check_request, group_check_response> group_check_rpc;
 typedef rpc_holder<query_replica_decree_request, query_replica_decree_response>
     query_replica_decree_rpc;
 typedef rpc_holder<query_replica_info_request, query_replica_info_response> query_replica_info_rpc;
 typedef rpc_holder<replica_configuration, learn_response> copy_checkpoint_rpc;
+typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk_info_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -99,8 +101,7 @@ public:
     void on_config_proposal(const configuration_update_request &proposal);
     void on_query_decree(query_replica_decree_rpc rpc);
     void on_query_replica_info(query_replica_info_rpc rpc);
-    void on_query_disk_info(const query_disk_info_request &req,
-                            /*out*/ query_disk_info_response &resp);
+    void on_query_disk_info(query_disk_info_rpc rpc);
     void on_query_app_info(const query_app_info_request &req,
                            /*out*/ query_app_info_response &resp);
     void on_cold_backup(const backup_request &request, /*out*/ backup_response &response);
@@ -116,8 +117,7 @@ public:
     //
     void on_prepare(dsn::message_ex *request);
     void on_learn(dsn::message_ex *msg);
-    void on_learn_completion_notification(const group_check_response &report,
-                                          /*out*/ learn_notify_response &response);
+    void on_learn_completion_notification(learn_completion_notification_rpc rpc);
     void on_add_learner(const group_check_request &request);
     void on_remove(const replica_configuration &request);
     void on_group_check(group_check_rpc rpc);

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -53,6 +53,7 @@ typedef rpc_holder<query_replica_decree_request, query_replica_decree_response>
 typedef rpc_holder<query_replica_info_request, query_replica_info_response> query_replica_info_rpc;
 typedef rpc_holder<replica_configuration, learn_response> copy_checkpoint_rpc;
 typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk_info_rpc;
+typedef rpc_holder<query_app_info_request, query_app_info_response> query_app_info_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -102,8 +103,7 @@ public:
     void on_query_decree(query_replica_decree_rpc rpc);
     void on_query_replica_info(query_replica_info_rpc rpc);
     void on_query_disk_info(query_disk_info_rpc rpc);
-    void on_query_app_info(const query_app_info_request &req,
-                           /*out*/ query_app_info_response &resp);
+    void on_query_app_info(query_app_info_rpc rpc);
     void on_cold_backup(const backup_request &request, /*out*/ backup_response &response);
     void on_clear_cold_backup(const backup_clear_request &request);
     void on_bulk_load(const bulk_load_request &request, /*out*/ bulk_load_response &response);

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -55,6 +55,7 @@ typedef rpc_holder<replica_configuration, learn_response> copy_checkpoint_rpc;
 typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk_info_rpc;
 typedef rpc_holder<query_app_info_request, query_app_info_response> query_app_info_rpc;
 typedef rpc_holder<backup_request, backup_response> backup_rpc;
+typedef rpc_holder<notify_catch_up_request, notify_cacth_up_response> notify_catch_up_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -130,8 +131,7 @@ public:
     //    functions while executing partition split
     //
     // on primary, child notify itself has been caught up parent
-    void on_notify_primary_split_catch_up(const notify_catch_up_request &request,
-                                          notify_cacth_up_response &response);
+    void on_notify_primary_split_catch_up(notify_catch_up_rpc rpc);
 
     //
     //    local messages

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -50,6 +50,7 @@ typedef rpc_holder<group_check_request, group_check_response> group_check_rpc;
 typedef rpc_holder<query_replica_decree_request, query_replica_decree_response>
     query_replica_decree_rpc;
 typedef rpc_holder<query_replica_info_request, query_replica_info_response> query_replica_info_rpc;
+typedef rpc_holder<replica_configuration, learn_response> copy_checkpoint_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -120,7 +121,7 @@ public:
     void on_add_learner(const group_check_request &request);
     void on_remove(const replica_configuration &request);
     void on_group_check(group_check_rpc rpc);
-    void on_copy_checkpoint(const replica_configuration &request, /*out*/ learn_response &response);
+    void on_copy_checkpoint(copy_checkpoint_rpc rpc);
     void on_group_bulk_load(const group_bulk_load_request &request,
                             /*out*/ group_bulk_load_response &response);
 

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -54,6 +54,7 @@ typedef rpc_holder<query_replica_info_request, query_replica_info_response> quer
 typedef rpc_holder<replica_configuration, learn_response> copy_checkpoint_rpc;
 typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk_info_rpc;
 typedef rpc_holder<query_app_info_request, query_app_info_response> query_app_info_rpc;
+typedef rpc_holder<backup_request, backup_response> backup_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -104,7 +105,7 @@ public:
     void on_query_replica_info(query_replica_info_rpc rpc);
     void on_query_disk_info(query_disk_info_rpc rpc);
     void on_query_app_info(query_app_info_rpc rpc);
-    void on_cold_backup(const backup_request &request, /*out*/ backup_response &response);
+    void on_cold_backup(backup_rpc rpc);
     void on_clear_cold_backup(const backup_clear_request &request);
     void on_bulk_load(const bulk_load_request &request, /*out*/ bulk_load_response &response);
 

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -56,7 +56,7 @@ typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk
 typedef rpc_holder<query_app_info_request, query_app_info_response> query_app_info_rpc;
 typedef rpc_holder<backup_request, backup_response> backup_rpc;
 typedef rpc_holder<notify_catch_up_request, notify_cacth_up_response> notify_catch_up_rpc;
-typedef rpc_holder<bulk_load_request, bulk_load_response> bulk_load_rpc;
+
 
 class mutation_log;
 class replication_checker;

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -46,6 +46,10 @@
 namespace dsn {
 namespace replication {
 
+typedef rpc_holder<group_check_request, group_check_response> group_check_rpc;
+typedef rpc_holder<query_replica_decree_request, query_replica_decree_response>
+    query_replica_decree_rpc;
+
 class mutation_log;
 class replication_checker;
 namespace test {
@@ -91,8 +95,7 @@ public:
     //    messages from meta server
     //
     void on_config_proposal(const configuration_update_request &proposal);
-    void on_query_decree(const query_replica_decree_request &req,
-                         /*out*/ query_replica_decree_response &resp);
+    void on_query_decree(query_replica_decree_rpc rpc);
     void on_query_replica_info(const query_replica_info_request &req,
                                /*out*/ query_replica_info_response &resp);
     void on_query_disk_info(const query_disk_info_request &req,
@@ -116,7 +119,7 @@ public:
                                           /*out*/ learn_notify_response &response);
     void on_add_learner(const group_check_request &request);
     void on_remove(const replica_configuration &request);
-    void on_group_check(const group_check_request &request, /*out*/ group_check_response &response);
+    void on_group_check(group_check_rpc rpc);
     void on_copy_checkpoint(const replica_configuration &request, /*out*/ learn_response &response);
     void on_group_bulk_load(const group_bulk_load_request &request,
                             /*out*/ group_bulk_load_response &response);

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -56,7 +56,7 @@ typedef rpc_holder<query_disk_info_request, query_disk_info_response> query_disk
 typedef rpc_holder<query_app_info_request, query_app_info_response> query_app_info_rpc;
 typedef rpc_holder<backup_request, backup_response> backup_rpc;
 typedef rpc_holder<notify_catch_up_request, notify_cacth_up_response> notify_catch_up_rpc;
-
+typedef rpc_holder<group_bulk_load_request, group_bulk_load_response> group_bulk_load_rpc;
 
 class mutation_log;
 class replication_checker;
@@ -125,8 +125,7 @@ public:
     void on_remove(const replica_configuration &request);
     void on_group_check(group_check_rpc rpc);
     void on_copy_checkpoint(copy_checkpoint_rpc rpc);
-    void on_group_bulk_load(const group_bulk_load_request &request,
-                            /*out*/ group_bulk_load_response &response);
+    void on_group_bulk_load(group_bulk_load_rpc rpc);
 
     //
     //    functions while executing partition split

--- a/src/dist/replication/test/replica_test/unit_test/replica_disk_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_disk_test.cpp
@@ -91,10 +91,17 @@ private:
 TEST_F(replica_disk_test, on_query_disk_info_all_app)
 {
     // disk_info_request.app_id default value = 0 means test query all apps' replica_count
-    query_disk_info_request disk_info_request;
-    query_disk_info_response disk_info_response;
-    stub->on_query_disk_info(disk_info_request, disk_info_response);
+    // create fake request
+    dsn::message_ptr fake_request = dsn::message_ex::create_request(RPC_QUERY_DISK_INFO);
+    query_disk_info_request request;
+    ::dsn::marshall(fake_request, request);
 
+    // get received request and query disk info
+    dsn::message_ex *recvd_request = fake_request->copy(true, true);
+    auto rpc = rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
+    stub->on_query_disk_info(rpc);
+
+    query_disk_info_response &disk_info_response = rpc.response();
     // test response disk_info
     ASSERT_EQ(disk_info_response.total_capacity_mb, 2500);
     ASSERT_EQ(disk_info_response.total_available_mb, 750);
@@ -119,22 +126,37 @@ TEST_F(replica_disk_test, on_query_disk_info_all_app)
 TEST_F(replica_disk_test, on_query_disk_info_app_not_existed)
 {
     // test app_id not existed
-    query_disk_info_request disk_info_request_without_existed_app;
-    query_disk_info_response disk_info_response_without_existed_app;
-    disk_info_request_without_existed_app.app_name = "not_existed_app";
-    stub->on_query_disk_info(disk_info_request_without_existed_app,
-                             disk_info_response_without_existed_app);
-    ASSERT_EQ(disk_info_response_without_existed_app.err, ERR_OBJECT_NOT_FOUND);
+    // create fake request
+    dsn::message_ptr fake_request = dsn::message_ex::create_request(RPC_QUERY_DISK_INFO);
+    query_disk_info_request tmp_request;
+    ::dsn::marshall(fake_request, tmp_request);
+
+    // get received request and query disk info
+    dsn::message_ex *recvd_request = fake_request->copy(true, true);
+    auto rpc = rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
+    query_disk_info_request &request = const_cast<query_disk_info_request &>(rpc.request());
+    request.app_name = "not_existed_app";
+    stub->on_query_disk_info(rpc);
+
+    ASSERT_EQ(rpc.response().err, ERR_OBJECT_NOT_FOUND);
 }
 
 TEST_F(replica_disk_test, on_query_disk_info_one_app)
 {
     // test app_name = "disk_test_1"
-    query_disk_info_request disk_info_request_with_app_1;
-    query_disk_info_response disk_info_response_with_app_1;
-    disk_info_request_with_app_1.app_name = app_info_1.app_name;
-    stub->on_query_disk_info(disk_info_request_with_app_1, disk_info_response_with_app_1);
-    auto &disk_infos_with_app_1 = disk_info_response_with_app_1.disk_infos;
+    // create fake request
+    dsn::message_ptr fake_request = dsn::message_ex::create_request(RPC_QUERY_DISK_INFO);
+    query_disk_info_request tmp_request;
+    ::dsn::marshall(fake_request, tmp_request);
+
+    // get received request and query disk info
+    dsn::message_ex *recvd_request = fake_request->copy(true, true);
+    auto rpc = rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
+    query_disk_info_request &request = const_cast<query_disk_info_request &>(rpc.request());
+    request.app_name = app_info_1.app_name;
+    stub->on_query_disk_info(rpc);
+
+    auto &disk_infos_with_app_1 = rpc.response().disk_infos;
     int info_size = disk_infos_with_app_1.size();
     for (int i = 0; i < info_size; i++) {
         ASSERT_EQ(disk_infos_with_app_1[i].holding_primary_replica_counts.size(), 1);

--- a/src/dist/replication/test/replica_test/unit_test/replica_disk_test.cpp
+++ b/src/dist/replication/test/replica_test/unit_test/replica_disk_test.cpp
@@ -98,7 +98,8 @@ TEST_F(replica_disk_test, on_query_disk_info_all_app)
 
     // get received request and query disk info
     dsn::message_ex *recvd_request = fake_request->copy(true, true);
-    auto rpc = rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
+    auto rpc =
+        rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
     stub->on_query_disk_info(rpc);
 
     query_disk_info_response &disk_info_response = rpc.response();
@@ -133,7 +134,8 @@ TEST_F(replica_disk_test, on_query_disk_info_app_not_existed)
 
     // get received request and query disk info
     dsn::message_ex *recvd_request = fake_request->copy(true, true);
-    auto rpc = rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
+    auto rpc =
+        rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
     query_disk_info_request &request = const_cast<query_disk_info_request &>(rpc.request());
     request.app_name = "not_existed_app";
     stub->on_query_disk_info(rpc);
@@ -151,7 +153,8 @@ TEST_F(replica_disk_test, on_query_disk_info_one_app)
 
     // get received request and query disk info
     dsn::message_ex *recvd_request = fake_request->copy(true, true);
-    auto rpc = rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
+    auto rpc =
+        rpc_holder<query_disk_info_request, query_disk_info_response>::auto_reply(recvd_request);
     query_disk_info_request &request = const_cast<query_disk_info_request &>(rpc.request());
     request.app_name = app_info_1.app_name;
     stub->on_query_disk_info(rpc);


### PR DESCRIPTION
For most RPC interfaces of replica server, use rpc holder to reimplement them.