### PR TITLE
refactor: make simple logger decoupled from dsn_runtime

### DIFF
--- a/include/dsn/tool-api/logging_provider.h
+++ b/include/dsn/tool-api/logging_provider.h
@@ -39,6 +39,9 @@
 #include <stdarg.h>
 
 namespace dsn {
+namespace tools {
+void set_log_prefixed_message_func(std::function<std::string()> func);
+} // namespace tools
 
 /*!
 @addtogroup tool-api-providers

--- a/include/dsn/tool-api/logging_provider.h
+++ b/include/dsn/tool-api/logging_provider.h
@@ -86,8 +86,6 @@ private:
     static logging_provider *create_default_instance();
 };
 
-namespace tools {
 void set_log_prefixed_message_func(std::function<std::string()> func);
-} // namespace tools
-
+extern std::function<std::string()> log_prefixed_message_func;
 } // namespace dsn

--- a/include/dsn/tool-api/logging_provider.h
+++ b/include/dsn/tool-api/logging_provider.h
@@ -39,10 +39,6 @@
 #include <stdarg.h>
 
 namespace dsn {
-namespace tools {
-void set_log_prefixed_message_func(std::function<std::string()> func);
-} // namespace tools
-
 /*!
 @addtogroup tool-api-providers
 @{
@@ -90,6 +86,8 @@ private:
     static logging_provider *create_default_instance();
 };
 
-/*@}*/
-// ----------------------- inline implementation ---------------------------------------
+namespace tools {
+void set_log_prefixed_message_func(std::function<std::string()> func);
+} // namespace tools
+
 } // namespace dsn

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -50,7 +50,7 @@ static void log_on_sys_exit(::dsn::sys_exit_type)
 
 void dsn_log_init(const std::string &logging_factory_name,
                   const std::string &dir_log,
-                  std::function<std::string()> current_node_name_func)
+                  std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header_func)
 {
     dsn_log_start_level =
         enum_from_string(FLAGS_logging_start_level, dsn_log_level_t::LOG_LEVEL_INVALID);
@@ -100,8 +100,8 @@ void dsn_log_init(const std::string &logging_factory_name,
 
     {
         using dsn::tools;
-        extern std::function<std::string()> node_name_func;
-        node_name_func = current_node_name_func;
+        extern std::function<std::string()> print_header;
+        node_name_func = print_header_func;
     }
 }
 

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -41,10 +41,11 @@ DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system
 
 namespace dsn {
 std::function<std::string()> log_prefixed_message_func = []() {
-    static thread_local std::string prefixed_message(' ', 23);
+    static thread_local std::string prefixed_message;
 
     static thread_local std::once_flag flag;
     std::call_once(flag, [&]() {
+        prefixed_message.resize(23);
         int tid = dsn::utils::get_current_tid();
         sprintf(const_cast<char *>(prefixed_message.c_str()), "unknown.io-thrd.%05d: ", tid);
     });

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -98,8 +98,7 @@ void dsn_log_init(const std::string &logging_factory_name,
             return std::string("OK, current level is ") + enum_to_string(start_level);
         });
 
-    extern std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header;
-    print_header = print_header_func;
+    dsn::tools::set_printf_header_func(print_header_func);
 }
 
 DSN_API dsn_log_level_t dsn_log_get_start_level() { return dsn_log_start_level; }

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -42,8 +42,13 @@ DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system
 namespace dsn {
 std::function<std::string()> log_prefixed_message_func = []() {
     static thread_local std::string prefixed_message(' ', 23);
-    int tid = dsn::utils::get_current_tid();
-    sprintf(const_cast<char *>(prefixed_message.c_str()), "unknown.io-thrd.%05d: ", tid);
+
+    static thread_local std::once_flag flag;
+    std::call_once(flag, [&]() {
+        int tid = dsn::utils::get_current_tid();
+        sprintf(const_cast<char *>(prefixed_message.c_str()), "unknown.io-thrd.%05d: ", tid);
+    });
+
     return prefixed_message;
 };
 

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -41,10 +41,10 @@ DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system
 
 namespace dsn {
 std::function<std::string()> log_prefixed_message_func = []() {
+    static thread_local std::string prefixed_message(' ', 23);
     int tid = dsn::utils::get_current_tid();
-    char res[25];
-    sprintf(res, "unknown.io-thrd.%05d: ", tid);
-    return std::string(res);
+    sprintf(const_cast<char *>(prefixed_message.c_str()), "unknown.io-thrd.%05d: ", tid);
+    return prefixed_message;
 };
 
 void set_log_prefixed_message_func(std::function<std::string()> func)

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -40,13 +40,17 @@ DSN_DEFINE_string("core",
 DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system");
 
 namespace dsn {
-namespace tools {
+std::function<std::string()> log_prefixed_message_func = []() {
+    int tid = dsn::utils::get_current_tid();
+    char res[25];
+    sprintf(res, "unknown.io-thrd.%05d: ", tid);
+    return std::string(res);
+};
+
 void set_log_prefixed_message_func(std::function<std::string()> func)
 {
-    extern std::function<std::string()> log_prefixed_message_func;
     log_prefixed_message_func = func;
 }
-} // namespace tools
 } // namespace dsn
 
 static void log_on_sys_exit(::dsn::sys_exit_type)
@@ -105,7 +109,7 @@ void dsn_log_init(const std::string &logging_factory_name,
             return std::string("OK, current level is ") + enum_to_string(start_level);
         });
 
-    dsn::tools::set_log_prefixed_message_func(dsn_log_prefixed_message_func);
+    dsn::set_log_prefixed_message_func(dsn_log_prefixed_message_func);
 }
 
 DSN_API dsn_log_level_t dsn_log_get_start_level() { return dsn_log_start_level; }

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -39,6 +39,16 @@ DSN_DEFINE_string("core",
 
 DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system");
 
+namespace dsn {
+namespace tools {
+void set_log_prefixed_message_func(std::function<std::string()> func)
+{
+    extern std::function<std::string()> log_prefixed_message_func;
+    log_prefixed_message_func = func;
+}
+} // namespace tools
+} // namespace dsn
+
 static void log_on_sys_exit(::dsn::sys_exit_type)
 {
     dsn::logging_provider *logger = dsn::logging_provider::instance();

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -50,7 +50,7 @@ static void log_on_sys_exit(::dsn::sys_exit_type)
 
 void dsn_log_init(const std::string &logging_factory_name,
                   const std::string &dir_log,
-                  std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header_func)
+                  std::function<std::string()> dsn_log_prefixed_message_func)
 {
     dsn_log_start_level =
         enum_from_string(FLAGS_logging_start_level, dsn_log_level_t::LOG_LEVEL_INVALID);
@@ -98,7 +98,7 @@ void dsn_log_init(const std::string &logging_factory_name,
             return std::string("OK, current level is ") + enum_to_string(start_level);
         });
 
-    dsn::tools::set_printf_header_func(print_header_func);
+    dsn::tools::set_log_prefixed_message_func(dsn_log_prefixed_message_func);
 }
 
 DSN_API dsn_log_level_t dsn_log_get_start_level() { return dsn_log_start_level; }

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -98,11 +98,8 @@ void dsn_log_init(const std::string &logging_factory_name,
             return std::string("OK, current level is ") + enum_to_string(start_level);
         });
 
-    {
-        using dsn::tools;
-        extern std::function<std::string()> print_header;
-        node_name_func = print_header_func;
-    }
+    extern std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header;
+    print_header = print_header_func;
 }
 
 DSN_API dsn_log_level_t dsn_log_get_start_level() { return dsn_log_start_level; }

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -48,7 +48,9 @@ static void log_on_sys_exit(::dsn::sys_exit_type)
     logger->flush();
 }
 
-void dsn_log_init(const std::string &logging_factory_name, const std::string &dir_log)
+void dsn_log_init(const std::string &logging_factory_name,
+                  const std::string &dir_log,
+                  std::function<std::string()> current_node_name_func)
 {
     dsn_log_start_level =
         enum_from_string(FLAGS_logging_start_level, dsn_log_level_t::LOG_LEVEL_INVALID);
@@ -95,6 +97,12 @@ void dsn_log_init(const std::string &logging_factory_name, const std::string &di
             dsn_log_set_start_level(start_level);
             return std::string("OK, current level is ") + enum_to_string(start_level);
         });
+
+    {
+        using dsn::tools;
+        extern std::function<std::string()> node_name_func;
+        node_name_func = current_node_name_func;
+    }
 }
 
 DSN_API dsn_log_level_t dsn_log_get_start_level() { return dsn_log_start_level; }

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -275,7 +275,9 @@ tool_app *get_current_tool() { return dsn_all.tool.get(); }
 } // namespace tools
 } // namespace dsn
 
-extern void dsn_log_init(const std::string &logging_factory_name, const std::string &dir_log);
+extern void dsn_log_init(const std::string &logging_factory_name,
+                         const std::string &dir_log,
+                         std::function<std::string()> current_node_name_func);
 extern void dsn_core_init();
 
 inline void dsn_global_init()
@@ -386,7 +388,7 @@ bool run(const char *config_file,
 #endif
 
     // init logging
-    dsn_log_init(spec.logging_factory_name, spec.dir_log);
+    dsn_log_init(spec.logging_factory_name, spec.dir_log, dsn::task::get_current_node_name);
 
     // prepare minimum necessary
     ::dsn::service_engine::instance().init_before_toollets(spec);

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -291,7 +291,7 @@ inline void dsn_global_init()
     dsn::service_engine::instance();
 }
 
-static const std::string dsn_log_prefixed_message_func()
+static std::string dsn_log_prefixed_message_func()
 {
     char res[100];
 

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -293,20 +293,22 @@ inline void dsn_global_init()
 
 static std::string dsn_log_prefixed_message_func()
 {
-    char res[100];
+    std::string res;
+    res.resize(100);
+    char *prefixed_message = const_cast<char *>(res.c_str());
 
     int tid = dsn::utils::get_current_tid();
     auto t = dsn::task::get_current_task_id();
     if (t) {
         if (nullptr != dsn::task::get_current_worker2()) {
-            sprintf(res,
+            sprintf(prefixed_message,
                     "%6s.%7s%d.%016" PRIx64 ": ",
                     dsn::task::get_current_node_name(),
                     dsn::task::get_current_worker2()->pool_spec().name.c_str(),
                     dsn::task::get_current_worker2()->index(),
                     t);
         } else {
-            sprintf(res,
+            sprintf(prefixed_message,
                     "%6s.%7s.%05d.%016" PRIx64 ": ",
                     dsn::task::get_current_node_name(),
                     "io-thrd",
@@ -315,13 +317,17 @@ static std::string dsn_log_prefixed_message_func()
         }
     } else {
         if (nullptr != dsn::task::get_current_worker2()) {
-            sprintf(res,
+            sprintf(prefixed_message,
                     "%6s.%7s%u: ",
                     dsn::task::get_current_node_name(),
                     dsn::task::get_current_worker2()->pool_spec().name.c_str(),
                     dsn::task::get_current_worker2()->index());
         } else {
-            sprintf(res, "%6s.%7s.%05d: ", dsn::task::get_current_node_name(), "io-thrd", tid);
+            sprintf(prefixed_message,
+                    "%6s.%7s.%05d: ",
+                    dsn::task::get_current_node_name(),
+                    "io-thrd",
+                    tid);
         }
     }
 

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -32,6 +32,8 @@
 #include <dsn/utility/flags.h>
 #include <dsn/tool-api/command_manager.h>
 #include <fstream>
+#include <dsn/utility/time_utils.h>
+
 #ifdef DSN_ENABLE_GPERF
 #include <gperftools/malloc_extension.h>
 #endif
@@ -275,9 +277,10 @@ tool_app *get_current_tool() { return dsn_all.tool.get(); }
 } // namespace tools
 } // namespace dsn
 
-extern void dsn_log_init(const std::string &logging_factory_name,
-                         const std::string &dir_log,
-                         std::function<std::string()> current_node_name_func);
+extern void
+dsn_log_init(const std::string &logging_factory_name,
+             const std::string &dir_log,
+             std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header_func);
 extern void dsn_core_init();
 
 inline void dsn_global_init()
@@ -287,6 +290,51 @@ inline void dsn_global_init()
     // task queues length.
     dsn::perf_counters::instance();
     dsn::service_engine::instance();
+}
+
+static void print_header(FILE *fp, dsn_log_level_t log_level)
+{
+    static char s_level_char[] = "IDWEF";
+
+    uint64_t ts = 0;
+    if (::dsn::tools::is_engine_ready())
+        ts = dsn_now_ns();
+
+    char str[24];
+    ::dsn::utils::time_ms_to_string(ts / 1000000, str);
+
+    int tid = ::dsn::utils::get_current_tid();
+
+    fprintf(fp, "%c%s (%" PRIu64 " %04x) ", s_level_char[log_level], str, ts, tid);
+
+    auto t = dsn::task::get_current_task_id();
+    if (t) {
+        if (nullptr != dsn::task::get_current_worker2()) {
+            fprintf(fp,
+                    "%6s.%7s%d.%016" PRIx64 ": ",
+                    dsn::task::get_current_node_name(),
+                    dsn::task::get_current_worker2()->pool_spec().name.c_str(),
+                    dsn::task::get_current_worker2()->index(),
+                    t);
+        } else {
+            fprintf(fp,
+                    "%6s.%7s.%05d.%016" PRIx64 ": ",
+                    dsn::task::get_current_node_name(),
+                    "io-thrd",
+                    tid,
+                    t);
+        }
+    } else {
+        if (nullptr != dsn::task::get_current_worker2()) {
+            fprintf(fp,
+                    "%6s.%7s%u: ",
+                    dsn::task::get_current_node_name(),
+                    dsn::task::get_current_worker2()->pool_spec().name.c_str(),
+                    dsn::task::get_current_worker2()->index());
+        } else {
+            fprintf(fp, "%6s.%7s.%05d: ", dsn::task::get_current_node_name(), "io-thrd", tid);
+        }
+    }
 }
 
 bool run(const char *config_file,
@@ -388,7 +436,7 @@ bool run(const char *config_file,
 #endif
 
     // init logging
-    dsn_log_init(spec.logging_factory_name, spec.dir_log, dsn::task::get_current_node_name);
+    dsn_log_init(spec.logging_factory_name, spec.dir_log, print_header);
 
     // prepare minimum necessary
     ::dsn::service_engine::instance().init_before_toollets(spec);

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -53,13 +53,6 @@ DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
     return strcmp(level, "LOG_LEVEL_INVALID") != 0;
 });
 
-std::function<std::string()> log_prefixed_message_func = []() {
-    int tid = dsn::utils::get_current_tid();
-    char res[25];
-    sprintf(res, "unknow.io-thrd.%05d: ", tid);
-    return std::string(res);
-};
-
 static void print_header(FILE *fp, dsn_log_level_t log_level)
 {
     static char s_level_char[] = "IDWEF";
@@ -69,7 +62,6 @@ static void print_header(FILE *fp, dsn_log_level_t log_level)
     dsn::utils::time_ms_to_string(ts / 1000000, str);
 
     int tid = dsn::utils::get_current_tid();
-
     fprintf(fp,
             "%c%s (%" PRIu64 " %04x) %s",
             s_level_char[log_level],

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -30,12 +30,6 @@
 #include <dsn/utility/flags.h>
 #include <dsn/utility/time_utils.h>
 
-std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header =
-    [](FILE *fp, dsn_log_level_t log_level) {
-        int tid = ::dsn::utils::get_current_tid();
-        fprintf(fp, "unknow.io-thrd.%05d: ", tid);
-    };
-
 namespace dsn {
 namespace tools {
 
@@ -58,6 +52,18 @@ DSN_DEFINE_string("tools.simple_logger",
 DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
     return strcmp(level, "LOG_LEVEL_INVALID") != 0;
 });
+
+std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header =
+    [](FILE *fp, dsn_log_level_t log_level) {
+        int tid = ::dsn::utils::get_current_tid();
+        fprintf(fp, "unknow.io-thrd.%05d: ", tid);
+    };
+
+void set_printf_header_func(
+    std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header_func)
+{
+    print_header = print_header_func;
+}
 
 screen_logger::screen_logger(bool short_header) : logging_provider("./")
 {

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -30,6 +30,12 @@
 #include <dsn/utility/flags.h>
 #include <dsn/utility/time_utils.h>
 
+std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header =
+    [](FILE *fp, dsn_log_level_t log_level) {
+        int tid = ::dsn::utils::get_current_tid();
+        fprintf(fp, "unknow.io-thrd.%05d: ", tid);
+    };
+
 namespace dsn {
 namespace tools {
 
@@ -52,12 +58,6 @@ DSN_DEFINE_string("tools.simple_logger",
 DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
     return strcmp(level, "LOG_LEVEL_INVALID") != 0;
 });
-
-std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header =
-    [](FILE *fp, dsn_log_level_t log_level) {
-        auto t = task::get_current_task_id();
-        fprintf(fp, "unknow.io-thrd.%05d: ", "io-thrd", tid);
-    };
 
 screen_logger::screen_logger(bool short_header) : logging_provider("./")
 {

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -53,47 +53,11 @@ DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
     return strcmp(level, "LOG_LEVEL_INVALID") != 0;
 });
 
-std::function<std::string()> node_name_func = []() { return "unknown"; };
-
-static void print_header(FILE *fp, dsn_log_level_t log_level)
-{
-    static char s_level_char[] = "IDWEF";
-
-    uint64_t ts = 0;
-    if (::dsn::tools::is_engine_ready())
-        ts = dsn_now_ns();
-
-    char str[24];
-    ::dsn::utils::time_ms_to_string(ts / 1000000, str);
-
-    int tid = ::dsn::utils::get_current_tid();
-
-    fprintf(fp, "%c%s (%" PRIu64 " %04x) ", s_level_char[log_level], str, ts, tid);
-
-    auto t = task::get_current_task_id();
-    if (t) {
-        if (nullptr != task::get_current_worker2()) {
-            fprintf(fp,
-                    "%6s.%7s%d.%016" PRIx64 ": ",
-                    node_name_func(),
-                    task::get_current_worker2()->pool_spec().name.c_str(),
-                    task::get_current_worker2()->index(),
-                    t);
-        } else {
-            fprintf(fp, "%6s.%7s.%05d.%016" PRIx64 ": ", node_name_func(), "io-thrd", tid, t);
-        }
-    } else {
-        if (nullptr != task::get_current_worker2()) {
-            fprintf(fp,
-                    "%6s.%7s%u: ",
-                    node_name_func(),
-                    task::get_current_worker2()->pool_spec().name.c_str(),
-                    task::get_current_worker2()->index());
-        } else {
-            fprintf(fp, "%6s.%7s.%05d: ", node_name_func(), "io-thrd", tid);
-        }
-    }
-}
+std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header =
+    [](FILE *fp, dsn_log_level_t log_level) {
+        auto t = task::get_current_task_id();
+        fprintf(fp, "unknow.io-thrd.%05d: ", "io-thrd", tid);
+    };
 
 screen_logger::screen_logger(bool short_header) : logging_provider("./")
 {

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -53,6 +53,8 @@ DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
     return strcmp(level, "LOG_LEVEL_INVALID") != 0;
 });
 
+std::function<std::string()> node_name_func = []() { return "unknown"; };
+
 static void print_header(FILE *fp, dsn_log_level_t log_level)
 {
     static char s_level_char[] = "IDWEF";
@@ -73,27 +75,22 @@ static void print_header(FILE *fp, dsn_log_level_t log_level)
         if (nullptr != task::get_current_worker2()) {
             fprintf(fp,
                     "%6s.%7s%d.%016" PRIx64 ": ",
-                    task::get_current_node_name(),
+                    node_name_func(),
                     task::get_current_worker2()->pool_spec().name.c_str(),
                     task::get_current_worker2()->index(),
                     t);
         } else {
-            fprintf(fp,
-                    "%6s.%7s.%05d.%016" PRIx64 ": ",
-                    task::get_current_node_name(),
-                    "io-thrd",
-                    tid,
-                    t);
+            fprintf(fp, "%6s.%7s.%05d.%016" PRIx64 ": ", node_name_func(), "io-thrd", tid, t);
         }
     } else {
         if (nullptr != task::get_current_worker2()) {
             fprintf(fp,
                     "%6s.%7s%u: ",
-                    task::get_current_node_name(),
+                    node_name_func(),
                     task::get_current_worker2()->pool_spec().name.c_str(),
                     task::get_current_worker2()->index());
         } else {
-            fprintf(fp, "%6s.%7s.%05d: ", task::get_current_node_name(), "io-thrd", tid);
+            fprintf(fp, "%6s.%7s.%05d: ", node_name_func(), "io-thrd", tid);
         }
     }
 }

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -53,17 +53,12 @@ DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
     return strcmp(level, "LOG_LEVEL_INVALID") != 0;
 });
 
-std::function<const std::string()> log_prefixed_message_func = []() {
-    int tid = ::dsn::utils::get_current_tid();
+std::function<std::string()> log_prefixed_message_func = []() {
+    int tid = dsn::utils::get_current_tid();
     char res[25];
     sprintf(res, "unknow.io-thrd.%05d: ", tid);
     return std::string(res);
 };
-
-void set_log_prefixed_message_func(std::function<const std::string()> func)
-{
-    log_prefixed_message_func = func;
-}
 
 static void print_header(FILE *fp, dsn_log_level_t log_level)
 {

--- a/src/core/tools/common/simple_logger.h
+++ b/src/core/tools/common/simple_logger.h
@@ -33,8 +33,6 @@
 namespace dsn {
 namespace tools {
 
-void set_log_prefixed_message_func(std::function<const std::string()> func);
-
 /*
  * screen_logger provides a logger which writes to terminal.
  */

--- a/src/core/tools/common/simple_logger.h
+++ b/src/core/tools/common/simple_logger.h
@@ -33,6 +33,9 @@
 namespace dsn {
 namespace tools {
 
+void set_printf_header_func(
+    std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header_func);
+
 /*
  * screen_logger provides a logger which writes to terminal.
  */

--- a/src/core/tools/common/simple_logger.h
+++ b/src/core/tools/common/simple_logger.h
@@ -33,8 +33,7 @@
 namespace dsn {
 namespace tools {
 
-void set_printf_header_func(
-    std::function<void(FILE *fp, dsn_log_level_t log_level)> print_header_func);
+void set_log_prefixed_message_func(std::function<const std::string()> func);
 
 /*
  * screen_logger provides a logger which writes to terminal.


### PR DESCRIPTION
In `simple_logger.cpp`, function `print_header` calls `dsn::task::get_current_node_name()` and `dsn::task::get_current_worker2()>pool_spec().name.c_str()`, which are coupled with dsn_runtime.