### PR TITLE
feat(bulk-load): bulk load succeed part2 - meta handle bulk load succeed

### DIFF
--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -575,30 +575,24 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
     const std::string &app_name = response.app_name;
     const gpid &pid = response.pid;
 
-    if (!response.__isset.is_group_bulk_load_context_cleaned_up) {
-        dassert_f(
-            false,
-            "receive bulk load response from node({}) app({}), partition({}), primary_status({}), "
-            "but is_group_bulk_load_context_cleaned_up is not set",
-            primary_addr.to_string(),
-            app_name,
-            pid,
-            dsn::enum_to_string(response.primary_bulk_load_status));
-        return;
-    }
+    dassert_f(
+        response.__isset.is_group_bulk_load_context_cleaned_up,
+        "receive bulk load response from node({}) app({}), partition({}), primary_status({}), "
+        "but is_group_bulk_load_context_cleaned_up is not set",
+        primary_addr.to_string(),
+        app_name,
+        pid,
+        dsn::enum_to_string(response.primary_bulk_load_status));
 
     for (const auto &kv : response.group_bulk_load_state) {
-        if (!kv.second.__isset.is_cleaned_up) {
-            dassert_f(false,
-                      "receive bulk load response from node({}) app({}), partition({}), "
-                      "primary_status({}), but node({}) is_cleaned_up is not set",
-                      primary_addr.to_string(),
-                      app_name,
-                      pid,
-                      dsn::enum_to_string(response.primary_bulk_load_status),
-                      kv.first.to_string());
-            return;
-        }
+        dassert_f(kv.second.__isset.is_cleaned_up,
+                  "receive bulk load response from node({}) app({}), partition({}), "
+                  "primary_status({}), but node({}) is_cleaned_up is not set",
+                  primary_addr.to_string(),
+                  app_name,
+                  pid,
+                  dsn::enum_to_string(response.primary_bulk_load_status),
+                  kv.first.to_string());
     }
 
     {

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -627,7 +627,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
     }
 
     if (group_cleaned_up) {
-        int32_t count;
+        int32_t count = 0;
         {
             zauto_write_lock l(_lock);
             count = --_apps_in_progress_count[pid.get_app_id()];

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -1003,6 +1003,8 @@ inline void erase_map_elem_by_id(int32_t app_id, std::unordered_map<gpid, T> &my
     for (auto iter = mymap.begin(); iter != mymap.end();) {
         if (iter->first.get_app_id() == app_id) {
             mymap.erase(iter++);
+        } else {
+            iter++;
         }
     }
 }

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -572,8 +572,84 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
 void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &response,
                                                 const rpc_address &primary_addr)
 {
-    // TODO(heyuchen): TBD
-    // called by `on_partition_bulk_load_reply` when app status is succeed, failed, canceled
+    const std::string &app_name = response.app_name;
+    const gpid &pid = response.pid;
+
+    if (!response.__isset.is_group_bulk_load_context_cleaned_up) {
+        dwarn_f(
+            "receive bulk load response from node({}) app({}), partition({}), primary_status({}), "
+            "but is_group_bulk_load_context_cleaned_up is not set",
+            primary_addr.to_string(),
+            app_name,
+            pid,
+            dsn::enum_to_string(response.primary_bulk_load_status));
+        return;
+    }
+
+    for (const auto &kv : response.group_bulk_load_state) {
+        if (!kv.second.__isset.is_cleaned_up) {
+            dwarn_f("receive bulk load response from node({}) app({}), partition({}), "
+                    "primary_status({}), but node({}) is_cleaned_up is not set",
+                    primary_addr.to_string(),
+                    app_name,
+                    pid,
+                    dsn::enum_to_string(response.primary_bulk_load_status),
+                    kv.first.to_string());
+            return;
+        }
+    }
+
+    {
+        zauto_read_lock l(_lock);
+        if (_partitions_cleaned_up[pid]) {
+            dwarn_f(
+                "receive bulk load response from node({}) app({}) partition({}), current partition "
+                "has already be cleaned up",
+                primary_addr.to_string(),
+                app_name,
+                pid);
+            return;
+        }
+    }
+
+    bool group_cleaned_up = response.is_group_bulk_load_context_cleaned_up;
+    ddebug_f("receive bulk load response from node({}) app({}) partition({}), primary status = {}, "
+             "is_group_bulk_load_context_cleaned_up = {}",
+             primary_addr.to_string(),
+             app_name,
+             pid,
+             dsn::enum_to_string(response.primary_bulk_load_status),
+             group_cleaned_up);
+    {
+        zauto_write_lock l(_lock);
+        _partitions_cleaned_up[pid] = group_cleaned_up;
+        _partitions_bulk_load_state[pid] = response.group_bulk_load_state;
+    }
+
+    if (group_cleaned_up) {
+        int32_t count;
+        {
+            zauto_write_lock l(_lock);
+            count = --_apps_in_progress_count[pid.get_app_id()];
+        }
+        if (count == 0) {
+            std::shared_ptr<app_state> app;
+            {
+                zauto_read_lock l(app_lock());
+                app = _state->get_app(pid.get_app_id());
+                if (app == nullptr || app->status != app_status::AS_AVAILABLE) {
+                    dwarn_f("app(name={}, id={}) is not existed, remove bulk load dir on remote "
+                            "storage",
+                            app_name,
+                            pid.get_app_id());
+                    remove_bulk_load_dir_on_remote_storage(pid.get_app_id(), app_name);
+                    return;
+                }
+            }
+            ddebug_f("app({}) all partitions cleanup bulk load context", app_name);
+            remove_bulk_load_dir_on_remote_storage(std::move(app), true);
+        }
+    }
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
@@ -898,6 +974,65 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
+void bulk_load_service::remove_bulk_load_dir_on_remote_storage(int32_t app_id,
+                                                               const std::string &app_name)
+{
+    std::string bulk_load_path = get_app_bulk_load_path(app_id);
+    _meta_svc->get_meta_storage()->delete_node_recursively(
+        std::move(bulk_load_path), [this, app_id, app_name, bulk_load_path]() {
+            ddebug_f("remove app({}) bulk load dir {} succeed", app_name, bulk_load_path);
+            reset_local_bulk_load_states(app_id, app_name);
+        });
+}
+
+// ThreadPool: THREAD_POOL_META_STATE
+void bulk_load_service::remove_bulk_load_dir_on_remote_storage(std::shared_ptr<app_state> app,
+                                                               bool set_app_not_bulk_loading)
+{
+    std::string bulk_load_path = get_app_bulk_load_path(app->app_id);
+    _meta_svc->get_meta_storage()->delete_node_recursively(
+        std::move(bulk_load_path), [this, app, set_app_not_bulk_loading, bulk_load_path]() {
+            ddebug_f("remove app({}) bulk load dir {} succeed", app->app_name, bulk_load_path);
+            reset_local_bulk_load_states(app->app_id, app->app_name);
+            if (set_app_not_bulk_loading) {
+                update_app_not_bulk_loading_on_remote_storage(std::move(app));
+            }
+        });
+}
+
+// ThreadPool: THREAD_POOL_META_STATE
+void bulk_load_service::reset_local_bulk_load_states(int32_t app_id, const std::string &app_name)
+{
+    zauto_write_lock l(_lock);
+    _app_bulk_load_info.erase(app_id);
+    _apps_in_progress_count.erase(app_id);
+    _apps_pending_sync_flag.erase(app_id);
+    erase_map_elem_by_id(app_id, _partitions_pending_sync_flag);
+    erase_map_elem_by_id(app_id, _partitions_bulk_load_state);
+    erase_map_elem_by_id(app_id, _partition_bulk_load_info);
+    erase_map_elem_by_id(app_id, _partitions_total_download_progress);
+    erase_map_elem_by_id(app_id, _partitions_cleaned_up);
+    // TODO(heyuchen): add other varieties
+    _bulk_load_app_id.erase(app_id);
+    ddebug_f("reset local app({}) bulk load context", app_name);
+}
+
+// ThreadPool: THREAD_POOL_META_STATE
+void bulk_load_service::update_app_not_bulk_loading_on_remote_storage(
+    std::shared_ptr<app_state> app)
+{
+    app_info info = *app;
+    info.__set_is_bulk_loading(false);
+
+    blob value = dsn::json::json_forwarder<app_info>::encode(info);
+    _meta_svc->get_meta_storage()->set_data(
+        _state->get_app_path(*app), std::move(value), [app, this]() {
+            zauto_write_lock l(app_lock());
+            app->is_bulk_loading = false;
+            ddebug_f("app({}) update app is_bulk_loading to false", app->app_name);
+        });
+}
+
 void bulk_load_service::create_bulk_load_root_dir(error_code &err, task_tracker &tracker)
 {
     blob value = blob();

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -576,7 +576,8 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
     const gpid &pid = response.pid;
 
     if (!response.__isset.is_group_bulk_load_context_cleaned_up) {
-        dwarn_f(
+        dassert_f(
+            false,
             "receive bulk load response from node({}) app({}), partition({}), primary_status({}), "
             "but is_group_bulk_load_context_cleaned_up is not set",
             primary_addr.to_string(),
@@ -588,13 +589,14 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
 
     for (const auto &kv : response.group_bulk_load_state) {
         if (!kv.second.__isset.is_cleaned_up) {
-            dwarn_f("receive bulk load response from node({}) app({}), partition({}), "
-                    "primary_status({}), but node({}) is_cleaned_up is not set",
-                    primary_addr.to_string(),
-                    app_name,
-                    pid,
-                    dsn::enum_to_string(response.primary_bulk_load_status),
-                    kv.first.to_string());
+            dassert_f(false,
+                      "receive bulk load response from node({}) app({}), partition({}), "
+                      "primary_status({}), but node({}) is_cleaned_up is not set",
+                      primary_addr.to_string(),
+                      app_name,
+                      pid,
+                      dsn::enum_to_string(response.primary_bulk_load_status),
+                      kv.first.to_string());
             return;
         }
     }

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -604,7 +604,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
         if (_partitions_cleaned_up[pid]) {
             dwarn_f(
                 "receive bulk load response from node({}) app({}) partition({}), current partition "
-                "has already be cleaned up",
+                "has already been cleaned up",
                 primary_addr.to_string(),
                 app_name,
                 pid);

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -612,6 +612,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
         }
     }
 
+    // The replicas have cleaned up their bulk load states and removed temporary sst files
     bool group_cleaned_up = response.is_group_bulk_load_context_cleaned_up;
     ddebug_f("receive bulk load response from node({}) app({}) partition({}), primary status = {}, "
              "is_group_bulk_load_context_cleaned_up = {}",
@@ -998,6 +999,16 @@ void bulk_load_service::remove_bulk_load_dir_on_remote_storage(std::shared_ptr<a
                 update_app_not_bulk_loading_on_remote_storage(std::move(app));
             }
         });
+}
+
+template <typename T>
+inline void erase_map_elem_by_id(int32_t app_id, std::unordered_map<gpid, T> &mymap)
+{
+    for (auto iter = mymap.begin(); iter != mymap.end();) {
+        if (iter->first.get_app_id() == app_id) {
+            mymap.erase(iter++);
+        }
+    }
 }
 
 // ThreadPool: THREAD_POOL_META_STATE

--- a/src/dist/replication/meta_server/meta_bulk_load_service.h
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.h
@@ -43,16 +43,6 @@ struct bulk_load_info
     DEFINE_JSON_SERIALIZATION(app_id, app_name, partition_count)
 };
 
-template <typename T>
-inline void erase_map_elem_by_id(int32_t app_id, std::unordered_map<gpid, T> &mymap)
-{
-    for (auto iter = mymap.begin(); iter != mymap.end();) {
-        if (iter->first.get_app_id() == app_id) {
-            mymap.erase(iter++);
-        }
-    }
-}
-
 ///
 /// Bulk load process:
 /// when client sent `start_bulk_load_rpc` to meta server to start bulk load,
@@ -200,7 +190,7 @@ private:
                                                    bulk_load_status::type new_status,
                                                    bool should_send_request);
 
-    // callled when app is not available or dropped during bulk load, remove bulk load directory on
+    // called when app is not available or dropped during bulk load, remove bulk load directory on
     // remote storage
     void remove_bulk_load_dir_on_remote_storage(int32_t app_id, const std::string &app_name);
 

--- a/src/dist/replication/meta_server/meta_bulk_load_service.h
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.h
@@ -43,6 +43,16 @@ struct bulk_load_info
     DEFINE_JSON_SERIALIZATION(app_id, app_name, partition_count)
 };
 
+template <typename T>
+inline void erase_map_elem_by_id(int32_t app_id, std::unordered_map<gpid, T> &mymap)
+{
+    for (auto iter = mymap.begin(); iter != mymap.end();) {
+        if (iter->first.get_app_id() == app_id) {
+            mymap.erase(iter++);
+        }
+    }
+}
+
 ///
 /// Bulk load process:
 /// when client sent `start_bulk_load_rpc` to meta server to start bulk load,
@@ -144,6 +154,8 @@ private:
                                       const std::string &app_name,
                                       const gpid &pid);
 
+    void reset_local_bulk_load_states(int32_t app_id, const std::string &app_name);
+
     ///
     /// update bulk load states to remote storage functions
     ///
@@ -187,6 +199,19 @@ private:
                                                    bulk_load_status::type old_status,
                                                    bulk_load_status::type new_status,
                                                    bool should_send_request);
+
+    // callled when app is not available or dropped during bulk load, remove bulk load directory on
+    // remote storage
+    void remove_bulk_load_dir_on_remote_storage(int32_t app_id, const std::string &app_name);
+
+    // called when app is available, remove bulk load directory on remote storage
+    // if `set_app_not_bulk_loading` = true: call function
+    // `update_app_not_bulk_loading_on_remote_storage` to set app not bulk_loading after removing
+    void remove_bulk_load_dir_on_remote_storage(std::shared_ptr<app_state> app,
+                                                bool set_app_not_bulk_loading);
+
+    // update app's is_bulk_loading to false on remote_storage
+    void update_app_not_bulk_loading_on_remote_storage(std::shared_ptr<app_state> app);
 
     ///
     /// sync bulk load states from remote storage
@@ -315,6 +340,8 @@ private:
     // partition_index -> group bulk load states(node address -> state)
     std::unordered_map<gpid, std::map<rpc_address, partition_bulk_load_state>>
         _partitions_bulk_load_state;
+
+    std::unordered_map<gpid, bool> _partitions_cleaned_up;
 };
 
 } // namespace replication


### PR DESCRIPTION
The whole bulk load succeed process is like:
1. meta server set app and all partitions bulk load status is succeed #500 
2. meta server send bulk_load_request to primary #457
3. primary handle bulk_load_request #502 
4. primary broadcast request to secondary #460
5. secondary handle bulk_load_request #502 
6. secondary report cleanup flag to primary #502 
7. primary report group cleanup flag  to meta server #502 
8. **meta handle bulk load succeed**

This pull request is about meta handle bulk load succeed, step 8 above.

meta handle bulk_load_response in `handle_bulk_load_finish`
- if all replicas in group cleaned up bulk load state, set `_partitions_cleaned_up[pid] = true` and `_apps_in_progress_count[app_id] - 1`
- if all partitions cleaned up, remove bulk load directory(in function `remove_bulk_load_dir_on_remote_storage`), reset local bulk load states(in function `reset_local_bulk_load_states`), set app's is_bulk_loading as false (in function `update_app_not_bulk_loading_on_remote_storage`), whole bulk load process finished

**_Tips:_** 
when app's is_bulk_loading = false, meta will not send bulk load request to replica server any more in function `try_resend_bulk_load_request` #463 