### PR TITLE
feat(bulk-load): handle bulk load failed and app unavailable

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -233,10 +233,13 @@ error_code replica_bulk_loader::do_bulk_load(const std::string &app_name,
     case bulk_load_status::BLS_PAUSING:
         pause_bulk_load();
         break;
-    case bulk_load_status::BLS_CANCELED: {
+    case bulk_load_status::BLS_CANCELED:
         handle_bulk_load_finish(bulk_load_status::BLS_CANCELED);
-    } break;
-    // TODO(heyuchen): add other bulk load status
+        break;
+    case bulk_load_status::BLS_FAILED:
+        handle_bulk_load_finish(bulk_load_status::BLS_FAILED);
+        // TODO(heyuchen): add perf-counter here
+        break;
     default:
         break;
     }
@@ -604,12 +607,12 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
         break;
     case bulk_load_status::BLS_SUCCEED:
     case bulk_load_status::BLS_CANCELED:
+    case bulk_load_status::BLS_FAILED:
         report_group_cleaned_up(response);
         break;
     case bulk_load_status::BLS_PAUSING:
         report_group_is_paused(response);
         break;
-    // TODO(heyuchen): add other status
     default:
         break;
     }
@@ -795,12 +798,12 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
         break;
     case bulk_load_status::BLS_SUCCEED:
     case bulk_load_status::BLS_CANCELED:
+    case bulk_load_status::BLS_FAILED:
         bulk_load_state.__set_is_cleaned_up(is_cleaned_up());
         break;
     case bulk_load_status::BLS_PAUSING:
         bulk_load_state.__set_is_paused(local_status == bulk_load_status::BLS_PAUSED);
         break;
-    // TODO(heyuchen): add other status
     default:
         break;
     }

--- a/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/dist/replication/lib/bulk_load/test/replica_bulk_loader_test.cpp
@@ -519,10 +519,13 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
     // Test cases
     // - bulk load succeed
     // - double bulk load finish
-    //  TODO(heyuchen): add following cases
-    //  istatus, is_ingestion, create_dir will be used in further tests
+    // - cancel during downloaded
+    // - cancel during ingestion
+    // - cancel during succeed
     // - failed during downloading
     // - failed during ingestion
+    // Tip: bulk load dir will be removed if bulk load finished, so we should create dir before some
+    // cases
     struct test_struct
     {
         bulk_load_status::type local_status;
@@ -560,6 +563,18 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
                ingestion_status::IS_INVALID,
                false,
                bulk_load_status::BLS_CANCELED,
+               true},
+              {bulk_load_status::BLS_DOWNLOADING,
+               10,
+               ingestion_status::IS_INVALID,
+               false,
+               bulk_load_status::BLS_FAILED,
+               true},
+              {bulk_load_status::BLS_INGESTING,
+               100,
+               ingestion_status::type::IS_FAILED,
+               false,
+               bulk_load_status::BLS_FAILED,
                true}};
 
     for (auto test : tests) {

--- a/src/dist/replication/meta_server/meta_bulk_load_service.h
+++ b/src/dist/replication/meta_server/meta_bulk_load_service.h
@@ -334,6 +334,8 @@ private:
         _partitions_bulk_load_state;
 
     std::unordered_map<gpid, bool> _partitions_cleaned_up;
+    // Used for bulk load failed and app unavailable to avoid duplicated clean up
+    std::unordered_map<app_id, bool> _apps_cleaning_up;
 };
 
 } // namespace replication


### PR DESCRIPTION
This pull request is about handle bulk load failed and app unavailable during bulk load.

**bulk load failed**
1. when bulk load meet unrecoverable errors such as file on remote storage is corrupted, bulk load process will be considered as failed, call function `handle_bulk_load_failed`
    - update app bulk load status to failed (in function `update_app_status_on_remote_storage_reply`)
    - update each partition status to failed #482
    - send bulk_load_request to replica server #457 
2. replica server receive bulk_load_request during failed
    - when replica receive request whose status is failed, will call function handle_bulk_load_finish to cleanup bulk load (in function `do_bulk_load`)
    - secondary reports cleaned up flag to primary (in function `report_bulk_load_states_to_primary`)
    - primary reports group cleaned up flag to meta server (in function `report_bulk_load_states_to_meta`)
3. meta server handle bulk_load_response during failed #463 #508 

**app unavailable**
when app is dropped, it will be unavailable, we should handle this situation.
For meta server, call function `handle_app_unavailable`, clean up meta server bulk load context and remove app bulk load directory on remote storage. For replica server, garbage collection will handle dropped partitions, the directory who stores downloaded files is like under partition directory, we don't need remove it specially.