### PR TITLE
feat(bulk-load): cancel bulk load

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -233,6 +233,9 @@ error_code replica_bulk_loader::do_bulk_load(const std::string &app_name,
     case bulk_load_status::BLS_PAUSING:
         pause_bulk_load();
         break;
+    case bulk_load_status::BLS_CANCELED: {
+        handle_bulk_load_finish(bulk_load_status::BLS_CANCELED);
+    } break;
     // TODO(heyuchen): add other bulk load status
     default:
         break;

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -603,6 +603,7 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
         report_group_ingestion_status(response);
         break;
     case bulk_load_status::BLS_SUCCEED:
+    case bulk_load_status::BLS_CANCELED:
         report_group_cleaned_up(response);
         break;
     case bulk_load_status::BLS_PAUSING:
@@ -793,6 +794,7 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
         bulk_load_state.__set_ingest_status(_replica->_app->get_ingestion_status());
         break;
     case bulk_load_status::BLS_SUCCEED:
+    case bulk_load_status::BLS_CANCELED:
         bulk_load_state.__set_is_cleaned_up(is_cleaned_up());
         break;
     case bulk_load_status::BLS_PAUSING:

--- a/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
@@ -523,9 +523,6 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
     //  istatus, is_ingestion, create_dir will be used in further tests
     // - failed during downloading
     // - failed during ingestion
-    // - cancel during downloaded
-    // - cancel during ingestion
-    // - cancel during succeed
     struct test_struct
     {
         bulk_load_status::type local_status;
@@ -545,7 +542,25 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
                ingestion_status::IS_INVALID,
                false,
                bulk_load_status::BLS_SUCCEED,
-               false}};
+               false},
+              {bulk_load_status::BLS_DOWNLOADED,
+               100,
+               ingestion_status::IS_INVALID,
+               false,
+               bulk_load_status::BLS_CANCELED,
+               true},
+              {bulk_load_status::BLS_INGESTING,
+               100,
+               ingestion_status::type::IS_RUNNING,
+               true,
+               bulk_load_status::BLS_CANCELED,
+               true},
+              {bulk_load_status::BLS_SUCCEED,
+               100,
+               ingestion_status::IS_INVALID,
+               false,
+               bulk_load_status::BLS_CANCELED,
+               true}};
 
     for (auto test : tests) {
         if (test.create_dir) {


### PR DESCRIPTION
This pull request is about cancel bulk load by client.
1. client send cancel/force_cancel request to meta server #514 
2. meta server handle cancel bulk load
    - cancel bulk load is only allowed when current bulk load status is downloading or paused, while force bulk load has no limit, however, force bulk load may lead to consistency problem, some data may have ingested while some data may not (in function `on_control_bulk_load`)
    - update app bulk load status to canceled (in function `update_app_status_on_remote_storage_reply`)
    - update each partition status to canceled, and if old status is paused, should set `should_send_request` = true to resend bulk_load_request, for other status, request will be resent in function `on_partition_bulk_load_reply` #482 
3. replica server receive bulk_load_request during cancel 
    - when replica receive request whose status is canceled, will call function `handle_bulk_load_finish` to cleanup bulk load (in function `do_bulk_load`)
    - secondary reports cleaned up flag to primary (in function `report_bulk_load_states_to_primary`)
    - primary reports group cleaned up flag to meta server (in function `report_bulk_load_states_to_meta`)
4. meta server handle bulk_load_response during cancel
    - handle response in function `on_partition_bulk_load_reply` and call function `handle_bulk_load_finish` #463 
    - the following process is same as bulk load succeed #508 

**_Special explanations_**:
- It is possible for `is_group_bulk_load_context_cleaned_up` is not set in function `handle_bulk_load_finish`, the possible condition:
    - app and partition bulk load status is downloading, meta send request to replica, replica server report download progress to meta server, at this time, bulk load is canceled, app bulk load status has been updated to cancel, meta will call function handle_bulk_load_finish, and is_group_bulk_load_context_cleaned_up flag is not set in this response, meta will do nothing with this response, and resend bulk_load_request to replica

As a result, I update related code in function `handle_bulk_load_finish`.