### PR TITLE
feat(bulk-load): bulk load ingestion part5 - replica handle bulk load request during ingestion

### DIFF
--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -620,7 +620,12 @@ inline std::ostream &operator<<(std::ostream &out, const mutation_data &obj)
 typedef struct _replica_configuration__isset
 {
     _replica_configuration__isset()
-        : pid(false), ballot(false), primary(false), status(true), learner_signature(false)
+        : pid(false),
+          ballot(false),
+          primary(false),
+          status(true),
+          learner_signature(false),
+          pop_all(true)
     {
     }
     bool pid : 1;
@@ -628,6 +633,7 @@ typedef struct _replica_configuration__isset
     bool primary : 1;
     bool status : 1;
     bool learner_signature : 1;
+    bool pop_all : 1;
 } _replica_configuration__isset;
 
 class replica_configuration
@@ -637,7 +643,8 @@ public:
     replica_configuration(replica_configuration &&);
     replica_configuration &operator=(const replica_configuration &);
     replica_configuration &operator=(replica_configuration &&);
-    replica_configuration() : ballot(0), status((partition_status::type)0), learner_signature(0)
+    replica_configuration()
+        : ballot(0), status((partition_status::type)0), learner_signature(0), pop_all(false)
     {
         status = (partition_status::type)0;
     }
@@ -648,6 +655,7 @@ public:
     ::dsn::rpc_address primary;
     partition_status::type status;
     int64_t learner_signature;
+    bool pop_all;
 
     _replica_configuration__isset __isset;
 
@@ -661,6 +669,8 @@ public:
 
     void __set_learner_signature(const int64_t val);
 
+    void __set_pop_all(const bool val);
+
     bool operator==(const replica_configuration &rhs) const
     {
         if (!(pid == rhs.pid))
@@ -672,6 +682,10 @@ public:
         if (!(status == rhs.status))
             return false;
         if (!(learner_signature == rhs.learner_signature))
+            return false;
+        if (__isset.pop_all != rhs.__isset.pop_all)
+            return false;
+        else if (__isset.pop_all && !(pop_all == rhs.pop_all))
             return false;
         return true;
     }

--- a/src/dist/replication/common/replication_types.cpp
+++ b/src/dist/replication/common/replication_types.cpp
@@ -698,6 +698,12 @@ void replica_configuration::__set_learner_signature(const int64_t val)
     this->learner_signature = val;
 }
 
+void replica_configuration::__set_pop_all(const bool val)
+{
+    this->pop_all = val;
+    __isset.pop_all = true;
+}
+
 uint32_t replica_configuration::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -759,6 +765,14 @@ uint32_t replica_configuration::read(::apache::thrift::protocol::TProtocol *ipro
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 6:
+            if (ftype == ::apache::thrift::protocol::T_BOOL) {
+                xfer += iprot->readBool(this->pop_all);
+                this->__isset.pop_all = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -797,6 +811,11 @@ uint32_t replica_configuration::write(::apache::thrift::protocol::TProtocol *opr
     xfer += oprot->writeI64(this->learner_signature);
     xfer += oprot->writeFieldEnd();
 
+    if (this->__isset.pop_all) {
+        xfer += oprot->writeFieldBegin("pop_all", ::apache::thrift::protocol::T_BOOL, 6);
+        xfer += oprot->writeBool(this->pop_all);
+        xfer += oprot->writeFieldEnd();
+    }
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -810,6 +829,7 @@ void swap(replica_configuration &a, replica_configuration &b)
     swap(a.primary, b.primary);
     swap(a.status, b.status);
     swap(a.learner_signature, b.learner_signature);
+    swap(a.pop_all, b.pop_all);
     swap(a.__isset, b.__isset);
 }
 
@@ -820,6 +840,7 @@ replica_configuration::replica_configuration(const replica_configuration &other1
     primary = other19.primary;
     status = other19.status;
     learner_signature = other19.learner_signature;
+    pop_all = other19.pop_all;
     __isset = other19.__isset;
 }
 replica_configuration::replica_configuration(replica_configuration &&other20)
@@ -829,6 +850,7 @@ replica_configuration::replica_configuration(replica_configuration &&other20)
     primary = std::move(other20.primary);
     status = std::move(other20.status);
     learner_signature = std::move(other20.learner_signature);
+    pop_all = std::move(other20.pop_all);
     __isset = std::move(other20.__isset);
 }
 replica_configuration &replica_configuration::operator=(const replica_configuration &other21)
@@ -838,6 +860,7 @@ replica_configuration &replica_configuration::operator=(const replica_configurat
     primary = other21.primary;
     status = other21.status;
     learner_signature = other21.learner_signature;
+    pop_all = other21.pop_all;
     __isset = other21.__isset;
     return *this;
 }
@@ -848,6 +871,7 @@ replica_configuration &replica_configuration::operator=(replica_configuration &&
     primary = std::move(other22.primary);
     status = std::move(other22.status);
     learner_signature = std::move(other22.learner_signature);
+    pop_all = std::move(other22.pop_all);
     __isset = std::move(other22.__isset);
     return *this;
 }
@@ -864,6 +888,9 @@ void replica_configuration::printTo(std::ostream &out) const
         << "status=" << to_string(status);
     out << ", "
         << "learner_signature=" << to_string(learner_signature);
+    out << ", "
+        << "pop_all=";
+    (__isset.pop_all ? (out << to_string(pop_all)) : (out << "<null>"));
     out << ")";
 }
 

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -194,14 +194,52 @@ error_code replica_bulk_loader::do_bulk_load(const std::string &app_name,
                                              const std::string &cluster_name,
                                              const std::string &provider_name)
 {
+    if (status() != partition_status::PS_PRIMARY && status() != partition_status::PS_SECONDARY) {
+        return ERR_INVALID_STATE;
+    }
+
+    bulk_load_status::type local_status = _status;
+    error_code ec = validate_bulk_load_status(meta_status, local_status);
+    if (ec != ERR_OK) {
+        derror_replica("invalid bulk load status, remote = {}, local = {}",
+                       enum_to_string(meta_status),
+                       enum_to_string(local_status));
+        return ec;
+    }
+
+    switch (meta_status) {
+    case bulk_load_status::BLS_DOWNLOADING:
+        // TODO(heyuchen): add restart downloading status check
+        if (local_status == bulk_load_status::BLS_INVALID) {
+            ec = start_download(app_name, cluster_name, provider_name);
+        }
+        break;
+    case bulk_load_status::BLS_INGESTING:
+        if (local_status == bulk_load_status::BLS_DOWNLOADED) {
+            start_ingestion();
+        } else if (local_status == bulk_load_status::BLS_INGESTING &&
+                   status() == partition_status::PS_PRIMARY) {
+            check_ingestion_finish();
+        }
+        break;
+    // TODO(heyuchen): add other bulk load status
+    default:
+        break;
+    }
+    return ec;
+}
+
+error_code replica_bulk_loader::validate_bulk_load_status(bulk_load_status::type meta_status,
+                                                          bulk_load_status::type local_status)
+{
     // TODO(heyuchen): TBD
     return ERR_OK;
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-error_code replica_bulk_loader::bulk_load_start_download(const std::string &app_name,
-                                                         const std::string &cluster_name,
-                                                         const std::string &provider_name)
+error_code replica_bulk_loader::start_download(const std::string &app_name,
+                                               const std::string &cluster_name,
+                                               const std::string &provider_name)
 {
     if (_stub->_bulk_load_downloading_count.load() >=
         _stub->_max_concurrent_bulk_load_downloading_count) {
@@ -381,6 +419,35 @@ void replica_bulk_loader::check_download_finish()
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::start_ingestion()
+{
+    _status = bulk_load_status::BLS_INGESTING;
+    // TODO(heyuchen): add perf-counter
+    if (status() == partition_status::PS_PRIMARY) {
+        _replica->_primary_states.ingestion_is_empty_prepare_sent = false;
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::check_ingestion_finish()
+{
+    if (_replica->_app->get_ingestion_status() == ingestion_status::IS_SUCCEED &&
+        !_replica->_primary_states.ingestion_is_empty_prepare_sent) {
+        // send an empty prepare to gurantee secondary commit ingestion request, and set
+        // `pop_all_committed_mutations` as true
+        // ingestion is a special write request, replay this mutation can not learn data from
+        // external files, so when ingestion succeed, we should create a checkpoint
+        // if learn is evoked after ingestion, we should gurantee that learner should learn from
+        // checkpoint, to gurantee the condition above, we should pop all committed mutations in
+        // prepare list to gurantee learn type is LT_APP
+        mutation_ptr mu = _replica->new_mutation(invalid_decree);
+        mu->add_client_request(RPC_REPLICATION_WRITE_EMPTY, nullptr);
+        _replica->init_prepare(mu, false, true);
+        _replica->_primary_states.ingestion_is_empty_prepare_sent = true;
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::cleanup_download_task()
 {
     for (auto &kv : _download_task) {
@@ -413,6 +480,9 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
     case bulk_load_status::BLS_DOWNLOADING:
     case bulk_load_status::BLS_DOWNLOADED:
         report_group_download_progress(response);
+        break;
+    case bulk_load_status::BLS_INGESTING:
+        report_group_ingestion_status(response);
         break;
     // TODO(heyuchen): add other status
     default:
@@ -464,6 +534,50 @@ void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_respo
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_response &response)
+{
+    if (status() != partition_status::PS_PRIMARY) {
+        dwarn_replica("replica status={}, should be {}",
+                      enum_to_string(status()),
+                      enum_to_string(partition_status::PS_PRIMARY));
+        response.err = ERR_INVALID_STATE;
+        return;
+    }
+
+    partition_bulk_load_state primary_state;
+    primary_state.__set_ingest_status(_replica->_app->get_ingestion_status());
+    response.group_bulk_load_state[_replica->_primary_states.membership.primary] = primary_state;
+    ddebug_replica("primary = {}, ingestion status = {}",
+                   _replica->_primary_states.membership.primary.to_string(),
+                   enum_to_string(primary_state.ingest_status));
+
+    bool is_group_ingestion_finish = primary_state.ingest_status == ingestion_status::IS_SUCCEED;
+    for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
+        const auto &secondary_state =
+            _replica->_primary_states.secondary_bulk_load_states[target_address];
+        ingestion_status::type ingest_status = secondary_state.__isset.ingest_status
+                                                   ? secondary_state.ingest_status
+                                                   : ingestion_status::IS_INVALID;
+        ddebug_replica("secondary = {}, ingestion status={}",
+                       target_address.to_string(),
+                       enum_to_string(ingest_status));
+        response.group_bulk_load_state[target_address] = secondary_state;
+        is_group_ingestion_finish =
+            is_group_ingestion_finish && (ingest_status == ingestion_status::IS_SUCCEED);
+    }
+    response.__set_is_group_ingestion_finished(
+        is_group_ingestion_finish && (_replica->_primary_states.membership.secondaries.size() + 1 ==
+                                      _replica->_primary_states.membership.max_replica_count));
+
+    // if group ingestion finish, recover wirte immediately
+    if (is_group_ingestion_finish) {
+        ddebug_replica("finish ingestion, recover write");
+        _replica->_is_bulk_load_ingestion = false;
+        // TODO(heyuchen): reset perf-counter
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::report_bulk_load_states_to_primary(
     bulk_load_status::type remote_status,
     /*out*/ group_bulk_load_response &response)
@@ -480,6 +594,9 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
     case bulk_load_status::BLS_DOWNLOADED:
         bulk_load_state.__set_download_progress(_download_progress.load());
         bulk_load_state.__set_download_status(_download_status.load());
+        break;
+    case bulk_load_status::BLS_INGESTING:
+        bulk_load_state.__set_ingest_status(_replica->_app->get_ingestion_status());
         break;
     // TODO(heyuchen): add other status
     default:

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -34,8 +34,9 @@ private:
                             const std::string &provider_name);
 
     // compare meta bulk load status and local bulk load status
-    // \return ERR_INVALID_STATE if it is invalid for replica whose local status is `local_status`
-    // while meta status is `meta_status`
+    // \return ERR_INVALID_STATE if local status is invalid
+    // for example, if meta status is ingestion, replica local status can only be downloaded or
+    // ingestion, if local status is other status, will return ERR_INVALID_STATE
     error_code validate_bulk_load_status(bulk_load_status::type meta_status,
                                          bulk_load_status::type local_status);
 

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -33,12 +33,18 @@ private:
                             const std::string &cluster_name,
                             const std::string &provider_name);
 
+    // compare meta bulk load status and local bulk load status
+    // \return ERR_INVALID_STATE if it is invalid for replica whose local status is `local_status`
+    // while meta status is `meta_status`
+    error_code validate_bulk_load_status(bulk_load_status::type meta_status,
+                                         bulk_load_status::type local_status);
+
     // replica start or restart download sst files from remote provider
     // \return ERR_BUSY if node has already had enough replica executing downloading
     // \return download errors by function `download_sst_files`
-    error_code bulk_load_start_download(const std::string &app_name,
-                                        const std::string &cluster_name,
-                                        const std::string &provider_name);
+    error_code start_download(const std::string &app_name,
+                              const std::string &cluster_name,
+                              const std::string &provider_name);
 
     // download metadata and sst files from remote provider
     // metadata and sst files will be downloaded in {_dir}/.bulk_load directory
@@ -58,6 +64,8 @@ private:
 
     void try_decrease_bulk_load_download_count();
     void check_download_finish();
+    void start_ingestion();
+    void check_ingestion_finish();
 
     void cleanup_download_task();
     void clear_bulk_load_states();
@@ -66,6 +74,7 @@ private:
                                          bool report_metadata,
                                          /*out*/ bulk_load_response &response);
     void report_group_download_progress(/*out*/ bulk_load_response &response);
+    void report_group_ingestion_status(/*out*/ bulk_load_response &response);
 
     void report_bulk_load_states_to_primary(bulk_load_status::type remote_status,
                                             /*out*/ group_bulk_load_response &response);

--- a/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
@@ -44,13 +44,21 @@ public:
 
     error_code test_start_downloading()
     {
-        return _bulk_loader->bulk_load_start_download(APP_NAME, CLUSTER, PROVIDER);
+        return _bulk_loader->start_download(APP_NAME, CLUSTER, PROVIDER);
     }
 
     error_code test_parse_bulk_load_metadata(const std::string &file_path)
     {
         return _bulk_loader->parse_bulk_load_metadata(file_path);
     }
+
+    void test_update_download_progress(uint64_t file_size)
+    {
+        _bulk_loader->update_bulk_load_download_progress(file_size, "test_file_name");
+        _bulk_loader->tracker()->wait_outstanding_tasks();
+    }
+
+    void test_start_ingestion() { _bulk_loader->start_ingestion(); }
 
     int32_t test_report_group_download_progress(bulk_load_status::type status,
                                                 int32_t p_progress,
@@ -61,6 +69,20 @@ public:
         bulk_load_response response;
         _bulk_loader->report_group_download_progress(response);
         return response.total_download_progress;
+    }
+
+    bool test_report_group_ingestion_status(ingestion_status::type primary,
+                                            ingestion_status::type secondary1,
+                                            ingestion_status::type secondary2,
+                                            bool is_empty_prepare_sent,
+                                            bool replica_is_ingestion)
+    {
+        _replica->set_is_ingestion(replica_is_ingestion);
+        _replica->set_ingestion_status(primary);
+        mock_secondary_ingestion_states(secondary1, secondary2, is_empty_prepare_sent);
+        bulk_load_response response;
+        _bulk_loader->report_group_ingestion_status(response);
+        return response.is_group_ingestion_finished;
     }
 
     /// mock structure functions
@@ -180,6 +202,16 @@ public:
         return true;
     }
 
+    void mock_downloading_progress(uint64_t file_total_size,
+                                   uint64_t cur_downloaded_size,
+                                   int32_t download_progress)
+    {
+        _bulk_loader->_status = bulk_load_status::type::BLS_DOWNLOADING;
+        _bulk_loader->_metadata.file_total_size = file_total_size;
+        _bulk_loader->_cur_downloaded_size = cur_downloaded_size;
+        _bulk_loader->_download_progress = download_progress;
+    }
+
     void mock_replica_bulk_load_varieties(bulk_load_status::type status,
                                           int32_t download_progress,
                                           ingestion_status::type istatus,
@@ -187,7 +219,8 @@ public:
     {
         _bulk_loader->_status = status;
         _bulk_loader->_download_progress = download_progress;
-        // TODO(heyuchen): add ingestion status
+        _replica->set_is_ingestion(is_ingestion);
+        _replica->set_ingestion_status(istatus);
     }
 
     void mock_secondary_progress(int32_t secondary_progress1, int32_t secondary_progress2)
@@ -223,6 +256,20 @@ public:
         } else if (p_status == bulk_load_status::BLS_DOWNLOADED) {
             mock_group_progress(p_status, 100, 100, 100);
         }
+    }
+
+    void mock_secondary_ingestion_states(ingestion_status::type status1,
+                                         ingestion_status::type status2,
+                                         bool is_empty_prepare_sent = true)
+    {
+        mock_secondary_progress(100, 100);
+        _replica->set_is_empty_prepare_sent(is_empty_prepare_sent);
+
+        partition_bulk_load_state state1, state2;
+        state1.__set_ingest_status(status1);
+        state2.__set_ingest_status(status2);
+        _replica->set_secondary_bulk_load_state(SECONDARY, state1);
+        _replica->set_secondary_bulk_load_state(SECONDARY2, state2);
     }
 
     // helper functions
@@ -298,8 +345,7 @@ TEST_F(replica_bulk_loader_test, start_downloading_test)
 {
     // Test cases:
     // - stub concurrent downloading count excceed
-    // - TODO(heyuchen): add 'downloading error' after implemtation do_download
-    // - /*{false, 1, ERR_CORRUPTION, bulk_load_status::BLS_DOWNLOADING, 1},*/
+    // - downloading error
     // - downloading succeed
     struct test_struct
     {
@@ -313,6 +359,7 @@ TEST_F(replica_bulk_loader_test, start_downloading_test)
                ERR_BUSY,
                bulk_load_status::BLS_INVALID,
                MAX_DOWNLOADING_COUNT},
+              {false, 1, ERR_CORRUPTION, bulk_load_status::BLS_DOWNLOADING, 1},
               {true, 1, ERR_OK, bulk_load_status::BLS_DOWNLOADING, 2}};
 
     for (auto test : tests) {
@@ -357,6 +404,25 @@ TEST_F(replica_bulk_loader_test, bulk_load_metadata_parse_succeed)
     utils::filesystem::remove_path(LOCAL_DIR);
 }
 
+// finish download test
+TEST_F(replica_bulk_loader_test, finish_download_test)
+{
+    mock_downloading_progress(100, 50, 50);
+    stub->set_bulk_load_downloading_count(3);
+
+    test_update_download_progress(50);
+    ASSERT_EQ(get_bulk_load_status(), bulk_load_status::BLS_DOWNLOADED);
+    ASSERT_EQ(stub->get_bulk_load_downloading_count(), 2);
+}
+
+// start ingestion test
+TEST_F(replica_bulk_loader_test, start_ingestion_test)
+{
+    mock_group_progress(bulk_load_status::BLS_DOWNLOADED);
+    test_start_ingestion();
+    ASSERT_EQ(get_bulk_load_status(), bulk_load_status::BLS_INGESTING);
+}
+
 // report_group_download_progress unit tests
 TEST_F(replica_bulk_loader_test, report_group_download_progress_test)
 {
@@ -379,6 +445,80 @@ TEST_F(replica_bulk_loader_test, report_group_download_progress_test)
                                                       test.secondary1_progress,
                                                       test.secondary2_progress),
                   test.total_progress);
+    }
+}
+
+// report_group_ingestion_status unit tests
+TEST_F(replica_bulk_loader_test, report_group_ingestion_status_test)
+{
+
+    struct ingestion_struct
+    {
+        ingestion_status::type primary;
+        ingestion_status::type secondary1;
+        ingestion_status::type secondary2;
+        bool is_empty_prepare_sent;
+        bool replica_is_ingestion;
+        bool is_group_ingestion_finished;
+    } tests[] = {
+        {ingestion_status::IS_INVALID,
+         ingestion_status::IS_INVALID,
+         ingestion_status::IS_INVALID,
+         false,
+         false,
+         false},
+        {ingestion_status::IS_RUNNING,
+         ingestion_status::IS_INVALID,
+         ingestion_status::IS_INVALID,
+         false,
+         false,
+         false},
+        {ingestion_status::IS_SUCCEED,
+         ingestion_status::IS_INVALID,
+         ingestion_status::IS_INVALID,
+         false,
+         false,
+         false},
+        {ingestion_status::IS_FAILED,
+         ingestion_status::IS_INVALID,
+         ingestion_status::IS_INVALID,
+         false,
+         false,
+         false},
+        {ingestion_status::IS_RUNNING,
+         ingestion_status::IS_RUNNING,
+         ingestion_status::IS_INVALID,
+         false,
+         false,
+         false},
+        {ingestion_status::IS_SUCCEED,
+         ingestion_status::IS_SUCCEED,
+         ingestion_status::IS_RUNNING,
+         true,
+         false,
+         false},
+        {ingestion_status::IS_FAILED,
+         ingestion_status::IS_FAILED,
+         ingestion_status::IS_RUNNING,
+         false,
+         false,
+         false},
+        {ingestion_status::IS_SUCCEED,
+         ingestion_status::IS_SUCCEED,
+         ingestion_status::IS_SUCCEED,
+         true,
+         true,
+         true},
+    };
+
+    for (auto test : tests) {
+        ASSERT_EQ(test_report_group_ingestion_status(test.primary,
+                                                     test.secondary1,
+                                                     test.secondary2,
+                                                     test.is_empty_prepare_sent,
+                                                     test.replica_is_ingestion),
+                  test.is_group_ingestion_finished);
+        ASSERT_FALSE(_replica->is_ingestion());
     }
 }
 

--- a/src/dist/replication/lib/prepare_list.cpp
+++ b/src/dist/replication/lib/prepare_list.cpp
@@ -67,7 +67,9 @@ void prepare_list::truncate(decree init_decree)
     _last_committed_decree = init_decree;
 }
 
-error_code prepare_list::prepare(mutation_ptr &mu, partition_status::type status)
+error_code prepare_list::prepare(mutation_ptr &mu,
+                                 partition_status::type status,
+                                 bool pop_all_committed_mutations)
 {
     decree d = mu->data.header.decree;
     dcheck_gt_replica(d, last_committed_decree());
@@ -75,8 +77,9 @@ error_code prepare_list::prepare(mutation_ptr &mu, partition_status::type status
     error_code err;
     switch (status) {
     case partition_status::PS_PRIMARY:
-        // pop committed mutations if buffer is full
-        while (d - min_decree() >= capacity() && last_committed_decree() > min_decree()) {
+        // pop committed mutations if buffer is full or pop_all_committed_mutations = true
+        while ((d - min_decree() >= capacity() || pop_all_committed_mutations) &&
+               last_committed_decree() > min_decree()) {
             pop_min();
         }
         return mutation_cache::put(mu);
@@ -85,8 +88,9 @@ error_code prepare_list::prepare(mutation_ptr &mu, partition_status::type status
     case partition_status::PS_POTENTIAL_SECONDARY:
         // all mutations with lower decree must be ready
         commit(mu->data.header.last_committed_decree, COMMIT_TO_DECREE_HARD);
-        // pop committed mutations if buffer is full
-        while (d - min_decree() >= capacity() && last_committed_decree() > min_decree()) {
+        // pop committed mutations if buffer is full or pop_all_committed_mutations = true
+        while ((d - min_decree() >= capacity() || pop_all_committed_mutations) &&
+               last_committed_decree() > min_decree()) {
             pop_min();
         }
         err = mutation_cache::put(mu);

--- a/src/dist/replication/lib/prepare_list.h
+++ b/src/dist/replication/lib/prepare_list.h
@@ -63,8 +63,12 @@ public:
     //
     // for two-phase commit
     //
-    error_code prepare(mutation_ptr &mu, partition_status::type status); // unordered prepare
-    void commit(decree decree, commit_type ct);                          // ordered commit
+    // if pop_all_committed_mutations = true, pop all committed mutations, will only used during
+    // bulk load ingestion
+    error_code prepare(mutation_ptr &mu,
+                       partition_status::type status,
+                       bool pop_all_committed_mutations = false); // unordered prepare
+    void commit(decree decree, commit_type ct);                   // ordered commit
 
 private:
     decree _last_committed_decree;

--- a/src/dist/replication/lib/replica.h
+++ b/src/dist/replication/lib/replica.h
@@ -220,11 +220,15 @@ private:
 
     /////////////////////////////////////////////////////////////////
     // 2pc
-    void init_prepare(mutation_ptr &mu, bool reconciliation);
+    // `pop_all_committed_mutations = true` will be used for ingestion empty write
+    // See more about it in `replica_bulk_loader.cpp`
+    void
+    init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_committed_mutations = false);
     void send_prepare_message(::dsn::rpc_address addr,
                               partition_status::type status,
                               const mutation_ptr &mu,
                               int timeout_milliseconds,
+                              bool pop_all_committed_mutations = false,
                               int64_t learn_signature = invalid_signature);
     void on_append_log_completed(mutation_ptr &mu, error_code err, size_t size);
     void on_prepare_reply(std::pair<mutation_ptr, partition_status::type> pr,
@@ -444,7 +448,6 @@ private:
     friend class replica_test;
     friend class replica_backup_manager;
     friend class replica_bulk_loader;
-    friend class replica_file_provider_test;
 
     // replica configuration, updated by update_local_configuration ONLY
     replica_configuration _config;

--- a/src/dist/replication/lib/replica_2pc.cpp
+++ b/src/dist/replication/lib/replica_2pc.cpp
@@ -116,7 +116,7 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
     }
 }
 
-void replica::init_prepare(mutation_ptr &mu, bool reconciliation)
+void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_committed_mutations)
 {
     dassert(partition_status::PS_PRIMARY == status(),
             "invalid partition_status, status = %s",
@@ -184,7 +184,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation)
             last_committed_decree());
 
     // local prepare
-    err = _prepare_list->prepare(mu, partition_status::PS_PRIMARY);
+    err = _prepare_list->prepare(mu, partition_status::PS_PRIMARY, pop_all_committed_mutations);
     if (err != ERR_OK) {
         goto ErrOut;
     }
@@ -195,8 +195,11 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation)
     for (auto it = _primary_states.membership.secondaries.begin();
          it != _primary_states.membership.secondaries.end();
          ++it) {
-        send_prepare_message(
-            *it, partition_status::PS_SECONDARY, mu, _options->prepare_timeout_ms_for_secondaries);
+        send_prepare_message(*it,
+                             partition_status::PS_SECONDARY,
+                             mu,
+                             _options->prepare_timeout_ms_for_secondaries,
+                             pop_all_committed_mutations);
     }
 
     count = 0;
@@ -207,6 +210,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation)
                                  partition_status::PS_POTENTIAL_SECONDARY,
                                  mu,
                                  _options->prepare_timeout_ms_for_potential_secondaries,
+                                 pop_all_committed_mutations,
                                  it->second.signature);
             count++;
         }
@@ -262,12 +266,14 @@ void replica::send_prepare_message(::dsn::rpc_address addr,
                                    partition_status::type status,
                                    const mutation_ptr &mu,
                                    int timeout_milliseconds,
+                                   bool pop_all_committed_mutations,
                                    int64_t learn_signature)
 {
     dsn::message_ex *msg = dsn::message_ex::create_request(
         RPC_PREPARE, timeout_milliseconds, get_gpid().thread_hash());
     replica_configuration rconfig;
     _primary_states.get_replica_config(status, rconfig, learn_signature);
+    rconfig.__set_pop_all(pop_all_committed_mutations);
 
     {
         rpc_write_stream writer(msg);
@@ -648,8 +654,12 @@ void replica::on_prepare_reply(std::pair<mutation_ptr, partition_status::type> p
                         if (status() == partition_status::PS_PRIMARY &&
                             get_ballot() == mu->data.header.ballot &&
                             mu->get_decree() > last_committed_decree()) {
-                            send_prepare_message(
-                                node, target_status, mu, prepare_timeout_ms, learn_signature);
+                            send_prepare_message(node,
+                                                 target_status,
+                                                 mu,
+                                                 prepare_timeout_ms,
+                                                 false,
+                                                 learn_signature);
                         }
                     },
                     get_gpid().thread_hash(),

--- a/src/dist/replication/lib/replica_context.cpp
+++ b/src/dist/replication/lib/replica_context.cpp
@@ -156,11 +156,9 @@ bool primary_context::check_exist(::dsn::rpc_address node, partition_status::typ
 
 void primary_context::cleanup_bulk_load_states()
 {
-    // TODO(heyuchen): TBD
-    // primary will save bulk load states reported from secondaries, this function is to cleanup
-    // those states
     secondary_bulk_load_states.erase(secondary_bulk_load_states.begin(),
                                      secondary_bulk_load_states.end());
+    ingestion_is_empty_prepare_sent = false;
 }
 
 bool secondary_context::cleanup(bool force)

--- a/src/dist/replication/lib/replica_context.h
+++ b/src/dist/replication/lib/replica_context.h
@@ -154,6 +154,9 @@ public:
     node_tasks group_bulk_load_pending_replies;
     // bulk_load_state of secondary replicas
     std::unordered_map<rpc_address, partition_bulk_load_state> secondary_bulk_load_states;
+    // if primary send an empty prepare after ingestion succeed to gurantee secondary commit its
+    // ingestion request
+    bool ingestion_is_empty_prepare_sent{false};
 };
 
 class secondary_context

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -47,6 +47,9 @@ struct replica_configuration
     3:dsn.rpc_address     primary;
     4:partition_status    status = partition_status.PS_INVALID;
     5:i64                 learner_signature;
+    // Used for bulk load
+    // secondary will pop all committed mutations even if buffer is not full
+    6:optional bool       pop_all = false;
 }
 
 struct prepare_msg
@@ -1014,7 +1017,8 @@ struct ingestion_request
 
 struct ingestion_response
 {
-    // Possible errors are same as write request errors, such as ERR_OBJECT_NOT_FOUND, ERR_INVALID_STATE
+    // Possible errors:
+    // - ERR_TRY_AGAIN: retry ingestion
     1:dsn.error_code    err;
     // rocksdb ingestion error code
     2:i32               rocksdb_error;

--- a/src/dist/replication/test/replica_test/unit_test/mock_utils.h
+++ b/src/dist/replication/test/replica_test/unit_test/mock_utils.h
@@ -72,9 +72,13 @@ public:
     // TODO(heyuchen): implement this function in further pull request
     void set_partition_version(int32_t partition_version) override {}
 
+    void set_ingestion_status(ingestion_status::type status) { _ingestion_status = status; }
+    ingestion_status::type get_ingestion_status() override { return _ingestion_status; }
+
 private:
     std::map<std::string, std::string> _envs;
     decree _decree = 5;
+    ingestion_status::type _ingestion_status;
 };
 
 class mock_replica : public replica
@@ -148,6 +152,13 @@ public:
     {
         _primary_states.secondary_bulk_load_states[node] = state;
     }
+    void set_is_empty_prepare_sent(bool flag)
+    {
+        _primary_states.ingestion_is_empty_prepare_sent = flag;
+    }
+    bool is_ingestion() { return _is_bulk_load_ingestion; }
+    void set_is_ingestion(bool flag) { _is_bulk_load_ingestion = flag; }
+    void set_ingestion_status(ingestion_status::type status) { _app->set_ingestion_status(status); }
 
 private:
     decree _max_gced_decree{invalid_decree - 1};


### PR DESCRIPTION
The whole bulk load ingestion process is like:
1. meta server set app and all partitions bulk load status as ingesting #486 
2. meta send two requests to primary 
    - send ingestion request to primary #486 
    - send bulk load request to query ingestion status #457
3. primary handle two requests above:
    - primary consider ingestion request as a client write and replica group execute 2pc process to do actual rocksdb ingestion operation #490 pegasus pr [#546](https://github.com/XiaoMi/pegasus/pull/546)
    - **primary handle bulk load request** and broadcast it to secondary #460 
4. secondary handle two cases:
    - ingestion files through 2pc #490 pegasus pr [#546](https://github.com/XiaoMi/pegasus/pull/546)
    - **report ingestion status to primary**
5. **primary report group ingestion status to meta server**
6. meta handle two response
    - handle ingestion_response #493 
    - handle group ingestion status and do bulk load status transformation

This pull request is about how replica handle bulk_load_request during ingestion.
- **implement function `do_bulk_load`**
     - this function will be called when primary receives `bulk_load_request` and secondary receives `group_bulk_load_request`. It will first check primary status, and compare bulk load status from request and replica local bulk load status (in function `validate_bulk_load_status`, not implemented in this pull request), then call different functions according to bulk load status.
    - when request status is downloading, and local status is invalid, will call `start_download` to start download files from file provider.
    - when request status is ingestion, local status is downloaded, will call `start_ingestion`
    - when request status is ingestion, local status is ingestion, will call `check_ingestion_finish`
- **ingestion is considered as a write request, but it is different from normal write, we should add some special checking for it**
    - **write an empty put after ingestion.** For write request, when primary receives secondaries prepare reply, it will commit this mutation, and secondaries will commit the mutation when they prepare next mutation, so send an empty prepare to guarantee secondary commit ingestion request.
    - **pop all committed mutation when prepare the empty put.** For ingestion mutation, replay private log can not learn data ingested. To make data correct, we will create a checkpoint ( not implemented in this pull request), and should guarantee learner learn data from checkpoint. To satisfy the condition above, we should pop all committed mutation when prepare the empty put, so the prepare list is empty, learn type will always be LT_APP, learn checkpoint firstly. 
        - add `ingestion_is_empty_prepare_sent` in primary_context to write empty put only once.
        - add `pop_all_committed_mutations` parameter for function `init_prepare`, `send_prepare_message`, `prepare`, add `pop_all` for thrift structure `replica_configuration`.
- **report ingestion status**
    - secondary report ingestion status in function `report_bulk_load_states_to_primary`
    - primary report group ingestion status in function `report_group_ingestion_status`, when group ingestion succeed, recover normal write

