### PR TITLE
feat(bulk-load): pause bulk load part2 - implement bulk load pause

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -70,8 +70,9 @@ private:
     void handle_bulk_load_succeed();
     // called when bulk load succeed or failed or canceled
     void handle_bulk_load_finish(bulk_load_status::type new_status);
-    error_code remove_local_bulk_load_dir(const std::string &bulk_load_dir);
+    void pause_bulk_load();
 
+    error_code remove_local_bulk_load_dir(const std::string &bulk_load_dir);
     void cleanup_download_task();
     void clear_bulk_load_states();
     bool is_cleaned_up();
@@ -82,6 +83,7 @@ private:
     void report_group_download_progress(/*out*/ bulk_load_response &response);
     void report_group_ingestion_status(/*out*/ bulk_load_response &response);
     void report_group_cleaned_up(/*out*/ bulk_load_response &response);
+    void report_group_is_paused(/*out*/ bulk_load_response &response);
 
     void report_bulk_load_states_to_primary(bulk_load_status::type remote_status,
                                             /*out*/ group_bulk_load_response &response);

--- a/src/dist/replication/meta_server/meta_bulk_load_service.cpp
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.cpp
@@ -653,8 +653,50 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
 void bulk_load_service::handle_app_pausing(const bulk_load_response &response,
                                            const rpc_address &primary_addr)
 {
-    // TODO(heyuchen): TBD
-    // called by `on_partition_bulk_load_reply` when app status is pausing
+    const std::string &app_name = response.app_name;
+    const gpid &pid = response.pid;
+
+    if (!response.__isset.is_group_bulk_load_paused) {
+        dwarn_f("receive bulk load response from node({}) app({}) partition({}), "
+                "primary_status({}), but is_group_bulk_load_paused is not set",
+                primary_addr.to_string(),
+                app_name,
+                pid,
+                dsn::enum_to_string(response.primary_bulk_load_status));
+        return;
+    }
+
+    for (const auto &kv : response.group_bulk_load_state) {
+        if (!kv.second.__isset.is_paused) {
+            dwarn_f("receive bulk load response from node({}) app({}), partition({}), "
+                    "primary_status({}), but node({}) is_paused is not set",
+                    primary_addr.to_string(),
+                    app_name,
+                    pid,
+                    dsn::enum_to_string(response.primary_bulk_load_status),
+                    kv.first.to_string());
+            return;
+        }
+    }
+
+    bool is_group_paused = response.is_group_bulk_load_paused;
+    ddebug_f("receive bulk load response from node({}) app({}) partition({}), primary status = {}, "
+             "is_group_bulk_load_paused = {}",
+             primary_addr.to_string(),
+             app_name,
+             pid,
+             dsn::enum_to_string(response.primary_bulk_load_status),
+             is_group_paused);
+    {
+        zauto_write_lock l(_lock);
+        _partitions_bulk_load_state[pid] = response.group_bulk_load_state;
+    }
+
+    if (is_group_paused) {
+        ddebug_f("app({}) partirion({}) pause bulk load succeed", response.app_name, pid);
+        update_partition_status_on_remote_storage(
+            response.app_name, pid, bulk_load_status::BLS_PAUSED);
+    }
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
@@ -759,6 +801,7 @@ void bulk_load_service::update_partition_status_on_remote_storage_reply(
         case bulk_load_status::BLS_DOWNLOADED:
         case bulk_load_status::BLS_INGESTING:
         case bulk_load_status::BLS_SUCCEED:
+        case bulk_load_status::BLS_PAUSED:
             if (old_status != new_status && --_apps_in_progress_count[pid.get_app_id()] == 0) {
                 update_app_status_on_remote_storage_unlocked(pid.get_app_id(), new_status);
             }


### PR DESCRIPTION
Pause bulk load process is like:
1. client sends pause request to meta server, and meta server update app and partitions' bulk load status to pausing #514
2. meta server still broadcast pause bulk load to replica server through `bulk_load_request`  #457 
3. **primary handle bulk_load_request**
4. primary broadcast request to secondary #460
5. **secondary handle bulk_load_request**
6. **secondary report is_paused flag to primary**
7. **primary report group is_paused flag to meta server**
8. **meta handle bulk load paused**

This pull request is about the remaining part of the process.
-  replica handle bulk_load_request
    - when bulk load status of request is  `pausing`, replica will try to cleanup all downloading tasks and turn status to `paused` (in function `pause_bulk_load`)
    - secondary report is_paused flag to primary (in function `report_bulk_load_states_to_primary`)
    - primary report group is_paused flag to meta server (in function `report_group_is_paused`)
- meta server handle bulk load paused
    - handle bulk_load_response in function `handle_app_pausing`
    - if all replicas in group paused bulk load, set partition bulk load status as `paused`
    - if all partitions bulk load status is paused, set app bulk load status as `paused` (in function `update_partition_status_on_remote_storage_reply`)

**_Special explanations:_**
1. It is possible for `is_group_bulk_load_paused` is not set in function `handle_app_pausing`, the possible condition:
    - app and partition bulk load status is downloading, meta send request to replica, replica server report download progress to meta server, at this time, bulk load is paused, app bulk load status has been updated to pausing, meta will call function `handle_app_pausing`, and is_paused flag is not set in this response, meta will do nothing with this response, and resend bulk_load_request to replica.
2. When app status is paused, meta server will not resend request to replica server in function `on_partition_bulk_load_reply`, related pull request is #463 
