### PR TITLE
refactor: make command manager decoupled from dsn_runtime

### DIFF
--- a/include/dsn/tool-api/command_manager.h
+++ b/include/dsn/tool-api/command_manager.h
@@ -47,10 +47,6 @@ public:
                                   const std::string &help_long,
                                   command_handler handler);
 
-    dsn_handle_t register_app_command(const std::vector<std::string> &commands,
-                                      const std::string &help_one_line,
-                                      const std::string &help_long,
-                                      command_handler handler);
     void deregister_command(dsn_handle_t handle);
 
     bool run_command(const std::string &cmd,

--- a/include/dsn/tool-api/global_config.h
+++ b/include/dsn/tool-api/global_config.h
@@ -157,7 +157,6 @@ struct service_spec
     std::string lock_nr_factory_name;
     std::string rwlock_nr_factory_name;
     std::string semaphore_factory_name;
-    std::string nfs_factory_name;
     std::string logging_factory_name;
 
     network_client_configs network_default_client_cfs; // default network configed by tools
@@ -193,7 +192,6 @@ CONFIG_FLD_STRING(lock_factory_name, "", "recursive exclusive lock provider")
 CONFIG_FLD_STRING(lock_nr_factory_name, "", "non-recurisve exclusive lock provider")
 CONFIG_FLD_STRING(rwlock_nr_factory_name, "", "non-recurisve rwlock provider")
 CONFIG_FLD_STRING(semaphore_factory_name, "", "semaphore provider")
-CONFIG_FLD_STRING(nfs_factory_name, "", "nfs provider")
 CONFIG_FLD_STRING(logging_factory_name, "", "logging provider")
 CONFIG_END
 

--- a/src/core/core/command_manager.cpp
+++ b/src/core/core/command_manager.cpp
@@ -29,25 +29,9 @@
 #include <sstream>
 
 #include <dsn/utility/utils.h>
-#include <dsn/cpp/service_app.h>
 #include <dsn/tool-api/command_manager.h>
 
 namespace dsn {
-
-dsn_handle_t command_manager::register_app_command(const std::vector<std::string> &commands,
-                                                   const std::string &help_one_line,
-                                                   const std::string &help_long,
-                                                   command_handler handler)
-{
-    std::string app_tag = std::string(service_app::current_service_app_info().full_name) + ".";
-    std::vector<std::string> commands_with_app_tag;
-    commands_with_app_tag.reserve(commands.size());
-    for (const std::string &c : commands) {
-        commands_with_app_tag.push_back(app_tag + c);
-    }
-    return register_command(
-        commands_with_app_tag, app_tag + help_one_line, app_tag + help_long, handler);
-}
 
 dsn_handle_t command_manager::register_command(const std::vector<std::string> &commands,
                                                const std::string &help_one_line,

--- a/src/core/tools/common/nativerun.cpp
+++ b/src/core/tools/common/nativerun.cpp
@@ -93,9 +93,6 @@ void nativerun::install(service_spec &spec)
     if (spec.semaphore_factory_name == "")
         spec.semaphore_factory_name = ("dsn::tools::std_semaphore_provider");
 
-    if (spec.nfs_factory_name == "")
-        spec.nfs_factory_name = "dsn::service::nfs_node_simple";
-
     for (auto it = spec.threadpool_specs.begin(); it != spec.threadpool_specs.end(); ++it) {
         threadpool_spec &tspec = *it;
 

--- a/src/core/tools/simulator/simulator.cpp
+++ b/src/core/tools/simulator/simulator.cpp
@@ -104,9 +104,6 @@ void simulator::install(service_spec &spec)
     if (spec.semaphore_factory_name == "")
         spec.semaphore_factory_name = ("dsn::tools::sim_semaphore_provider");
 
-    if (spec.nfs_factory_name == "")
-        spec.nfs_factory_name = "dsn::service::nfs_node_simple";
-
     for (auto it = spec.threadpool_specs.begin(); it != spec.threadpool_specs.end(); ++it) {
         threadpool_spec &tspec = *it;
 

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -60,12 +60,12 @@ void failure_detector::register_ctrl_commands()
 {
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-    _get_allow_list = dsn::command_manager::instance().register_command(
-        {"fd.allow_list"},
-        "fd.allow_list",
-        "show allow list of replica",
-        [this](const std::vector<std::string> &args) { return get_allow_list(args); });
-      });
+        _get_allow_list = dsn::command_manager::instance().register_command(
+            {"fd.allow_list"},
+            "fd.allow_list",
+            "show allow list of replica",
+            [this](const std::vector<std::string> &args) { return get_allow_list(args); });
+    });
 }
 
 void failure_detector::unregister_ctrl_commands() { UNREGISTER_VALID_HANDLER(_get_allow_list); }

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -58,11 +58,14 @@ failure_detector::failure_detector()
 
 void failure_detector::register_ctrl_commands()
 {
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
     _get_allow_list = dsn::command_manager::instance().register_command(
         {"fd.allow_list"},
         "fd.allow_list",
         "show allow list of replica",
         [this](const std::vector<std::string> &args) { return get_allow_list(args); });
+      });
 }
 
 void failure_detector::unregister_ctrl_commands() { UNREGISTER_VALID_HANDLER(_get_allow_list); }

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -63,7 +63,7 @@ void failure_detector::register_ctrl_commands()
         _get_allow_list = dsn::command_manager::instance().register_command(
             {"fd.allow_list"},
             "fd.allow_list",
-            "show allow list of replica",
+            "show allow list of failure detector",
             [this](const std::vector<std::string> &args) { return get_allow_list(args); });
     });
 }

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -58,7 +58,7 @@ failure_detector::failure_detector()
 
 void failure_detector::register_ctrl_commands()
 {
-    _get_allow_list = dsn::command_manager::instance().register_app_command(
+    _get_allow_list = dsn::command_manager::instance().register_command(
         {"fd.allow_list"},
         "fd.allow_list",
         "show allow list of replica",

--- a/src/dist/nfs/nfs_client_impl.cpp
+++ b/src/dist/nfs/nfs_client_impl.cpp
@@ -557,7 +557,7 @@ void nfs_client_impl::handle_completion(const user_request_ptr &req, error_code 
 
 void nfs_client_impl::register_cli_commands()
 {
-    dsn::command_manager::instance().register_app_command(
+    dsn::command_manager::instance().register_command(
         {"nfs.max_copy_rate_megabytes"},
         "nfs.max_copy_rate_megabytes [num | DEFAULT]",
         "control the max rate(MB/s) to copy file from remote node",

--- a/src/dist/nfs/nfs_client_impl.cpp
+++ b/src/dist/nfs/nfs_client_impl.cpp
@@ -110,7 +110,6 @@ nfs_client_impl::nfs_client_impl()
     dassert(max_copy_rate_bytes > FLAGS_nfs_copy_block_bytes,
             "max_copy_rate_bytes should be greater than nfs_copy_block_bytes");
     _copy_token_bucket.reset(new TokenBucket(max_copy_rate_bytes, 1.5 * max_copy_rate_bytes));
-    FLAGS_max_copy_rate_megabytes = FLAGS_max_copy_rate_megabytes;
 
     register_cli_commands();
 }
@@ -574,7 +573,6 @@ void nfs_client_impl::register_cli_commands()
                 if (args[0] == "DEFAULT") {
                     uint32_t max_copy_rate_bytes = FLAGS_max_copy_rate_megabytes << 20;
                     _copy_token_bucket->reset(max_copy_rate_bytes, 1.5 * max_copy_rate_bytes);
-                    FLAGS_max_copy_rate_megabytes = FLAGS_max_copy_rate_megabytes;
                     return result;
                 }
 

--- a/src/dist/nfs/nfs_client_impl.cpp
+++ b/src/dist/nfs/nfs_client_impl.cpp
@@ -557,40 +557,45 @@ void nfs_client_impl::handle_completion(const user_request_ptr &req, error_code 
 
 void nfs_client_impl::register_cli_commands()
 {
-    dsn::command_manager::instance().register_command(
-        {"nfs.max_copy_rate_megabytes"},
-        "nfs.max_copy_rate_megabytes [num | DEFAULT]",
-        "control the max rate(MB/s) to copy file from remote node",
-        [this](const std::vector<std::string> &args) {
-            std::string result("OK");
 
-            if (args.empty()) {
-                return std::to_string(FLAGS_max_copy_rate_megabytes);
-            }
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        dsn::command_manager::instance().register_command(
+            {"nfs.max_copy_rate_megabytes"},
+            "nfs.max_copy_rate_megabytes [num | DEFAULT]",
+            "control the max rate(MB/s) to copy file from remote node",
+            [this](const std::vector<std::string> &args) {
+                std::string result("OK");
 
-            if (args[0] == "DEFAULT") {
-                uint32_t max_copy_rate_bytes = FLAGS_max_copy_rate_megabytes << 20;
+                if (args.empty()) {
+                    return std::to_string(FLAGS_max_copy_rate_megabytes);
+                }
+
+                if (args[0] == "DEFAULT") {
+                    uint32_t max_copy_rate_bytes = FLAGS_max_copy_rate_megabytes << 20;
+                    _copy_token_bucket->reset(max_copy_rate_bytes, 1.5 * max_copy_rate_bytes);
+                    FLAGS_max_copy_rate_megabytes = FLAGS_max_copy_rate_megabytes;
+                    return result;
+                }
+
+                int32_t max_copy_rate_megabytes = 0;
+                if (!dsn::buf2int32(args[0], max_copy_rate_megabytes) ||
+                    max_copy_rate_megabytes <= 0) {
+                    return std::string("ERR: invalid arguments");
+                }
+
+                uint32_t max_copy_rate_bytes = max_copy_rate_megabytes << 20;
+                if (max_copy_rate_bytes <= FLAGS_nfs_copy_block_bytes) {
+                    result = std::string("ERR: max_copy_rate_bytes(max_copy_rate_megabytes << 20) "
+                                         "should be greater than nfs_copy_block_bytes:")
+                                 .append(std::to_string(FLAGS_nfs_copy_block_bytes));
+                    return result;
+                }
                 _copy_token_bucket->reset(max_copy_rate_bytes, 1.5 * max_copy_rate_bytes);
-                FLAGS_max_copy_rate_megabytes = FLAGS_max_copy_rate_megabytes;
+                FLAGS_max_copy_rate_megabytes = max_copy_rate_megabytes;
                 return result;
-            }
-
-            int32_t max_copy_rate_megabytes = 0;
-            if (!dsn::buf2int32(args[0], max_copy_rate_megabytes) || max_copy_rate_megabytes <= 0) {
-                return std::string("ERR: invalid arguments");
-            }
-
-            uint32_t max_copy_rate_bytes = max_copy_rate_megabytes << 20;
-            if (max_copy_rate_bytes <= FLAGS_nfs_copy_block_bytes) {
-                result = std::string("ERR: max_copy_rate_bytes(max_copy_rate_megabytes << 20) "
-                                     "should be greater than nfs_copy_block_bytes:")
-                             .append(std::to_string(FLAGS_nfs_copy_block_bytes));
-                return result;
-            }
-            _copy_token_bucket->reset(max_copy_rate_bytes, 1.5 * max_copy_rate_bytes);
-            FLAGS_max_copy_rate_megabytes = max_copy_rate_megabytes;
-            return result;
-        });
+            });
+    });
 }
 } // namespace service
 } // namespace dsn

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2082,182 +2082,193 @@ void replica_stub::open_service()
     register_rpc_handler_with_rpc_holder(
         RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
 
-    _kill_partition_command = ::dsn::command_manager::instance().register_command(
-        {"replica.kill_partition"},
-        "kill_partition [app_id [partition_index]]",
-        "kill_partition: kill partitions by (all, one app, one partition)",
-        [this](const std::vector<std::string> &args) {
-            dsn::gpid pid;
-            if (args.size() == 0) {
-                pid.set_app_id(-1);
-                pid.set_partition_index(-1);
-            } else if (args.size() == 1) {
-                pid.set_app_id(atoi(args[0].c_str()));
-                pid.set_partition_index(-1);
-            } else if (args.size() == 2) {
-                pid.set_app_id(atoi(args[0].c_str()));
-                pid.set_partition_index(atoi(args[1].c_str()));
-            } else {
-                return std::string(ERR_INVALID_PARAMETERS.to_string());
-            }
-            dsn::error_code e = this->on_kill_replica(pid);
-            return std::string(e.to_string());
-        });
-
-    _deny_client_command = ::dsn::command_manager::instance().register_command(
-        {"replica.deny-client"},
-        "deny-client <true|false>",
-        "deny-client - control if deny client read & write request",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_deny_client, "deny-client", args);
-        });
-
-    _verbose_client_log_command = ::dsn::command_manager::instance().register_command(
-        {"replica.verbose-client-log"},
-        "verbose-client-log <true|false>",
-        "verbose-client-log - control if print verbose error log when reply read & write request",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_verbose_client_log, "verbose-client-log", args);
-        });
-
-    _verbose_commit_log_command = ::dsn::command_manager::instance().register_command(
-        {"replica.verbose-commit-log"},
-        "verbose-commit-log <true|false>",
-        "verbose-commit-log - control if print verbose log when commit mutation",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_verbose_commit_log, "verbose-commit-log", args);
-        });
-
-    _trigger_chkpt_command = ::dsn::command_manager::instance().register_command(
-        {"replica.trigger-checkpoint"},
-        "trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
-        "trigger-checkpoint - trigger replicas to do checkpoint",
-        [this](const std::vector<std::string> &args) {
-            return exec_command_on_replica(args, true, [this](const replica_ptr &rep) {
-                tasking::enqueue(LPC_PER_REPLICA_CHECKPOINT_TIMER,
-                                 rep->tracker(),
-                                 std::bind(&replica_stub::trigger_checkpoint, this, rep, true),
-                                 rep->get_gpid().thread_hash());
-                return std::string("triggered");
-            });
-        });
-
-    _query_compact_command = ::dsn::command_manager::instance().register_command(
-        {"replica.query-compact"},
-        "query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
-        "query-compact - query full compact status on the underlying storage engine",
-        [this](const std::vector<std::string> &args) {
-            return exec_command_on_replica(
-                args, true, [](const replica_ptr &rep) { return rep->query_compact_state(); });
-        });
-
-    _query_app_envs_command = ::dsn::command_manager::instance().register_command(
-        {"replica.query-app-envs"},
-        "query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
-        "query-app-envs - query app envs on the underlying storage engine",
-        [this](const std::vector<std::string> &args) {
-            return exec_command_on_replica(args, true, [](const replica_ptr &rep) {
-                std::map<std::string, std::string> kv_map;
-                rep->query_app_envs(kv_map);
-                return dsn::utils::kv_map_to_string(kv_map, ',', '=');
-            });
-        });
-
-    _useless_dir_reserve_seconds_command = dsn::command_manager::instance().register_command(
-        {"replica.useless-dir-reserve-seconds"},
-        "useless-dir-reserve-seconds [num | DEFAULT]",
-        "control gc_disk_error_replica_interval_seconds and "
-        "gc_disk_garbage_replica_interval_seconds",
-        [this](const std::vector<std::string> &args) {
-            std::string result("OK");
-            if (args.empty()) {
-                result = "error_dir_reserve_seconds=" +
-                         std::to_string(_gc_disk_error_replica_interval_seconds) +
-                         ",garbage_dir_reserve_seconds=" +
-                         std::to_string(_gc_disk_garbage_replica_interval_seconds);
-            } else {
-                if (args[0] == "DEFAULT") {
-                    _gc_disk_error_replica_interval_seconds =
-                        _options.gc_disk_error_replica_interval_seconds;
-                    _gc_disk_garbage_replica_interval_seconds =
-                        _options.gc_disk_garbage_replica_interval_seconds;
+    /// In simple_kv test, three replica apps are created, which means that three replica_stubs are
+    /// initialized in simple_kv test. If we don't use std::call_once, these command are registered
+    /// for three times. And in command_manager, one same command is not allowed to be registered
+    /// more than twice times. That is why we use std::call_once here. Same situation in
+    /// failure_detector::register_ctrl_commands and nfs_client_impl::register_cli_commands
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        _kill_partition_command = ::dsn::command_manager::instance().register_command(
+            {"replica.kill_partition"},
+            "kill_partition [app_id [partition_index]]",
+            "kill_partition: kill partitions by (all, one app, one partition)",
+            [this](const std::vector<std::string> &args) {
+                dsn::gpid pid;
+                if (args.size() == 0) {
+                    pid.set_app_id(-1);
+                    pid.set_partition_index(-1);
+                } else if (args.size() == 1) {
+                    pid.set_app_id(atoi(args[0].c_str()));
+                    pid.set_partition_index(-1);
+                } else if (args.size() == 2) {
+                    pid.set_app_id(atoi(args[0].c_str()));
+                    pid.set_partition_index(atoi(args[1].c_str()));
                 } else {
-                    int32_t seconds = 0;
-                    if (!dsn::buf2int32(args[0], seconds) || seconds < 0) {
-                        result = std::string("ERR: invalid arguments");
-                    } else {
-                        _gc_disk_error_replica_interval_seconds = seconds;
-                        _gc_disk_garbage_replica_interval_seconds = seconds;
-                    }
+                    return std::string(ERR_INVALID_PARAMETERS.to_string());
                 }
-            }
-            return result;
-        });
+                dsn::error_code e = this->on_kill_replica(pid);
+                return std::string(e.to_string());
+            });
 
-#ifdef DSN_ENABLE_GPERF
-    _release_tcmalloc_memory_command = ::dsn::command_manager::instance().register_command(
-        {"replica.release-tcmalloc-memory"},
-        "release-tcmalloc-memory <true|false>",
-        "release-tcmalloc-memory - control if try to release tcmalloc memory",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(
-                _release_tcmalloc_memory, "release-tcmalloc-memory", args);
-        });
+        _deny_client_command = ::dsn::command_manager::instance().register_command(
+            {"replica.deny-client"},
+            "deny-client <true|false>",
+            "deny-client - control if deny client read & write request",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(_deny_client, "deny-client", args);
+            });
 
-    _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_command(
-        {"replica.mem-release-max-reserved-percentage"},
-        "mem-release-max-reserved-percentage [num | DEFAULT]",
-        "control tcmalloc max reserved but not-used memory percentage",
-        [this](const std::vector<std::string> &args) {
-            std::string result("OK");
-            if (args.empty()) {
-                // show current value
-                result = "mem-release-max-reserved-percentage = " +
-                         std::to_string(_mem_release_max_reserved_mem_percentage);
-                return result;
-            }
-            if (args[0] == "DEFAULT") {
-                // set to default value
-                _mem_release_max_reserved_mem_percentage =
-                    _options.mem_release_max_reserved_mem_percentage;
-                return result;
-            }
-            int32_t percentage = 0;
-            if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 || percentage > 100) {
-                result = std::string("ERR: invalid arguments");
-            } else {
-                _mem_release_max_reserved_mem_percentage = percentage;
-            }
-            return result;
-        });
-#endif
-    _max_concurrent_bulk_load_downloading_count_command =
-        dsn::command_manager::instance().register_command(
-            {"replica.max-concurrent-bulk-load-downloading-count"},
-            "max-concurrent-bulk-load-downloading-count [num | DEFAULT]",
-            "control stub max_concurrent_bulk_load_downloading_count",
+        _verbose_client_log_command = ::dsn::command_manager::instance().register_command(
+            {"replica.verbose-client-log"},
+            "verbose-client-log <true|false>",
+            "verbose-client-log - control if print verbose error log when reply read & write "
+            "request",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(
+                    _verbose_client_log, "verbose-client-log", args);
+            });
+
+        _verbose_commit_log_command = ::dsn::command_manager::instance().register_command(
+            {"replica.verbose-commit-log"},
+            "verbose-commit-log <true|false>",
+            "verbose-commit-log - control if print verbose log when commit mutation",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(
+                    _verbose_commit_log, "verbose-commit-log", args);
+            });
+
+        _trigger_chkpt_command = ::dsn::command_manager::instance().register_command(
+            {"replica.trigger-checkpoint"},
+            "trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "trigger-checkpoint - trigger replicas to do checkpoint",
+            [this](const std::vector<std::string> &args) {
+                return exec_command_on_replica(args, true, [this](const replica_ptr &rep) {
+                    tasking::enqueue(LPC_PER_REPLICA_CHECKPOINT_TIMER,
+                                     rep->tracker(),
+                                     std::bind(&replica_stub::trigger_checkpoint, this, rep, true),
+                                     rep->get_gpid().thread_hash());
+                    return std::string("triggered");
+                });
+            });
+
+        _query_compact_command = ::dsn::command_manager::instance().register_command(
+            {"replica.query-compact"},
+            "query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "query-compact - query full compact status on the underlying storage engine",
+            [this](const std::vector<std::string> &args) {
+                return exec_command_on_replica(
+                    args, true, [](const replica_ptr &rep) { return rep->query_compact_state(); });
+            });
+
+        _query_app_envs_command = ::dsn::command_manager::instance().register_command(
+            {"replica.query-app-envs"},
+            "query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "query-app-envs - query app envs on the underlying storage engine",
+            [this](const std::vector<std::string> &args) {
+                return exec_command_on_replica(args, true, [](const replica_ptr &rep) {
+                    std::map<std::string, std::string> kv_map;
+                    rep->query_app_envs(kv_map);
+                    return dsn::utils::kv_map_to_string(kv_map, ',', '=');
+                });
+            });
+
+        _useless_dir_reserve_seconds_command = dsn::command_manager::instance().register_command(
+            {"replica.useless-dir-reserve-seconds"},
+            "useless-dir-reserve-seconds [num | DEFAULT]",
+            "control gc_disk_error_replica_interval_seconds and "
+            "gc_disk_garbage_replica_interval_seconds",
             [this](const std::vector<std::string> &args) {
                 std::string result("OK");
                 if (args.empty()) {
-                    result = "max_concurrent_bulk_load_downloading_count=" +
-                             std::to_string(_max_concurrent_bulk_load_downloading_count);
-                    return result;
-                }
-
-                if (args[0] == "DEFAULT") {
-                    _max_concurrent_bulk_load_downloading_count =
-                        _options.max_concurrent_bulk_load_downloading_count;
-                    return result;
-                }
-
-                int32_t count = 0;
-                if (!dsn::buf2int32(args[0], count) || count <= 0) {
-                    result = std::string("ERR: invalid arguments");
+                    result = "error_dir_reserve_seconds=" +
+                             std::to_string(_gc_disk_error_replica_interval_seconds) +
+                             ",garbage_dir_reserve_seconds=" +
+                             std::to_string(_gc_disk_garbage_replica_interval_seconds);
                 } else {
-                    _max_concurrent_bulk_load_downloading_count = count;
+                    if (args[0] == "DEFAULT") {
+                        _gc_disk_error_replica_interval_seconds =
+                            _options.gc_disk_error_replica_interval_seconds;
+                        _gc_disk_garbage_replica_interval_seconds =
+                            _options.gc_disk_garbage_replica_interval_seconds;
+                    } else {
+                        int32_t seconds = 0;
+                        if (!dsn::buf2int32(args[0], seconds) || seconds < 0) {
+                            result = std::string("ERR: invalid arguments");
+                        } else {
+                            _gc_disk_error_replica_interval_seconds = seconds;
+                            _gc_disk_garbage_replica_interval_seconds = seconds;
+                        }
+                    }
                 }
                 return result;
             });
+
+#ifdef DSN_ENABLE_GPERF
+        _release_tcmalloc_memory_command = ::dsn::command_manager::instance().register_command(
+            {"replica.release-tcmalloc-memory"},
+            "release-tcmalloc-memory <true|false>",
+            "release-tcmalloc-memory - control if try to release tcmalloc memory",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(
+                    _release_tcmalloc_memory, "release-tcmalloc-memory", args);
+            });
+
+        _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_command(
+            {"replica.mem-release-max-reserved-percentage"},
+            "mem-release-max-reserved-percentage [num | DEFAULT]",
+            "control tcmalloc max reserved but not-used memory percentage",
+            [this](const std::vector<std::string> &args) {
+                std::string result("OK");
+                if (args.empty()) {
+                    // show current value
+                    result = "mem-release-max-reserved-percentage = " +
+                             std::to_string(_mem_release_max_reserved_mem_percentage);
+                    return result;
+                }
+                if (args[0] == "DEFAULT") {
+                    // set to default value
+                    _mem_release_max_reserved_mem_percentage =
+                        _options.mem_release_max_reserved_mem_percentage;
+                    return result;
+                }
+                int32_t percentage = 0;
+                if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 || percentage > 100) {
+                    result = std::string("ERR: invalid arguments");
+                } else {
+                    _mem_release_max_reserved_mem_percentage = percentage;
+                }
+                return result;
+            });
+#endif
+        _max_concurrent_bulk_load_downloading_count_command =
+            dsn::command_manager::instance().register_command(
+                {"replica.max-concurrent-bulk-load-downloading-count"},
+                "max-concurrent-bulk-load-downloading-count [num | DEFAULT]",
+                "control stub max_concurrent_bulk_load_downloading_count",
+                [this](const std::vector<std::string> &args) {
+                    std::string result("OK");
+                    if (args.empty()) {
+                        result = "max_concurrent_bulk_load_downloading_count=" +
+                                 std::to_string(_max_concurrent_bulk_load_downloading_count);
+                        return result;
+                    }
+
+                    if (args[0] == "DEFAULT") {
+                        _max_concurrent_bulk_load_downloading_count =
+                            _options.max_concurrent_bulk_load_downloading_count;
+                        return result;
+                    }
+
+                    int32_t count = 0;
+                    if (!dsn::buf2int32(args[0], count) || count <= 0) {
+                        result = std::string("ERR: invalid arguments");
+                    } else {
+                        _max_concurrent_bulk_load_downloading_count = count;
+                    }
+                    return result;
+                });
+    });
 }
 
 std::string

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2082,8 +2082,8 @@ void replica_stub::open_service()
     register_rpc_handler_with_rpc_holder(
         RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
 
-    _kill_partition_command = ::dsn::command_manager::instance().register_app_command(
-        {"kill_partition"},
+    _kill_partition_command = ::dsn::command_manager::instance().register_command(
+        {"replica.kill_partition"},
         "kill_partition [app_id [partition_index]]",
         "kill_partition: kill partitions by (all, one app, one partition)",
         [this](const std::vector<std::string> &args) {
@@ -2104,32 +2104,32 @@ void replica_stub::open_service()
             return std::string(e.to_string());
         });
 
-    _deny_client_command = ::dsn::command_manager::instance().register_app_command(
-        {"deny-client"},
+    _deny_client_command = ::dsn::command_manager::instance().register_command(
+        {"replica.deny-client"},
         "deny-client <true|false>",
         "deny-client - control if deny client read & write request",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_deny_client, "deny-client", args);
         });
 
-    _verbose_client_log_command = ::dsn::command_manager::instance().register_app_command(
-        {"verbose-client-log"},
+    _verbose_client_log_command = ::dsn::command_manager::instance().register_command(
+        {"replica.verbose-client-log"},
         "verbose-client-log <true|false>",
         "verbose-client-log - control if print verbose error log when reply read & write request",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_verbose_client_log, "verbose-client-log", args);
         });
 
-    _verbose_commit_log_command = ::dsn::command_manager::instance().register_app_command(
-        {"verbose-commit-log"},
+    _verbose_commit_log_command = ::dsn::command_manager::instance().register_command(
+        {"replica.verbose-commit-log"},
         "verbose-commit-log <true|false>",
         "verbose-commit-log - control if print verbose log when commit mutation",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_verbose_commit_log, "verbose-commit-log", args);
         });
 
-    _trigger_chkpt_command = ::dsn::command_manager::instance().register_app_command(
-        {"trigger-checkpoint"},
+    _trigger_chkpt_command = ::dsn::command_manager::instance().register_command(
+        {"replica.trigger-checkpoint"},
         "trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
         "trigger-checkpoint - trigger replicas to do checkpoint",
         [this](const std::vector<std::string> &args) {
@@ -2142,8 +2142,8 @@ void replica_stub::open_service()
             });
         });
 
-    _query_compact_command = ::dsn::command_manager::instance().register_app_command(
-        {"query-compact"},
+    _query_compact_command = ::dsn::command_manager::instance().register_command(
+        {"replica.query-compact"},
         "query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
         "query-compact - query full compact status on the underlying storage engine",
         [this](const std::vector<std::string> &args) {
@@ -2151,8 +2151,8 @@ void replica_stub::open_service()
                 args, true, [](const replica_ptr &rep) { return rep->query_compact_state(); });
         });
 
-    _query_app_envs_command = ::dsn::command_manager::instance().register_app_command(
-        {"query-app-envs"},
+    _query_app_envs_command = ::dsn::command_manager::instance().register_command(
+        {"replica.query-app-envs"},
         "query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
         "query-app-envs - query app envs on the underlying storage engine",
         [this](const std::vector<std::string> &args) {
@@ -2163,8 +2163,8 @@ void replica_stub::open_service()
             });
         });
 
-    _useless_dir_reserve_seconds_command = dsn::command_manager::instance().register_app_command(
-        {"useless-dir-reserve-seconds"},
+    _useless_dir_reserve_seconds_command = dsn::command_manager::instance().register_command(
+        {"replica.useless-dir-reserve-seconds"},
         "useless-dir-reserve-seconds [num | DEFAULT]",
         "control gc_disk_error_replica_interval_seconds and "
         "gc_disk_garbage_replica_interval_seconds",
@@ -2195,8 +2195,8 @@ void replica_stub::open_service()
         });
 
 #ifdef DSN_ENABLE_GPERF
-    _release_tcmalloc_memory_command = ::dsn::command_manager::instance().register_app_command(
-        {"release-tcmalloc-memory"},
+    _release_tcmalloc_memory_command = ::dsn::command_manager::instance().register_command(
+        {"replica.release-tcmalloc-memory"},
         "release-tcmalloc-memory <true|false>",
         "release-tcmalloc-memory - control if try to release tcmalloc memory",
         [this](const std::vector<std::string> &args) {
@@ -2204,8 +2204,8 @@ void replica_stub::open_service()
                 _release_tcmalloc_memory, "release-tcmalloc-memory", args);
         });
 
-    _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_app_command(
-        {"mem-release-max-reserved-percentage"},
+    _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_command(
+        {"replica.mem-release-max-reserved-percentage"},
         "mem-release-max-reserved-percentage [num | DEFAULT]",
         "control tcmalloc max reserved but not-used memory percentage",
         [this](const std::vector<std::string> &args) {
@@ -2232,8 +2232,8 @@ void replica_stub::open_service()
         });
 #endif
     _max_concurrent_bulk_load_downloading_count_command =
-        dsn::command_manager::instance().register_app_command(
-            {"max-concurrent-bulk-load-downloading-count"},
+        dsn::command_manager::instance().register_command(
+            {"replica.max-concurrent-bulk-load-downloading-count"},
             "max-concurrent-bulk-load-downloading-count [num | DEFAULT]",
             "control stub max_concurrent_bulk_load_downloading_count",
             [this](const std::vector<std::string> &args) {

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -2082,6 +2082,11 @@ void replica_stub::open_service()
     register_rpc_handler_with_rpc_holder(
         RPC_GROUP_BULK_LOAD, "group_bulk_load", &replica_stub::on_group_bulk_load);
 
+    register_ctrl_command();
+}
+
+void replica_stub::register_ctrl_command()
+{
     /// In simple_kv test, three replica apps are created, which means that three replica_stubs are
     /// initialized in simple_kv test. If we don't use std::call_once, these command are registered
     /// for three times. And in command_manager, one same command is not allowed to be registered

--- a/src/dist/replication/lib/replica_stub.h
+++ b/src/dist/replication/lib/replica_stub.h
@@ -260,6 +260,8 @@ private:
                          error_code error);
     void update_disk_holding_replicas();
 
+    void register_ctrl_command();
+
     int get_app_id_from_replicas(std::string app_name)
     {
         for (const auto &replica : _replicas) {

--- a/src/dist/replication/meta_server/greedy_load_balancer.cpp
+++ b/src/dist/replication/meta_server/greedy_load_balancer.cpp
@@ -90,16 +90,16 @@ void greedy_load_balancer::register_ctrl_commands()
     // register command that belong to simple_load_balancer
     simple_load_balancer::register_ctrl_commands();
 
-    _ctrl_balancer_in_turn = dsn::command_manager::instance().register_app_command(
-        {"lb.balancer_in_turn"},
+    _ctrl_balancer_in_turn = dsn::command_manager::instance().register_command(
+        {"meta.lb.balancer_in_turn"},
         "lb.balancer_in_turn <true|false>",
         "control whether do app balancer in turn",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_balancer_in_turn, "lb.balancer_in_turn", args);
         });
 
-    _ctrl_only_primary_balancer = dsn::command_manager::instance().register_app_command(
-        {"lb.only_primary_balancer"},
+    _ctrl_only_primary_balancer = dsn::command_manager::instance().register_command(
+        {"meta.lb.only_primary_balancer"},
         "lb.only_primary_balancer <true|false>",
         "control whether do only primary balancer",
         [this](const std::vector<std::string> &args) {
@@ -107,22 +107,22 @@ void greedy_load_balancer::register_ctrl_commands()
                 _only_primary_balancer, "lb.only_primary_balancer", args);
         });
 
-    _ctrl_only_move_primary = dsn::command_manager::instance().register_app_command(
-        {"lb.only_move_primary"},
+    _ctrl_only_move_primary = dsn::command_manager::instance().register_command(
+        {"meta.lb.only_move_primary"},
         "lb.only_move_primary <true|false>",
         "control whether only move primary in balancer",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_only_move_primary, "lb.only_move_primary", args);
         });
 
-    _get_balance_operation_count = dsn::command_manager::instance().register_app_command(
-        {"lb.get_balance_operation_count"},
+    _get_balance_operation_count = dsn::command_manager::instance().register_command(
+        {"meta.lb.get_balance_operation_count"},
         "lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]",
         "get balance operation count",
         [this](const std::vector<std::string> &args) { return get_balance_operation_count(args); });
 
-    _ctrl_balancer_ignored_apps = dsn::command_manager::instance().register_app_command(
-        {"lb.ignored_app_list"},
+    _ctrl_balancer_ignored_apps = dsn::command_manager::instance().register_command(
+        {"meta.lb.ignored_app_list"},
         "lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]",
         "get, set and clear balancer ignored_app_list",
         [this](const std::vector<std::string> &args) {

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -214,8 +214,8 @@ void meta_service::balancer_run() { _state->check_all_partitions(); }
 void meta_service::register_ctrl_commands()
 {
     _ctrl_node_live_percentage_threshold_for_update =
-        dsn::command_manager::instance().register_app_command(
-            {"live_percentage"},
+        dsn::command_manager::instance().register_command(
+            {"meta.live_percentage"},
             "live_percentage [num | DEFAULT]",
             "node live percentage threshold for update",
             [this](const std::vector<std::string> &args) {

--- a/src/dist/replication/meta_server/server_load_balancer.cpp
+++ b/src/dist/replication/meta_server/server_load_balancer.cpp
@@ -854,14 +854,14 @@ void simple_load_balancer::register_ctrl_commands()
 {
     server_load_balancer::register_ctrl_commands();
 
-    _ctrl_assign_delay_ms = dsn::command_manager::instance().register_app_command(
-        {"lb.assign_delay_ms"},
+    _ctrl_assign_delay_ms = dsn::command_manager::instance().register_command(
+        {"meta.lb.assign_delay_ms"},
         "lb.assign_delay_ms [num | DEFAULT]",
         "control the replica_assign_delay_ms_for_dropouts config",
         [this](const std::vector<std::string> &args) { return ctrl_assign_delay_ms(args); });
 
-    _ctrl_assign_secondary_black_list = dsn::command_manager::instance().register_app_command(
-        {"lb.assign_secondary_black_list"},
+    _ctrl_assign_secondary_black_list = dsn::command_manager::instance().register_command(
+        {"meta.lb.assign_secondary_black_list"},
         "lb.assign_secondary_black_list [<ip:port,ip:port,ip:port>|clear]",
         "control the assign secondary black list",
         [this](const std::vector<std::string> &args) {


### PR DESCRIPTION
In command_manager, `command_manager::register_app_command` needs app_name which is get from dsn_runtime. In this pull request, we want to let command_manager decoupled from dsn_runtime, so I delete this function, and use `command_manager::register_command` instead.