### PR TITLE
feat(bulk-load): bulk load ingestion part4 - meta handle ingestion response

### DIFF
--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -804,7 +804,6 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
                                                      const std::string &app_name,
                                                      const gpid &pid)
 {
-    // TODO(heyuchen): TBD
     // if meet 2pc error, ingesting will rollback to downloading, no need to retry here
     if (err != ERR_OK) {
         derror_f("app({}) partition({}) ingestion files failed, error = {}", app_name, pid, err);

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -805,6 +805,46 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
                                                      const gpid &pid)
 {
     // TODO(heyuchen): TBD
+    // if meet 2pc error, ingesting will rollback to downloading, no need to retry here
+    if (err != ERR_OK) {
+        derror_f("app({}) partition({}) ingestion files failed, error = {}", app_name, pid, err);
+        tasking::enqueue(
+            LPC_META_STATE_NORMAL,
+            _meta_svc->tracker(),
+            std::bind(&bulk_load_service::try_rollback_to_downloading, this, app_name, pid));
+        return;
+    }
+
+    if (resp.err == ERR_TRY_AGAIN && resp.rocksdb_error != 0) {
+        derror_f("app({}) partition({}) ingestion files failed while empty write, rocksdb error = "
+                 "{}, retry it later",
+                 app_name,
+                 pid,
+                 resp.rocksdb_error);
+        tasking::enqueue(LPC_BULK_LOAD_INGESTION,
+                         _meta_svc->tracker(),
+                         std::bind(&bulk_load_service::partition_ingestion, this, app_name, pid),
+                         0,
+                         std::chrono::milliseconds(10));
+        return;
+    }
+
+    // some unexpected errors happened, such as write empty write failed but rocksdb_error is ok
+    // stop bulk load process with failed
+    if (resp.err != ERR_OK || resp.rocksdb_error != 0) {
+        derror_f("app({}) partition({}) failed to ingestion files, error = {}, rocksdb error = {}",
+                 app_name,
+                 pid,
+                 resp.err,
+                 resp.rocksdb_error);
+        tasking::enqueue(
+            LPC_META_STATE_NORMAL,
+            _meta_svc->tracker(),
+            std::bind(&bulk_load_service::handle_bulk_load_failed, this, pid.get_app_id()));
+        return;
+    }
+
+    ddebug_f("app({}) partition({}) receive ingestion response succeed", app_name, pid);
 }
 
 // ThreadPool: THREAD_POOL_META_STATE

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -1014,7 +1014,8 @@ struct ingestion_request
 
 struct ingestion_response
 {
-    // Possible errors are same as write request errors, such as ERR_OBJECT_NOT_FOUND, ERR_INVALID_STATE
+    // Possible errors:
+    // - ERR_TRY_AGAIN: retry ingestion
     1:dsn.error_code    err;
     // rocksdb ingestion error code
     2:i32               rocksdb_error;


### PR DESCRIPTION
The whole bulk load ingestion process is like:
1. meta server set app and all partitions bulk load status as ingesting #486 
2. meta send two requests to primary 
    - send ingestion request to primary #486 
    - send bulk load request to query ingestion status #457
3. primary handle two requests above:
    - primary consider ingestion request as a client write and replica group execute 2pc process to do actual rocksdb ingestion operation #490 pegasus pr [#546](https://github.com/XiaoMi/pegasus/pull/546)
    - primary handle bulk load request and broadcast it to secondary
4. secondary handle two cases:
    - ingestion files through 2pc #490 pegasus pr [#546](https://github.com/XiaoMi/pegasus/pull/546)
    - report ingestion status to primary 
5. primary report group ingestion status to primary
6. meta handle two response
    - **handle ingestion_response**
    - handle group ingestion status and do bulk load status transformation

This pull request is about how meta handle ingestion_response, part of step 6, and add some unit tests. Ingestion is an asynchronous operation, its status will be reported by `bulk_load_response` like download status, `on_partition_ingestion_reply` will only handle write 2pc errors and empty write errors.