### PR TITLE
feat(bulk-load): bulk load ingestion part6 - meta handle bulk_load_response during ingestion

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -565,8 +565,7 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
                        target_address.to_string(),
                        enum_to_string(ingest_status));
         response.group_bulk_load_state[target_address] = secondary_state;
-        is_group_ingestion_finish =
-            is_group_ingestion_finish && (ingest_status == ingestion_status::IS_SUCCEED);
+        is_group_ingestion_finish &= (ingest_status == ingestion_status::IS_SUCCEED);
     }
     response.__set_is_group_ingestion_finished(is_group_ingestion_finish);
 

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -551,7 +551,10 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
                    _replica->_primary_states.membership.primary.to_string(),
                    enum_to_string(primary_state.ingest_status));
 
-    bool is_group_ingestion_finish = primary_state.ingest_status == ingestion_status::IS_SUCCEED;
+    bool is_group_ingestion_finish =
+        (primary_state.ingest_status == ingestion_status::IS_SUCCEED) &&
+        (_replica->_primary_states.membership.secondaries.size() + 1 ==
+         _replica->_primary_states.membership.max_replica_count);
     for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
         const auto &secondary_state =
             _replica->_primary_states.secondary_bulk_load_states[target_address];
@@ -565,9 +568,7 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
         is_group_ingestion_finish =
             is_group_ingestion_finish && (ingest_status == ingestion_status::IS_SUCCEED);
     }
-    response.__set_is_group_ingestion_finished(
-        is_group_ingestion_finish && (_replica->_primary_states.membership.secondaries.size() + 1 ==
-                                      _replica->_primary_states.membership.max_replica_count));
+    response.__set_is_group_ingestion_finished(is_group_ingestion_finish);
 
     // if group ingestion finish, recover wirte immediately
     if (is_group_ingestion_finish) {

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -318,7 +318,7 @@ void bulk_load_service::on_partition_bulk_load_reply(error_code err,
     int32_t interval = bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL;
 
     if (err != ERR_OK) {
-        derror_f("app({}), partition({}) failed to recevie bulk load response, error = {}",
+        derror_f("app({}), partition({}) failed to receive bulk load response, error = {}",
                  app_name,
                  pid,
                  err.to_string());
@@ -447,7 +447,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
 
     if (!response.__isset.total_download_progress) {
         dwarn_f(
-            "recevie bulk load response from node({}) app({}), partition({}), primary_status({}), "
+            "receive bulk load response from node({}) app({}), partition({}), primary_status({}), "
             "but total_download_progress is not set",
             primary_addr.to_string(),
             app_name,
@@ -460,7 +460,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
         const auto &bulk_load_states = kv.second;
         if (!bulk_load_states.__isset.download_progress ||
             !bulk_load_states.__isset.download_status) {
-            dwarn_f("recevie bulk load response from node({}) app({}), partition({}), "
+            dwarn_f("receive bulk load response from node({}) app({}), partition({}), "
                     "primary_status({}), but node({}) progress or status is not set",
                     primary_addr.to_string(),
                     app_name,
@@ -489,7 +489,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
 
     // update download progress
     int32_t total_progress = response.total_download_progress;
-    ddebug_f("recevie bulk load response from node({}) app({}) partition({}), primary_status({}), "
+    ddebug_f("receive bulk load response from node({}) app({}) partition({}), primary_status({}), "
              "total_download_progress = {}",
              primary_addr.to_string(),
              app_name,
@@ -518,10 +518,10 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
     const gpid &pid = response.pid;
 
     if (!response.__isset.is_group_ingestion_finished) {
-        dwarn_f("recevie bulk load response from node({}) app({}) partition({}), "
+        dwarn_f("receive bulk load response from node({}) app({}) partition({}), "
                 "primary_status({}), but is_group_ingestion_finished is not set",
                 primary_addr.to_string(),
-                response.app_name,
+                app_name,
                 pid,
                 dsn::enum_to_string(response.primary_bulk_load_status));
         return;
@@ -530,10 +530,10 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
     for (const auto &kv : response.group_bulk_load_state) {
         const auto &bulk_load_states = kv.second;
         if (!bulk_load_states.__isset.ingest_status) {
-            dwarn_f("recevie bulk load response from node({}) app({}) partition({}), "
+            dwarn_f("receive bulk load response from node({}) app({}) partition({}), "
                     "primary_status({}), but node({}) ingestion_status is not set",
                     primary_addr.to_string(),
-                    response.app_name,
+                    app_name,
                     pid,
                     dsn::enum_to_string(response.primary_bulk_load_status),
                     kv.first.to_string());
@@ -541,7 +541,7 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
         }
 
         if (bulk_load_states.ingest_status == ingestion_status::IS_FAILED) {
-            derror_f("app({}) partition({}) node({}) ingestion failed",
+            derror_f("app({}) partition({}) on node({}) ingestion failed",
                      app_name,
                      pid,
                      kv.first.to_string());
@@ -550,7 +550,7 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
         }
     }
 
-    ddebug_f("recevie bulk load response from node({}) app({}) partition({}), primary_status({}), "
+    ddebug_f("receive bulk load response from node({}) app({}) partition({}), primary_status({}), "
              "is_group_ingestion_finished = {}",
              primary_addr.to_string(),
              app_name,


### PR DESCRIPTION
The whole bulk load ingestion process is like:
1. meta server set app and all partitions bulk load status as ingesting #486 
2. meta send two requests to primary 
    - send ingestion request to primary #486 
    - send bulk load request to query ingestion status #457
3. primary handle two requests above:
    - primary consider ingestion request as a client write and replica group execute 2pc process to do actual rocksdb ingestion operation #490 pegasus pr [#546](https://github.com/XiaoMi/pegasus/pull/546)
    - primary handle bulk load request and broadcast it to secondary #496 #460
4. secondary handle two cases:
    - ingestion files through 2pc #490 pegasus pr [#546](https://github.com/XiaoMi/pegasus/pull/546)
    - report ingestion status to primary #496 
5. primary report group ingestion status to meta server #496 
6. meta handle two response
    - handle ingestion_response #493 
    - **handle group ingestion status and do bulk load status transformation**

This pull request is about meta handle ingestion status reported by replica server, part of step 6 above.
- meta handle ingestion status function `handle_app_ingestion`
    - check if `is_group_ingestion_finished` and replica's `ingest_status` are set, if not set, meta should not update partition ingestion_status in this round
    - if any replica's ingestion status is `IS_FAILED`, we consider it as an unrecoverable error, bulk load will set as failed
    - if all replicas of the group ingest succeed, meta will set this partition status from ingesting to succeed
- bulk load status transformation
    - if all partitions status turn from ingesting to succeed, meta will set app status from ingestion to succeed in `update_partition_status_on_remote_storage_reply`