### PR TITLE
feat(bulk-load): bulk load succeed part1 - replica handle bulk load succeed

### DIFF
--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -6479,14 +6479,14 @@ typedef struct _partition_bulk_load_state__isset
         : download_progress(true),
           download_status(false),
           ingest_status(true),
-          is_cleanuped(true),
+          is_cleaned_up(true),
           is_paused(true)
     {
     }
     bool download_progress : 1;
     bool download_status : 1;
     bool ingest_status : 1;
-    bool is_cleanuped : 1;
+    bool is_cleaned_up : 1;
     bool is_paused : 1;
 } _partition_bulk_load_state__isset;
 
@@ -6500,7 +6500,7 @@ public:
     partition_bulk_load_state()
         : download_progress(0),
           ingest_status((ingestion_status::type)0),
-          is_cleanuped(false),
+          is_cleaned_up(false),
           is_paused(false)
     {
         ingest_status = (ingestion_status::type)0;
@@ -6510,7 +6510,7 @@ public:
     int32_t download_progress;
     ::dsn::error_code download_status;
     ingestion_status::type ingest_status;
-    bool is_cleanuped;
+    bool is_cleaned_up;
     bool is_paused;
 
     _partition_bulk_load_state__isset __isset;
@@ -6521,7 +6521,7 @@ public:
 
     void __set_ingest_status(const ingestion_status::type val);
 
-    void __set_is_cleanuped(const bool val);
+    void __set_is_cleaned_up(const bool val);
 
     void __set_is_paused(const bool val);
 
@@ -6539,9 +6539,9 @@ public:
             return false;
         else if (__isset.ingest_status && !(ingest_status == rhs.ingest_status))
             return false;
-        if (__isset.is_cleanuped != rhs.__isset.is_cleanuped)
+        if (__isset.is_cleaned_up != rhs.__isset.is_cleaned_up)
             return false;
-        else if (__isset.is_cleanuped && !(is_cleanuped == rhs.is_cleanuped))
+        else if (__isset.is_cleaned_up && !(is_cleaned_up == rhs.is_cleaned_up))
             return false;
         if (__isset.is_paused != rhs.__isset.is_paused)
             return false;
@@ -6684,7 +6684,7 @@ typedef struct _bulk_load_response__isset
           metadata(false),
           total_download_progress(false),
           is_group_ingestion_finished(false),
-          is_group_bulk_load_context_cleaned(false),
+          is_group_bulk_load_context_cleaned_up(false),
           is_group_bulk_load_paused(false)
     {
     }
@@ -6696,7 +6696,7 @@ typedef struct _bulk_load_response__isset
     bool metadata : 1;
     bool total_download_progress : 1;
     bool is_group_ingestion_finished : 1;
-    bool is_group_bulk_load_context_cleaned : 1;
+    bool is_group_bulk_load_context_cleaned_up : 1;
     bool is_group_bulk_load_paused : 1;
 } _bulk_load_response__isset;
 
@@ -6712,7 +6712,7 @@ public:
           primary_bulk_load_status((bulk_load_status::type)0),
           total_download_progress(0),
           is_group_ingestion_finished(0),
-          is_group_bulk_load_context_cleaned(0),
+          is_group_bulk_load_context_cleaned_up(0),
           is_group_bulk_load_paused(0)
     {
     }
@@ -6726,7 +6726,7 @@ public:
     bulk_load_metadata metadata;
     int32_t total_download_progress;
     bool is_group_ingestion_finished;
-    bool is_group_bulk_load_context_cleaned;
+    bool is_group_bulk_load_context_cleaned_up;
     bool is_group_bulk_load_paused;
 
     _bulk_load_response__isset __isset;
@@ -6748,7 +6748,7 @@ public:
 
     void __set_is_group_ingestion_finished(const bool val);
 
-    void __set_is_group_bulk_load_context_cleaned(const bool val);
+    void __set_is_group_bulk_load_context_cleaned_up(const bool val);
 
     void __set_is_group_bulk_load_paused(const bool val);
 
@@ -6778,11 +6778,12 @@ public:
         else if (__isset.is_group_ingestion_finished &&
                  !(is_group_ingestion_finished == rhs.is_group_ingestion_finished))
             return false;
-        if (__isset.is_group_bulk_load_context_cleaned !=
-            rhs.__isset.is_group_bulk_load_context_cleaned)
+        if (__isset.is_group_bulk_load_context_cleaned_up !=
+            rhs.__isset.is_group_bulk_load_context_cleaned_up)
             return false;
-        else if (__isset.is_group_bulk_load_context_cleaned &&
-                 !(is_group_bulk_load_context_cleaned == rhs.is_group_bulk_load_context_cleaned))
+        else if (__isset.is_group_bulk_load_context_cleaned_up &&
+                 !(is_group_bulk_load_context_cleaned_up ==
+                   rhs.is_group_bulk_load_context_cleaned_up))
             return false;
         if (__isset.is_group_bulk_load_paused != rhs.__isset.is_group_bulk_load_paused)
             return false;

--- a/src/dist/replication/common/replication_types.cpp
+++ b/src/dist/replication/common/replication_types.cpp
@@ -15197,10 +15197,10 @@ void partition_bulk_load_state::__set_ingest_status(const ingestion_status::type
     __isset.ingest_status = true;
 }
 
-void partition_bulk_load_state::__set_is_cleanuped(const bool val)
+void partition_bulk_load_state::__set_is_cleaned_up(const bool val)
 {
-    this->is_cleanuped = val;
-    __isset.is_cleanuped = true;
+    this->is_cleaned_up = val;
+    __isset.is_cleaned_up = true;
 }
 
 void partition_bulk_load_state::__set_is_paused(const bool val)
@@ -15256,8 +15256,8 @@ uint32_t partition_bulk_load_state::read(::apache::thrift::protocol::TProtocol *
             break;
         case 4:
             if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->is_cleanuped);
-                this->__isset.is_cleanuped = true;
+                xfer += iprot->readBool(this->is_cleaned_up);
+                this->__isset.is_cleaned_up = true;
             } else {
                 xfer += iprot->skip(ftype);
             }
@@ -15303,9 +15303,9 @@ uint32_t partition_bulk_load_state::write(::apache::thrift::protocol::TProtocol 
         xfer += oprot->writeI32((int32_t)this->ingest_status);
         xfer += oprot->writeFieldEnd();
     }
-    if (this->__isset.is_cleanuped) {
-        xfer += oprot->writeFieldBegin("is_cleanuped", ::apache::thrift::protocol::T_BOOL, 4);
-        xfer += oprot->writeBool(this->is_cleanuped);
+    if (this->__isset.is_cleaned_up) {
+        xfer += oprot->writeFieldBegin("is_cleaned_up", ::apache::thrift::protocol::T_BOOL, 4);
+        xfer += oprot->writeBool(this->is_cleaned_up);
         xfer += oprot->writeFieldEnd();
     }
     if (this->__isset.is_paused) {
@@ -15324,7 +15324,7 @@ void swap(partition_bulk_load_state &a, partition_bulk_load_state &b)
     swap(a.download_progress, b.download_progress);
     swap(a.download_status, b.download_status);
     swap(a.ingest_status, b.ingest_status);
-    swap(a.is_cleanuped, b.is_cleanuped);
+    swap(a.is_cleaned_up, b.is_cleaned_up);
     swap(a.is_paused, b.is_paused);
     swap(a.__isset, b.__isset);
 }
@@ -15334,7 +15334,7 @@ partition_bulk_load_state::partition_bulk_load_state(const partition_bulk_load_s
     download_progress = other657.download_progress;
     download_status = other657.download_status;
     ingest_status = other657.ingest_status;
-    is_cleanuped = other657.is_cleanuped;
+    is_cleaned_up = other657.is_cleaned_up;
     is_paused = other657.is_paused;
     __isset = other657.__isset;
 }
@@ -15343,7 +15343,7 @@ partition_bulk_load_state::partition_bulk_load_state(partition_bulk_load_state &
     download_progress = std::move(other658.download_progress);
     download_status = std::move(other658.download_status);
     ingest_status = std::move(other658.ingest_status);
-    is_cleanuped = std::move(other658.is_cleanuped);
+    is_cleaned_up = std::move(other658.is_cleaned_up);
     is_paused = std::move(other658.is_paused);
     __isset = std::move(other658.__isset);
 }
@@ -15353,7 +15353,7 @@ operator=(const partition_bulk_load_state &other659)
     download_progress = other659.download_progress;
     download_status = other659.download_status;
     ingest_status = other659.ingest_status;
-    is_cleanuped = other659.is_cleanuped;
+    is_cleaned_up = other659.is_cleaned_up;
     is_paused = other659.is_paused;
     __isset = other659.__isset;
     return *this;
@@ -15364,7 +15364,7 @@ operator=(partition_bulk_load_state &&other660)
     download_progress = std::move(other660.download_progress);
     download_status = std::move(other660.download_status);
     ingest_status = std::move(other660.ingest_status);
-    is_cleanuped = std::move(other660.is_cleanuped);
+    is_cleaned_up = std::move(other660.is_cleaned_up);
     is_paused = std::move(other660.is_paused);
     __isset = std::move(other660.__isset);
     return *this;
@@ -15382,8 +15382,8 @@ void partition_bulk_load_state::printTo(std::ostream &out) const
         << "ingest_status=";
     (__isset.ingest_status ? (out << to_string(ingest_status)) : (out << "<null>"));
     out << ", "
-        << "is_cleanuped=";
-    (__isset.is_cleanuped ? (out << to_string(is_cleanuped)) : (out << "<null>"));
+        << "is_cleaned_up=";
+    (__isset.is_cleaned_up ? (out << to_string(is_cleaned_up)) : (out << "<null>"));
     out << ", "
         << "is_paused=";
     (__isset.is_paused ? (out << to_string(is_paused)) : (out << "<null>"));
@@ -15684,10 +15684,10 @@ void bulk_load_response::__set_is_group_ingestion_finished(const bool val)
     __isset.is_group_ingestion_finished = true;
 }
 
-void bulk_load_response::__set_is_group_bulk_load_context_cleaned(const bool val)
+void bulk_load_response::__set_is_group_bulk_load_context_cleaned_up(const bool val)
 {
-    this->is_group_bulk_load_context_cleaned = val;
-    __isset.is_group_bulk_load_context_cleaned = true;
+    this->is_group_bulk_load_context_cleaned_up = val;
+    __isset.is_group_bulk_load_context_cleaned_up = true;
 }
 
 void bulk_load_response::__set_is_group_bulk_load_paused(const bool val)
@@ -15797,8 +15797,8 @@ uint32_t bulk_load_response::read(::apache::thrift::protocol::TProtocol *iprot)
             break;
         case 9:
             if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->is_group_bulk_load_context_cleaned);
-                this->__isset.is_group_bulk_load_context_cleaned = true;
+                xfer += iprot->readBool(this->is_group_bulk_load_context_cleaned_up);
+                this->__isset.is_group_bulk_load_context_cleaned_up = true;
             } else {
                 xfer += iprot->skip(ftype);
             }
@@ -15879,10 +15879,10 @@ uint32_t bulk_load_response::write(::apache::thrift::protocol::TProtocol *oprot)
         xfer += oprot->writeBool(this->is_group_ingestion_finished);
         xfer += oprot->writeFieldEnd();
     }
-    if (this->__isset.is_group_bulk_load_context_cleaned) {
+    if (this->__isset.is_group_bulk_load_context_cleaned_up) {
         xfer += oprot->writeFieldBegin(
-            "is_group_bulk_load_context_cleaned", ::apache::thrift::protocol::T_BOOL, 9);
-        xfer += oprot->writeBool(this->is_group_bulk_load_context_cleaned);
+            "is_group_bulk_load_context_cleaned_up", ::apache::thrift::protocol::T_BOOL, 9);
+        xfer += oprot->writeBool(this->is_group_bulk_load_context_cleaned_up);
         xfer += oprot->writeFieldEnd();
     }
     if (this->__isset.is_group_bulk_load_paused) {
@@ -15907,7 +15907,7 @@ void swap(bulk_load_response &a, bulk_load_response &b)
     swap(a.metadata, b.metadata);
     swap(a.total_download_progress, b.total_download_progress);
     swap(a.is_group_ingestion_finished, b.is_group_ingestion_finished);
-    swap(a.is_group_bulk_load_context_cleaned, b.is_group_bulk_load_context_cleaned);
+    swap(a.is_group_bulk_load_context_cleaned_up, b.is_group_bulk_load_context_cleaned_up);
     swap(a.is_group_bulk_load_paused, b.is_group_bulk_load_paused);
     swap(a.__isset, b.__isset);
 }
@@ -15922,7 +15922,7 @@ bulk_load_response::bulk_load_response(const bulk_load_response &other675)
     metadata = other675.metadata;
     total_download_progress = other675.total_download_progress;
     is_group_ingestion_finished = other675.is_group_ingestion_finished;
-    is_group_bulk_load_context_cleaned = other675.is_group_bulk_load_context_cleaned;
+    is_group_bulk_load_context_cleaned_up = other675.is_group_bulk_load_context_cleaned_up;
     is_group_bulk_load_paused = other675.is_group_bulk_load_paused;
     __isset = other675.__isset;
 }
@@ -15936,7 +15936,8 @@ bulk_load_response::bulk_load_response(bulk_load_response &&other676)
     metadata = std::move(other676.metadata);
     total_download_progress = std::move(other676.total_download_progress);
     is_group_ingestion_finished = std::move(other676.is_group_ingestion_finished);
-    is_group_bulk_load_context_cleaned = std::move(other676.is_group_bulk_load_context_cleaned);
+    is_group_bulk_load_context_cleaned_up =
+        std::move(other676.is_group_bulk_load_context_cleaned_up);
     is_group_bulk_load_paused = std::move(other676.is_group_bulk_load_paused);
     __isset = std::move(other676.__isset);
 }
@@ -15950,7 +15951,7 @@ bulk_load_response &bulk_load_response::operator=(const bulk_load_response &othe
     metadata = other677.metadata;
     total_download_progress = other677.total_download_progress;
     is_group_ingestion_finished = other677.is_group_ingestion_finished;
-    is_group_bulk_load_context_cleaned = other677.is_group_bulk_load_context_cleaned;
+    is_group_bulk_load_context_cleaned_up = other677.is_group_bulk_load_context_cleaned_up;
     is_group_bulk_load_paused = other677.is_group_bulk_load_paused;
     __isset = other677.__isset;
     return *this;
@@ -15965,7 +15966,8 @@ bulk_load_response &bulk_load_response::operator=(bulk_load_response &&other678)
     metadata = std::move(other678.metadata);
     total_download_progress = std::move(other678.total_download_progress);
     is_group_ingestion_finished = std::move(other678.is_group_ingestion_finished);
-    is_group_bulk_load_context_cleaned = std::move(other678.is_group_bulk_load_context_cleaned);
+    is_group_bulk_load_context_cleaned_up =
+        std::move(other678.is_group_bulk_load_context_cleaned_up);
     is_group_bulk_load_paused = std::move(other678.is_group_bulk_load_paused);
     __isset = std::move(other678.__isset);
     return *this;
@@ -15995,9 +15997,9 @@ void bulk_load_response::printTo(std::ostream &out) const
     (__isset.is_group_ingestion_finished ? (out << to_string(is_group_ingestion_finished))
                                          : (out << "<null>"));
     out << ", "
-        << "is_group_bulk_load_context_cleaned=";
-    (__isset.is_group_bulk_load_context_cleaned
-         ? (out << to_string(is_group_bulk_load_context_cleaned))
+        << "is_group_bulk_load_context_cleaned_up=";
+    (__isset.is_group_bulk_load_context_cleaned_up
+         ? (out << to_string(is_group_bulk_load_context_cleaned_up))
          : (out << "<null>"));
     out << ", "
         << "is_group_bulk_load_paused=";

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -222,6 +222,13 @@ error_code replica_bulk_loader::do_bulk_load(const std::string &app_name,
             check_ingestion_finish();
         }
         break;
+    case bulk_load_status::BLS_SUCCEED:
+        if (local_status == bulk_load_status::BLS_INGESTING) {
+            handle_bulk_load_succeed();
+        } else if (local_status == bulk_load_status::BLS_SUCCEED) {
+            handle_bulk_load_finish(meta_status);
+        }
+        break;
     // TODO(heyuchen): add other bulk load status
     default:
         break;
@@ -448,6 +455,59 @@ void replica_bulk_loader::check_ingestion_finish()
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::handle_bulk_load_succeed()
+{
+    // generate checkpoint
+    _replica->init_checkpoint(true);
+
+    _replica->_app->set_ingestion_status(ingestion_status::IS_INVALID);
+    _status = bulk_load_status::BLS_SUCCEED;
+    // TODO(heyuchen): add perf-counter
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::handle_bulk_load_finish(bulk_load_status::type new_status)
+{
+    if (is_cleanuped()) {
+        ddebug_replica("bulk load states have been cleaned up");
+        return;
+    }
+
+    if (status() == partition_status::PS_PRIMARY) {
+        // TODO(heyuchen): cleanup _primary_states.secondary_bulk_load_states
+    }
+
+    ddebug_replica("bulk load finished, old_status = {}, new_status = {}",
+                   enum_to_string(_status),
+                   enum_to_string(new_status));
+
+    // remove local bulk load dir
+    std::string bulk_load_dir = utils::filesystem::path_combine(
+        _replica->_dir, bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR);
+    error_code err = remove_local_bulk_load_dir(bulk_load_dir);
+    if (err != ERR_OK) {
+        tasking::enqueue(
+            LPC_REPLICATION_COMMON,
+            &_replica->_tracker,
+            std::bind(&replica_bulk_loader::remove_local_bulk_load_dir, this, bulk_load_dir),
+            get_gpid().thread_hash());
+    }
+
+    clear_bulk_load_states();
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+error_code replica_bulk_loader::remove_local_bulk_load_dir(const std::string &bulk_load_dir)
+{
+    if (!utils::filesystem::directory_exists(bulk_load_dir) ||
+        !utils::filesystem::remove_path(bulk_load_dir)) {
+        derror_replica("remove bulk_load dir({}) failed", bulk_load_dir);
+        return ERR_FILE_OPERATION_FAILED;
+    }
+    return ERR_OK;
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::cleanup_download_task()
 {
     for (auto &kv : _download_task) {
@@ -456,10 +516,36 @@ void replica_bulk_loader::cleanup_download_task()
     _download_task.clear();
 }
 
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::clear_bulk_load_states()
 {
-    // TODO(heyuchen): TBD
-    // clear replica bulk load states and cleanup bulk load context
+    if (_status == bulk_load_status::BLS_DOWNLOADING) {
+        try_decrease_bulk_load_download_count();
+    }
+
+    cleanup_download_task();
+    _metadata.files.clear();
+    _metadata.file_total_size = 0;
+    _cur_downloaded_size.store(0);
+    _download_progress.store(0);
+    _download_status.store(ERR_OK);
+
+    _replica->_is_bulk_load_ingestion = false;
+    _replica->_app->set_ingestion_status(ingestion_status::IS_INVALID);
+
+    // TODO(heyuchen): clear other states
+
+    _status = bulk_load_status::BLS_INVALID;
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+bool replica_bulk_loader::is_cleanuped()
+{
+    return _status == bulk_load_status::type::BLS_INVALID && _cur_downloaded_size.load() == 0 &&
+           _download_progress.load() == 0 && _download_status.load() == ERR_OK &&
+           _download_task.size() == 0 && _metadata.files.size() == 0 &&
+           _metadata.file_total_size == 0 && !_replica->_is_bulk_load_ingestion &&
+           _replica->_app->get_ingestion_status() == ingestion_status::IS_INVALID;
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
@@ -483,6 +569,9 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
         break;
     case bulk_load_status::BLS_INGESTING:
         report_group_ingestion_status(response);
+        break;
+    case bulk_load_status::BLS_SUCCEED:
+        report_group_cleanup_flag(response);
         break;
     // TODO(heyuchen): add other status
     default:
@@ -578,6 +667,42 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::report_group_cleanup_flag(bulk_load_response &response)
+{
+    if (status() != partition_status::PS_PRIMARY) {
+        dwarn_replica("replica status={}, should be {}",
+                      enum_to_string(status()),
+                      enum_to_string(partition_status::PS_PRIMARY));
+        response.err = ERR_INVALID_STATE;
+        return;
+    }
+
+    partition_bulk_load_state primary_state;
+    primary_state.__set_is_cleanuped(is_cleanuped());
+    response.group_bulk_load_state[_replica->_primary_states.membership.primary] = primary_state;
+    ddebug_replica("primary = {}, bulk load states cleanuped = {}",
+                   _replica->_primary_states.membership.primary.to_string(),
+                   primary_state.is_cleanuped);
+
+    bool group_flag = (primary_state.is_cleanuped) &&
+                      (_replica->_primary_states.membership.secondaries.size() + 1 ==
+                       _replica->_primary_states.membership.max_replica_count);
+    for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
+        const auto &secondary_state =
+            _replica->_primary_states.secondary_bulk_load_states[target_address];
+        bool is_cleanuped =
+            secondary_state.__isset.is_cleanuped ? secondary_state.is_cleanuped : false;
+        ddebug_replica("secondary = {}, bulk load states cleanuped = {}",
+                       target_address.to_string(),
+                       is_cleanuped);
+        response.group_bulk_load_state[target_address] = secondary_state;
+        group_flag &= is_cleanuped;
+    }
+    ddebug_replica("group bulk load states cleanuped = {}", group_flag);
+    response.__set_is_group_bulk_load_context_cleaned(group_flag);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::report_bulk_load_states_to_primary(
     bulk_load_status::type remote_status,
     /*out*/ group_bulk_load_response &response)
@@ -597,6 +722,9 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
         break;
     case bulk_load_status::BLS_INGESTING:
         bulk_load_state.__set_ingest_status(_replica->_app->get_ingestion_status());
+        break;
+    case bulk_load_status::BLS_SUCCEED:
+        bulk_load_state.__set_is_cleanuped(is_cleanuped());
         break;
     // TODO(heyuchen): add other status
     default:

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -67,15 +67,21 @@ private:
     void check_download_finish();
     void start_ingestion();
     void check_ingestion_finish();
+    void handle_bulk_load_succeed();
+    // called when bulk load succeed or failed or canceled
+    void handle_bulk_load_finish(bulk_load_status::type new_status);
+    error_code remove_local_bulk_load_dir(const std::string &bulk_load_dir);
 
     void cleanup_download_task();
     void clear_bulk_load_states();
+    bool is_cleanuped();
 
     void report_bulk_load_states_to_meta(bulk_load_status::type remote_status,
                                          bool report_metadata,
                                          /*out*/ bulk_load_response &response);
     void report_group_download_progress(/*out*/ bulk_load_response &response);
     void report_group_ingestion_status(/*out*/ bulk_load_response &response);
+    void report_group_cleanup_flag(/*out*/ bulk_load_response &response);
 
     void report_bulk_load_states_to_primary(bulk_load_status::type remote_status,
                                             /*out*/ group_bulk_load_response &response);

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -74,14 +74,14 @@ private:
 
     void cleanup_download_task();
     void clear_bulk_load_states();
-    bool is_cleanuped();
+    bool is_cleaned_up();
 
     void report_bulk_load_states_to_meta(bulk_load_status::type remote_status,
                                          bool report_metadata,
                                          /*out*/ bulk_load_response &response);
     void report_group_download_progress(/*out*/ bulk_load_response &response);
     void report_group_ingestion_status(/*out*/ bulk_load_response &response);
-    void report_group_cleanup_flag(/*out*/ bulk_load_response &response);
+    void report_group_cleaned_up(/*out*/ bulk_load_response &response);
 
     void report_bulk_load_states_to_primary(bulk_load_status::type remote_status,
                                             /*out*/ group_bulk_load_response &response);

--- a/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
@@ -60,6 +60,17 @@ public:
 
     void test_start_ingestion() { _bulk_loader->start_ingestion(); }
 
+    void test_handle_bulk_load_finish(bulk_load_status::type status,
+                                      int32_t download_progress,
+                                      ingestion_status::type istatus,
+                                      bool is_bulk_load_ingestion,
+                                      bulk_load_status::type req_status)
+    {
+        mock_replica_bulk_load_varieties(
+            status, download_progress, istatus, is_bulk_load_ingestion);
+        _bulk_loader->handle_bulk_load_finish(req_status);
+    }
+
     int32_t test_report_group_download_progress(bulk_load_status::type status,
                                                 int32_t p_progress,
                                                 int32_t s1_progress,
@@ -83,6 +94,13 @@ public:
         bulk_load_response response;
         _bulk_loader->report_group_ingestion_status(response);
         return response.is_group_ingestion_finished;
+    }
+
+    bool test_report_group_cleanup_flag()
+    {
+        bulk_load_response response;
+        _bulk_loader->report_group_cleanup_flag(response);
+        return response.is_group_bulk_load_context_cleaned;
     }
 
     /// mock structure functions
@@ -272,8 +290,26 @@ public:
         _replica->set_secondary_bulk_load_state(SECONDARY2, state2);
     }
 
+    void mock_group_cleanup_flag(bulk_load_status::type primary_status,
+                                 bool s1_cleanuped = true,
+                                 bool s2_cleanuped = true)
+    {
+        int32_t primary_progress = primary_status == bulk_load_status::BLS_SUCCEED ? 100 : 0;
+        mock_replica_bulk_load_varieties(
+            primary_status, primary_progress, ingestion_status::IS_INVALID);
+        mock_secondary_ingestion_states(
+            ingestion_status::IS_INVALID, ingestion_status::IS_INVALID, true);
+
+        partition_bulk_load_state state1, state2;
+        state1.__set_is_cleanuped(s1_cleanuped);
+        state2.__set_is_cleanuped(s2_cleanuped);
+        _replica->set_secondary_bulk_load_state(SECONDARY, state1);
+        _replica->set_secondary_bulk_load_state(SECONDARY2, state2);
+    }
+
     // helper functions
     bulk_load_status::type get_bulk_load_status() const { return _bulk_loader->_status; }
+    bool is_cleanuped() { return _bulk_loader->is_cleanuped(); }
 
 public:
     std::unique_ptr<mock_replica> _replica;
@@ -366,6 +402,7 @@ TEST_F(replica_bulk_loader_test, start_downloading_test)
         if (test.mock_function) {
             fail::cfg("replica_bulk_loader_download_sst_files", "return()");
         }
+        mock_group_progress(bulk_load_status::BLS_INVALID);
         create_bulk_load_request(bulk_load_status::BLS_DOWNLOADING, test.downloading_count);
 
         ASSERT_EQ(test_start_downloading(), test.expected_err);
@@ -421,6 +458,53 @@ TEST_F(replica_bulk_loader_test, start_ingestion_test)
     mock_group_progress(bulk_load_status::BLS_DOWNLOADED);
     test_start_ingestion();
     ASSERT_EQ(get_bulk_load_status(), bulk_load_status::BLS_INGESTING);
+}
+
+// handle_bulk_load_finish unit tests
+TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
+{
+    // Test cases
+    // - bulk load succeed
+    // - double bulk load finish
+    //  TODO(heyuchen): add following cases
+    //  istatus, is_ingestion, create_dir will be used in further tests
+    // - failed during downloading
+    // - failed during ingestion
+    // - cancel during downloaded
+    // - cancel during ingestion
+    // - cancel during succeed
+    struct test_struct
+    {
+        bulk_load_status::type local_status;
+        int32_t progress;
+        ingestion_status::type istatus;
+        bool is_ingestion;
+        bulk_load_status::type request_status;
+        bool create_dir;
+    } tests[]{{bulk_load_status::BLS_SUCCEED,
+               100,
+               ingestion_status::IS_INVALID,
+               false,
+               bulk_load_status::BLS_SUCCEED,
+               false},
+              {bulk_load_status::BLS_INVALID,
+               0,
+               ingestion_status::IS_INVALID,
+               false,
+               bulk_load_status::BLS_SUCCEED,
+               false}};
+
+    for (auto test : tests) {
+        if (test.create_dir) {
+            utils::filesystem::create_directory(LOCAL_DIR);
+        }
+        test_handle_bulk_load_finish(
+            test.local_status, test.progress, test.istatus, test.is_ingestion, test.request_status);
+        ASSERT_EQ(_replica->get_ingestion_status(), ingestion_status::IS_INVALID);
+        ASSERT_FALSE(_replica->is_ingestion());
+        ASSERT_TRUE(is_cleanuped());
+        ASSERT_FALSE(utils::filesystem::directory_exists(LOCAL_DIR));
+    }
 }
 
 // report_group_download_progress unit tests
@@ -520,6 +604,26 @@ TEST_F(replica_bulk_loader_test, report_group_ingestion_status_test)
                   test.is_group_ingestion_finished);
         ASSERT_FALSE(_replica->is_ingestion());
     }
+}
+
+// report_group_context_clean_flag unit tests
+TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_in_unhealthy_state)
+{
+    // _primary_states.membership.secondaries is empty
+    mock_replica_config(partition_status::PS_PRIMARY);
+    ASSERT_FALSE(test_report_group_cleanup_flag());
+}
+
+TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_not_cleanuped)
+{
+    mock_group_cleanup_flag(bulk_load_status::BLS_SUCCEED, true, false);
+    ASSERT_FALSE(test_report_group_cleanup_flag());
+}
+
+TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_all_cleanuped)
+{
+    mock_group_cleanup_flag(bulk_load_status::BLS_INVALID, true, true);
+    ASSERT_TRUE(test_report_group_cleanup_flag());
 }
 
 } // namespace replication

--- a/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
@@ -96,11 +96,11 @@ public:
         return response.is_group_ingestion_finished;
     }
 
-    bool test_report_group_cleanup_flag()
+    bool test_report_group_cleaned_up()
     {
         bulk_load_response response;
-        _bulk_loader->report_group_cleanup_flag(response);
-        return response.is_group_bulk_load_context_cleaned;
+        _bulk_loader->report_group_cleaned_up(response);
+        return response.is_group_bulk_load_context_cleaned_up;
     }
 
     /// mock structure functions
@@ -291,8 +291,8 @@ public:
     }
 
     void mock_group_cleanup_flag(bulk_load_status::type primary_status,
-                                 bool s1_cleanuped = true,
-                                 bool s2_cleanuped = true)
+                                 bool s1_cleaned_up = true,
+                                 bool s2_cleaned_up = true)
     {
         int32_t primary_progress = primary_status == bulk_load_status::BLS_SUCCEED ? 100 : 0;
         mock_replica_bulk_load_varieties(
@@ -301,15 +301,15 @@ public:
             ingestion_status::IS_INVALID, ingestion_status::IS_INVALID, true);
 
         partition_bulk_load_state state1, state2;
-        state1.__set_is_cleanuped(s1_cleanuped);
-        state2.__set_is_cleanuped(s2_cleanuped);
+        state1.__set_is_cleaned_up(s1_cleaned_up);
+        state2.__set_is_cleaned_up(s2_cleaned_up);
         _replica->set_secondary_bulk_load_state(SECONDARY, state1);
         _replica->set_secondary_bulk_load_state(SECONDARY2, state2);
     }
 
     // helper functions
     bulk_load_status::type get_bulk_load_status() const { return _bulk_loader->_status; }
-    bool is_cleanuped() { return _bulk_loader->is_cleanuped(); }
+    bool is_cleaned_up() { return _bulk_loader->is_cleaned_up(); }
 
 public:
     std::unique_ptr<mock_replica> _replica;
@@ -502,7 +502,7 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
             test.local_status, test.progress, test.istatus, test.is_ingestion, test.request_status);
         ASSERT_EQ(_replica->get_ingestion_status(), ingestion_status::IS_INVALID);
         ASSERT_FALSE(_replica->is_ingestion());
-        ASSERT_TRUE(is_cleanuped());
+        ASSERT_TRUE(is_cleaned_up());
         ASSERT_FALSE(utils::filesystem::directory_exists(LOCAL_DIR));
     }
 }
@@ -611,19 +611,19 @@ TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_in_unhealthy_state)
 {
     // _primary_states.membership.secondaries is empty
     mock_replica_config(partition_status::PS_PRIMARY);
-    ASSERT_FALSE(test_report_group_cleanup_flag());
+    ASSERT_FALSE(test_report_group_cleaned_up());
 }
 
-TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_not_cleanuped)
+TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_not_cleaned_up)
 {
     mock_group_cleanup_flag(bulk_load_status::BLS_SUCCEED, true, false);
-    ASSERT_FALSE(test_report_group_cleanup_flag());
+    ASSERT_FALSE(test_report_group_cleaned_up());
 }
 
-TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_all_cleanuped)
+TEST_F(replica_bulk_loader_test, report_group_cleanup_flag_all_cleaned_up)
 {
     mock_group_cleanup_flag(bulk_load_status::BLS_INVALID, true, true);
-    ASSERT_TRUE(test_report_group_cleanup_flag());
+    ASSERT_TRUE(test_report_group_cleaned_up());
 }
 
 } // namespace replication

--- a/src/dist/replication/replication.thrift
+++ b/src/dist/replication/replication.thrift
@@ -944,7 +944,7 @@ struct partition_bulk_load_state
     1:optional i32              download_progress = 0;
     2:optional dsn.error_code   download_status;
     3:optional ingestion_status ingest_status = ingestion_status.IS_INVALID;
-    4:optional bool             is_cleanuped = false;
+    4:optional bool             is_cleaned_up = false;
     5:optional bool             is_paused = false;
 }
 
@@ -978,7 +978,7 @@ struct bulk_load_response
     6:optional bulk_load_metadata                       metadata;
     7:optional i32                                      total_download_progress;
     8:optional bool                                     is_group_ingestion_finished;
-    9:optional bool                                     is_group_bulk_load_context_cleaned;
+    9:optional bool                                     is_group_bulk_load_context_cleaned_up;
     10:optional bool                                    is_group_bulk_load_paused;
 }
 

--- a/src/dist/replication/test/replica_test/unit_test/mock_utils.h
+++ b/src/dist/replication/test/replica_test/unit_test/mock_utils.h
@@ -159,6 +159,7 @@ public:
     bool is_ingestion() { return _is_bulk_load_ingestion; }
     void set_is_ingestion(bool flag) { _is_bulk_load_ingestion = flag; }
     void set_ingestion_status(ingestion_status::type status) { _app->set_ingestion_status(status); }
+    ingestion_status::type get_ingestion_status() { return _app->get_ingestion_status(); }
 
 private:
     decree _max_gced_decree{invalid_decree - 1};


### PR DESCRIPTION
The whole bulk load succeed process is like:
1. meta server set app and all partitions bulk load status is succeed #500 
2. meta server send bulk_load_request to primary #457
3. **primary handle bulk_load_request**
4. primary broadcast request to secondary #460
5. **secondary handle bulk_load_request**
6. **secondary report cleanup flag to primary**
7. **primary report group cleanup flag  to meta server**
8. meta handle bulk load succeed

This pull request is about replica handle bulk load succeed, step 3,5,6,7 above.
- **handle bulk_load_request in function `do_bulk_load`**
    - when request status is succeed, local status is ingesting, will call `handle_bulk_load_succeed`
    - when request status is succeed, local status is succeed, will call `handle_bulk_load_finish`
    - both primary and secondary will execute this function
- **handle_bulk_load_succeed**
    - create checkpoint here, this newest checkpoint will include data ingested from files
    - reset ingestion status and turn replica status to succeed
- **handle_bulk_load_finish**
    - remove local bulk load directory who stores downloaded files (function `remove_local_bulk_load_dir`)
    - reset other local bulk load states and context (function `clear_bulk_load_states` and another function in further pull request)
    - this function will also be called when bulk load failed and canceling bulk load, so I call it `handle_bulk_load_finish`
- **report states**
    - secondary will report whether itself bulk load context cleaned (function `report_bulk_load_states_to_primary`)
    - primary will report group flag to meta (function `report_group_cleanup_flag`)
