### PR TITLE
refactor: use check_status to reimplement some rpc interfaces of meta_service

### DIFF
--- a/include/dsn/cpp/rpc_holder.h
+++ b/include/dsn/cpp/rpc_holder.h
@@ -200,6 +200,8 @@ public:
         return t;
     }
 
+    void forward(rpc_address addr) { _i->forward(addr); }
+
     // Returns an rpc_holder that will reply the request after its lifetime ends.
     // By default rpc_holder never replies.
     // SEE: serverlet<T>::register_rpc_handler_with_rpc_holder
@@ -280,6 +282,12 @@ private:
             message_ex *dsn_response = dsn_request->create_response();
             marshall(dsn_response, thrift_response);
             dsn_rpc_reply(dsn_response);
+        }
+
+        void forward(rpc_address addr)
+        {
+            auto_reply = false;
+            dsn_rpc_forward(dsn_request, addr);
         }
 
         ~internal()

--- a/include/dsn/cpp/rpc_holder.h
+++ b/include/dsn/cpp/rpc_holder.h
@@ -303,12 +303,6 @@ private:
             dsn_rpc_reply(dsn_response);
         }
 
-        void forward(rpc_address addr)
-        {
-            auto_reply = false;
-            dsn_rpc_forward(dsn_request, addr);
-        }
-
         ~internal()
         {
             if (auto_reply) {

--- a/include/dsn/cpp/rpc_holder.h
+++ b/include/dsn/cpp/rpc_holder.h
@@ -212,9 +212,6 @@ public:
         return rpc;
     }
 
-    // disable auto reply which is performed in the destructor of _i
-    void disable_auto_reply() { _i->auto_reply = false; }
-
     // Only use this function when testing.
     // In mock mode, all messages will be dropped into mail_box without going through network,
     // and response callbacks will never be called.

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -719,6 +719,7 @@ void meta_service::on_start_recovery(configuration_recovery_rpc rpc)
     if (result == 0) {
         return;
     }
+
     if (result == -1) {
         response.err = ERR_FORWARD_TO_OTHERS;
     } else {

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -716,6 +716,7 @@ void meta_service::on_start_recovery(configuration_recovery_rpc rpc)
     configuration_recovery_response &response = rpc.response();
     ddebug("got start recovery request, start to do recovery");
     int result = check_leader(rpc, nullptr);
+    // request has been forwarded to others
     if (result == 0) {
         return;
     }

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -93,6 +93,47 @@ bool meta_service::check_freeze() const
     return _alive_set.size() * 100 < _node_live_percentage_threshold_for_update * total;
 }
 
+template <typename TRpcHolder>
+int meta_service::check_leader(TRpcHolder rpc)
+{
+    dsn::rpc_address leader;
+    if (!_failure_detector->get_leader(&leader)) {
+        if (!rpc.dsn_request()->header->context.u.is_forward_supported) {
+            return -1;
+        }
+
+        dinfo("leader address: %s", leader.to_string());
+        if (!leader.is_invalid()) {
+            rpc.forward(leader);
+            return 0;
+        } else {
+            return -1;
+        }
+    }
+    return 1;
+}
+
+template <typename TRpcHolder>
+bool meta_service::check_status(TRpcHolder rpc)
+{
+    dinfo("rpc %s called", __FUNCTION__);
+    int result = check_leader(rpc);
+    if (result == 0)
+        return false;
+    if (result == -1 || !_started) {
+        if (result == -1)
+            rpc.response().err = ERR_FORWARD_TO_OTHERS;
+        else if (_recovering)
+            rpc.response().err = ERR_UNDER_RECOVERY;
+        else
+            rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
+        ddebug("reject request with %s", rpc.response().err.to_string());
+        return false;
+    }
+
+    return true;
+}
+
 error_code meta_service::remote_storage_initialize()
 {
     // create storage
@@ -472,17 +513,20 @@ void meta_service::on_recall_app(dsn::message_ex *req)
 
 void meta_service::on_list_apps(configuration_list_apps_rpc rpc)
 {
-    configuration_list_apps_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
-    _state->list_apps(rpc.request(), response);
+    _state->list_apps(rpc.request(), rpc.response());
 }
 
 void meta_service::on_list_nodes(configuration_list_nodes_rpc rpc)
 {
-    configuration_list_nodes_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
+    configuration_list_nodes_response &response = rpc.response();
     const configuration_list_nodes_request &request = rpc.request();
     {
         zauto_lock l(_failure_detector->_lock);
@@ -508,10 +552,12 @@ void meta_service::on_list_nodes(configuration_list_nodes_rpc rpc)
 
 void meta_service::on_query_cluster_info(configuration_cluster_info_rpc rpc)
 {
-    configuration_cluster_info_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
     std::stringstream oss;
+    configuration_cluster_info_response &response = rpc.response();
     response.keys.push_back("meta_servers");
     for (size_t i = 0; i < _opts.meta_servers.size(); ++i) {
         if (i != 0)
@@ -590,7 +636,9 @@ void meta_service::on_query_configuration_by_index(configuration_query_by_index_
 // meta state thread pool
 void meta_service::on_config_sync(configuration_query_by_node_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     {
         // this code piece should be referenced together with meta_service::set_node_state.
@@ -637,10 +685,12 @@ void meta_service::on_update_configuration(dsn::message_ex *req)
 
 void meta_service::on_control_meta_level(configuration_meta_control_rpc rpc)
 {
+    if (!check_status(rpc)) {
+        return;
+    }
+
     const configuration_meta_control_request &request = rpc.request();
     configuration_meta_control_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
-
     response.err = ERR_OK;
     response.old_level = _function_level.load();
     if (request.level == meta_function_level::fl_invalid) {
@@ -659,14 +709,15 @@ void meta_service::on_control_meta_level(configuration_meta_control_rpc rpc)
 
 void meta_service::on_propose_balancer(configuration_balancer_rpc rpc)
 {
-    const configuration_balancer_request &request = rpc.request();
-    configuration_balancer_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
+    const configuration_balancer_request &request = rpc.request();
     ddebug("get proposal balancer request, gpid(%d.%d)",
            request.gpid.get_app_id(),
            request.gpid.get_partition_index());
-    _state->on_propose_balancer(request, response);
+    _state->on_propose_balancer(request, rpc.response());
 }
 
 void meta_service::on_start_recovery(configuration_recovery_rpc rpc)
@@ -727,9 +778,11 @@ void meta_service::on_add_backup_policy(dsn::message_ex *req)
 
 void meta_service::on_query_backup_policy(query_backup_policy_rpc policy_rpc)
 {
-    auto &response = policy_rpc.response();
-    RPC_CHECK_STATUS(policy_rpc.dsn_request(), response);
+    if (!check_status(policy_rpc)) {
+        return;
+    }
 
+    auto &response = policy_rpc.response();
     if (_backup_handler == nullptr) {
         derror("meta doesn't enable backup service");
         response.err = ERR_SERVICE_NOT_ACTIVE;
@@ -743,12 +796,13 @@ void meta_service::on_query_backup_policy(query_backup_policy_rpc policy_rpc)
 
 void meta_service::on_modify_backup_policy(configuration_modify_backup_policy_rpc rpc)
 {
-    configuration_modify_backup_policy_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
     if (_backup_handler == nullptr) {
         derror("meta doesn't enable backup service");
-        response.err = ERR_SERVICE_NOT_ACTIVE;
+        rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
     } else {
         tasking::enqueue(
             LPC_DEFAULT_CALLBACK,
@@ -759,8 +813,9 @@ void meta_service::on_modify_backup_policy(configuration_modify_backup_policy_rp
 
 void meta_service::on_report_restore_status(configuration_report_restore_status_rpc rpc)
 {
-    configuration_report_restore_status_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
     tasking::enqueue(LPC_META_STATE_NORMAL,
                      nullptr,
@@ -769,8 +824,9 @@ void meta_service::on_report_restore_status(configuration_report_restore_status_
 
 void meta_service::on_query_restore_status(configuration_query_restore_rpc rpc)
 {
-    configuration_query_restore_response &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
     tasking::enqueue(LPC_META_STATE_NORMAL,
                      nullptr,
@@ -779,7 +835,9 @@ void meta_service::on_query_restore_status(configuration_query_restore_rpc rpc)
 
 void meta_service::on_add_duplication(duplication_add_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     if (!_dup_svc) {
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
@@ -793,7 +851,9 @@ void meta_service::on_add_duplication(duplication_add_rpc rpc)
 
 void meta_service::on_modify_duplication(duplication_modify_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     if (!_dup_svc) {
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
@@ -807,7 +867,9 @@ void meta_service::on_modify_duplication(duplication_modify_rpc rpc)
 
 void meta_service::on_query_duplication_info(duplication_query_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     if (_dup_svc) {
         _dup_svc->query_duplication_info(rpc.request(), rpc.response());
@@ -818,7 +880,9 @@ void meta_service::on_query_duplication_info(duplication_query_rpc rpc)
 
 void meta_service::on_duplication_sync(duplication_sync_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     tasking::enqueue(LPC_META_STATE_NORMAL,
                      tracker(),
@@ -861,9 +925,11 @@ void meta_service::initialize_duplication_service()
 
 void meta_service::update_app_env(app_env_rpc env_rpc)
 {
-    auto &response = env_rpc.response();
-    RPC_CHECK_STATUS(env_rpc.dsn_request(), response);
+    if (!check_status(env_rpc)) {
+        return;
+    }
 
+    auto &response = env_rpc.response();
     app_env_operation::type op = env_rpc.request().op;
     switch (op) {
     case app_env_operation::type::APP_ENV_OP_SET:
@@ -892,16 +958,20 @@ void meta_service::update_app_env(app_env_rpc env_rpc)
 
 void meta_service::ddd_diagnose(ddd_diagnose_rpc rpc)
 {
-    auto &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
+    auto &response = rpc.response();
     get_balancer()->get_ddd_partitions(rpc.request().pid, response.partitions);
     response.err = ERR_OK;
 }
 
 void meta_service::on_app_partition_split(app_partition_split_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     tasking::enqueue(LPC_META_STATE_NORMAL,
                      tracker(),
@@ -911,7 +981,9 @@ void meta_service::on_app_partition_split(app_partition_split_rpc rpc)
 
 void meta_service::on_register_child_on_meta(register_child_rpc rpc)
 {
-    RPC_CHECK_STATUS(rpc.dsn_request(), rpc.response());
+    if (!check_status(rpc)) {
+        return;
+    }
 
     tasking::enqueue(LPC_META_STATE_NORMAL,
                      tracker(),
@@ -921,12 +993,13 @@ void meta_service::on_register_child_on_meta(register_child_rpc rpc)
 
 void meta_service::on_start_bulk_load(start_bulk_load_rpc rpc)
 {
-    auto &response = rpc.response();
-    RPC_CHECK_STATUS(rpc.dsn_request(), response);
+    if (!check_status(rpc)) {
+        return;
+    }
 
     if (!_bulk_load_svc) {
         derror("meta doesn't support bulk load");
-        response.err = ERR_SERVICE_NOT_ACTIVE;
+        rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
     } else {
         tasking::enqueue(LPC_META_STATE_NORMAL,
                          tracker(),

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -604,30 +604,13 @@ void meta_service::on_query_cluster_info(configuration_cluster_info_rpc rpc)
 void meta_service::on_query_configuration_by_index(configuration_query_by_index_rpc rpc)
 {
     configuration_query_by_index_response &response = rpc.response();
-
-    // here we do not use RPC_CHECK_STATUS macro, but specially handle it
-    // to response forward address.
-    dinfo("rpc %s called", __FUNCTION__);
     rpc_address forward_address;
-    int result = check_leader(rpc.dsn_request(), &forward_address);
-    if (result == 0) {
-        rpc.disable_auto_reply();
-        return;
-    }
-    if (result == -1 || !_started) {
-        if (result == -1) {
-            response.err = ERR_FORWARD_TO_OTHERS;
-            if (!forward_address.is_invalid()) {
-                partition_configuration config;
-                config.primary = forward_address;
-                response.partitions.push_back(std::move(config));
-            }
-        } else if (_recovering) {
-            response.err = ERR_UNDER_RECOVERY;
-        } else {
-            response.err = ERR_SERVICE_NOT_ACTIVE;
+    if (!check_status(rpc, &forward_address)) {
+        if (!forward_address.is_invalid()) {
+            partition_configuration config;
+            config.primary = forward_address;
+            response.partitions.push_back(std::move(config));
         }
-        ddebug("reject request with %s", response.err.to_string());
         return;
     }
 
@@ -733,28 +716,15 @@ void meta_service::on_start_recovery(configuration_recovery_rpc rpc)
 {
     configuration_recovery_response &response = rpc.response();
     ddebug("got start recovery request, start to do recovery");
-    int result = check_leader(rpc.dsn_request(), nullptr);
-    if (result == 0) // request has been forwarded to others
-    {
-        rpc.disable_auto_reply();
+    if (!check_status(rpc)) {
         return;
     }
 
-    if (result == -1) {
-        response.err = ERR_FORWARD_TO_OTHERS;
-    } else {
-        zauto_write_lock l(_meta_lock);
-        if (_started.load()) {
-            ddebug("service(%s) is already started, ignore the recovery request",
-                   dsn_primary_address().to_string());
-            response.err = ERR_SERVICE_ALREADY_RUNNING;
-        } else {
-            _state->on_start_recovery(rpc.request(), response);
-            if (response.err == dsn::ERR_OK) {
-                _recovering = false;
-                start_service();
-            }
-        }
+    zauto_write_lock l(_meta_lock);
+    _state->on_start_recovery(rpc.request(), response);
+    if (response.err == dsn::ERR_OK) {
+        _recovering = false;
+        start_service();
     }
 }
 

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -458,6 +458,10 @@ int meta_service::check_leader(dsn::message_ex *req, dsn::rpc_address *forward_a
     return 1;
 }
 
+/**
+ * If your rpc interface uses rpc_holder, please don't use RPC_CHECK_STATUS.
+ * Because it will cause the response to be sent repeatedly
+ */
 #define RPC_CHECK_STATUS(dsn_msg, response_struct)                                                 \
     dinfo("rpc %s called", __FUNCTION__);                                                          \
     int result = check_leader(dsn_msg, nullptr);                                                   \

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -121,12 +121,13 @@ bool meta_service::check_status(TRpcHolder rpc)
     if (result == 0)
         return false;
     if (result == -1 || !_started) {
-        if (result == -1)
+        if (result == -1) {
             rpc.response().err = ERR_FORWARD_TO_OTHERS;
-        else if (_recovering)
+        } else if (_recovering) {
             rpc.response().err = ERR_UNDER_RECOVERY;
-        else
+        } else {
             rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
+        }
         ddebug("reject request with %s", rpc.response().err.to_string());
         return false;
     }

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -721,18 +721,18 @@ void meta_service::on_start_recovery(configuration_recovery_rpc rpc)
     }
     if (result == -1) {
         response.err = ERR_FORWARD_TO_OTHERS;
-    }
-
-    zauto_write_lock l(_meta_lock);
-    if (_started.load()) {
-        ddebug("service(%s) is already started, ignore the recovery request",
-               dsn_primary_address().to_string());
-        response.err = ERR_SERVICE_ALREADY_RUNNING;
     } else {
-        _state->on_start_recovery(rpc.request(), response);
-        if (response.err == dsn::ERR_OK) {
-            _recovering = false;
-            start_service();
+        zauto_write_lock l(_meta_lock);
+        if (_started.load()) {
+            ddebug("service(%s) is already started, ignore the recovery request",
+                   dsn_primary_address().to_string());
+            response.err = ERR_SERVICE_ALREADY_RUNNING;
+        } else {
+            _state->on_start_recovery(rpc.request(), response);
+            if (response.err == dsn::ERR_OK) {
+                _recovering = false;
+                start_service();
+            }
         }
     }
 }

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -715,15 +715,25 @@ void meta_service::on_start_recovery(configuration_recovery_rpc rpc)
 {
     configuration_recovery_response &response = rpc.response();
     ddebug("got start recovery request, start to do recovery");
-    if (!check_status(rpc)) {
+    int result = check_leader(rpc, nullptr);
+    if (result == 0) {
         return;
+    }
+    if (result == -1) {
+        response.err = ERR_FORWARD_TO_OTHERS;
     }
 
     zauto_write_lock l(_meta_lock);
-    _state->on_start_recovery(rpc.request(), response);
-    if (response.err == dsn::ERR_OK) {
-        _recovering = false;
-        start_service();
+    if (_started.load()) {
+        ddebug("service(%s) is already started, ignore the recovery request",
+               dsn_primary_address().to_string());
+        response.err = ERR_SERVICE_ALREADY_RUNNING;
+    } else {
+        _state->on_start_recovery(rpc.request(), response);
+        if (response.err == dsn::ERR_OK) {
+            _recovering = false;
+            start_service();
+        }
     }
 }
 

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -217,14 +217,13 @@ private:
     //   0. meta isn't leader, and rpc-msg can forward to others
     //  -1. meta isn't leader, and rpc-msg can't forward to others
     // if return -1 and `forward_address' != nullptr, then return leader by `forward_address'.
-    int check_leader(dsn::message_ex *req, dsn::rpc_address *forward_address);
-    error_code remote_storage_initialize();
-    bool check_freeze() const;
-
     template <typename TRpcHolder>
     int check_leader(TRpcHolder rpc, /*out*/ rpc_address *forward_address);
     template <typename TRpcHolder>
     bool check_status(TRpcHolder rpc, /*out*/ rpc_address *forward_address = nullptr);
+    int check_leader(dsn::message_ex *req, dsn::rpc_address *forward_address);
+    error_code remote_storage_initialize();
+    bool check_freeze() const;
 
 private:
     friend class replication_checker;

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -221,6 +221,11 @@ private:
     error_code remote_storage_initialize();
     bool check_freeze() const;
 
+    template <typename TRpcHolder>
+    int check_leader(TRpcHolder rpc);
+    template <typename TRpcHolder>
+    bool check_status(TRpcHolder rpc);
+
 private:
     friend class replication_checker;
     friend class test::test_checker;

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -217,11 +217,11 @@ private:
     //   0. meta isn't leader, and rpc-msg can forward to others
     //  -1. meta isn't leader, and rpc-msg can't forward to others
     // if return -1 and `forward_address' != nullptr, then return leader by `forward_address'.
+    int check_leader(dsn::message_ex *req, dsn::rpc_address *forward_address);
     template <typename TRpcHolder>
     int check_leader(TRpcHolder rpc, /*out*/ rpc_address *forward_address);
     template <typename TRpcHolder>
     bool check_status(TRpcHolder rpc, /*out*/ rpc_address *forward_address = nullptr);
-    int check_leader(dsn::message_ex *req, dsn::rpc_address *forward_address);
     error_code remote_storage_initialize();
     bool check_freeze() const;
 

--- a/src/dist/replication/meta_server/meta_service.h
+++ b/src/dist/replication/meta_server/meta_service.h
@@ -222,9 +222,9 @@ private:
     bool check_freeze() const;
 
     template <typename TRpcHolder>
-    int check_leader(TRpcHolder rpc);
+    int check_leader(TRpcHolder rpc, /*out*/ rpc_address *forward_address);
     template <typename TRpcHolder>
-    bool check_status(TRpcHolder rpc);
+    bool check_status(TRpcHolder rpc, /*out*/ rpc_address *forward_address = nullptr);
 
 private:
     friend class replication_checker;


### PR DESCRIPTION
use check_status to reimplement some rpc interfaces of meta_service: including `on_query_configuration_by_index` and `on_start_recovery`