### PR TITLE
fix: revert "dassert if shared log is damaged when replica server init" commit

### DIFF
--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -554,6 +554,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
         dassert(lerr == ERR_OK, "restart log service must succeed");
     }
 
+    bool is_log_complete = true;
     for (auto it = rps.begin(); it != rps.end(); ++it) {
         auto err = it->second->background_sync_checkpoint();
         dassert(err == ERR_OK, "sync checkpoint failed, err = %s", err.to_string());
@@ -597,12 +598,26 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
                smax);
 
         if (err == ERR_OK) {
-            dassert_f(smax == pmax,
-                      "{}: some shared log state must be lost, smax({}) vs pmax({})",
-                      it->second->name(),
-                      smax,
-                      pmax);
+            if (smax != pmax) {
+                derror("%s: some shared log state must be lost, smax(%" PRId64 ") vs pmax(%" PRId64
+                       ")",
+                       it->second->name(),
+                       smax,
+                       pmax);
+                is_log_complete = false;
+            } else {
+                // just leave inactive_state_transient as its old value
+            }
         } else {
+            it->second->set_inactive_state_transient(false);
+        }
+    }
+
+    // we will mark all replicas inactive not transient unless all logs are complete
+    if (!is_log_complete) {
+        derror("logs are not complete for some replicas, which means that shared log is truncated, "
+               "mark all replicas as inactive");
+        for (auto it = rps.begin(); it != rps.end(); ++it) {
             it->second->set_inactive_state_transient(false);
         }
     }


### PR DESCRIPTION
#513 think when shared log damaged because of node crash, we should forbid to restart it to avoid unexpected problem. however, since the the shared log usually wouldn't flush disk in time but private log do, so the `shared log != private log` case is common. In this case, restart failed will be frequently, which is not our expected.

After revert the commit, if shared log damaged, pegasus server will try reply from private log. But It do should be note that  private log may be not coincident. 

Consider the two above case, we prefer to avoid restart failed when the node server crash, so we choose revert the commit.