### PR TITLE
feat(bulk-load): replica handle errors during bulk load

### DIFF
--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -183,9 +183,33 @@ void replica_bulk_loader::on_group_bulk_load_reply(error_code err,
 
     _replica->_primary_states.group_bulk_load_pending_replies.erase(req.target_address);
 
-    // TODO(heyuchen): TBD
-    // if error happened, reset secondary bulk_load_state
-    // otherwise, set secondary bulk_load_states from resp
+    if (err != ERR_OK) {
+        derror_replica("failed to receive group_bulk_load_reply from {}, error = {}",
+                       req.target_address.to_string(),
+                       err.to_string());
+        _replica->_primary_states.reset_node_bulk_load_states(req.target_address);
+        return;
+    }
+
+    if (resp.err != ERR_OK) {
+        derror_replica("receive group_bulk_load response from {} failed, error = {}",
+                       req.target_address.to_string(),
+                       resp.err.to_string());
+        _replica->_primary_states.reset_node_bulk_load_states(req.target_address);
+        return;
+    }
+
+    if (req.config.ballot != get_ballot()) {
+        derror_replica("recevied wrong group_bulk_load response from {}, request ballot = {}, "
+                       "current ballot = {}",
+                       req.target_address.to_string(),
+                       req.config.ballot,
+                       get_ballot());
+        _replica->_primary_states.reset_node_bulk_load_states(req.target_address);
+        return;
+    }
+
+    _replica->_primary_states.secondary_bulk_load_states[req.target_address] = resp.bulk_load_state;
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
@@ -484,7 +508,9 @@ void replica_bulk_loader::handle_bulk_load_finish(bulk_load_status::type new_sta
     }
 
     if (status() == partition_status::PS_PRIMARY) {
-        // TODO(heyuchen): cleanup _primary_states.secondary_bulk_load_states
+        for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
+            _replica->_primary_states.reset_node_bulk_load_states(target_address);
+        }
     }
 
     ddebug_replica("bulk load finished, old_status = {}, new_status = {}",
@@ -543,7 +569,7 @@ void replica_bulk_loader::clear_bulk_load_states()
     _replica->_is_bulk_load_ingestion = false;
     _replica->_app->set_ingestion_status(ingestion_status::IS_INVALID);
 
-    // TODO(heyuchen): clear other states
+    // TODO(heyuchen): clear other states for perf-counter
 
     _status = bulk_load_status::BLS_INVALID;
 }

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.cpp
@@ -838,5 +838,16 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
     response.bulk_load_state = bulk_load_state;
 }
 
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type new_status)
+{
+    partition_status::type old_status = status();
+    if ((new_status == partition_status::PS_PRIMARY ||
+         new_status == partition_status::PS_SECONDARY) &&
+        new_status != old_status) {
+        clear_bulk_load_states();
+    }
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
+++ b/src/dist/replication/lib/bulk_load/replica_bulk_loader.h
@@ -88,6 +88,9 @@ private:
     void report_bulk_load_states_to_primary(bulk_load_status::type remote_status,
                                             /*out*/ group_bulk_load_response &response);
 
+    // called by `update_local_configuration` to do possible states cleaning up
+    void clear_bulk_load_states_if_needed(partition_status::type new_status);
+
     ///
     /// bulk load path on remote file provider:
     /// <bulk_load_root>/<cluster_name>/<app_name>/{bulk_load_info}

--- a/src/dist/replication/lib/replica_config.cpp
+++ b/src/dist/replication/lib/replica_config.cpp
@@ -38,6 +38,7 @@
 #include "mutation.h"
 #include "mutation_log.h"
 #include "replica_stub.h"
+#include "bulk_load/replica_bulk_loader.h"
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/dist/replication/replication_app_base.h>
 #include <dsn/utility/fail_point.h>
@@ -772,6 +773,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             break;
         case partition_status::PS_INACTIVE:
             _primary_states.cleanup(old_ballot != config.ballot);
+            _bulk_loader->clear_bulk_load_states();
             // here we use wheather ballot changes and wheather disconnecting with meta to
             // distinguish different case above mentioned
             if (old_ballot == config.ballot && _stub->is_connected()) {
@@ -790,6 +792,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             // upload
             set_backup_context_cancel();
             clear_cold_backup_state();
+            _bulk_loader->clear_bulk_load_states();
             break;
         case partition_status::PS_POTENTIAL_SECONDARY:
             dassert(false, "invalid execution path");
@@ -800,6 +803,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
         break;
     case partition_status::PS_SECONDARY:
         cleanup_preparing_mutations(false);
+        _bulk_loader->clear_bulk_load_states();
         if (config.status != partition_status::PS_SECONDARY) {
             // if primary change the ballot, secondary will update ballot from A to
             // A+1, we don't need clear cold backup context when this case

--- a/src/dist/replication/lib/replica_context.cpp
+++ b/src/dist/replication/lib/replica_context.cpp
@@ -154,6 +154,15 @@ bool primary_context::check_exist(::dsn::rpc_address node, partition_status::typ
     }
 }
 
+void primary_context::reset_node_bulk_load_states(const rpc_address &node)
+{
+    secondary_bulk_load_states[node].__set_download_progress(0);
+    secondary_bulk_load_states[node].__set_download_status(ERR_OK);
+    secondary_bulk_load_states[node].__set_ingest_status(ingestion_status::IS_INVALID);
+    secondary_bulk_load_states[node].__set_is_cleaned_up(false);
+    secondary_bulk_load_states[node].__set_is_paused(false);
+}
+
 void primary_context::cleanup_bulk_load_states()
 {
     secondary_bulk_load_states.erase(secondary_bulk_load_states.begin(),

--- a/src/dist/replication/lib/replica_context.h
+++ b/src/dist/replication/lib/replica_context.h
@@ -97,6 +97,9 @@ public:
 
     void do_cleanup_pending_mutations(bool clean_pending_mutations = true);
 
+    // reset bulk load states in secondary_bulk_load_states by node address
+    void reset_node_bulk_load_states(const rpc_address &node);
+
     void cleanup_bulk_load_states();
 
 public:

--- a/src/dist/replication/test/replica_test/unit_test/mock_utils.h
+++ b/src/dist/replication/test/replica_test/unit_test/mock_utils.h
@@ -147,6 +147,10 @@ public:
     {
         _primary_states.membership = pconfig;
     }
+    partition_bulk_load_state get_secondary_bulk_load_state(const rpc_address &node)
+    {
+        return _primary_states.secondary_bulk_load_states[node];
+    }
     void set_secondary_bulk_load_state(const rpc_address &node,
                                        const partition_bulk_load_state &state)
     {


### PR DESCRIPTION
As previous pull requests shows, bulk load process is like:
1. meta sends bulk load request to primary replica to let primary replica executing bulk load (#457)
2. primary replica broadcasts group_bulk_load_request to secondaries to let secondary replicas executing bulk load (#460)
3. secondary replica reports its bulk_load_state through group_bulk_load_response (#479)
4. primary replica reports group bulk_load_state through bulk_load_response (#479)

This pull request is about how replica handle errors during bulk load process, including two parts:
1. primary meet errors while receiving `group_bulk_load_response`
    - primary stores secondary bulk load state in primary context, when meet errors, primary should reset this secondary's state (in function `on_group_bulk_load_reply` and `reset_node_bulk_load_states`)
2. replica partition status changes during bulk load
    - if primary changes, primary should clean up its primary bulk load states in primary context (#465 #479 #496)
    - if other status switches, bulk load states should also be cleared (in function `update_local_configuration` and `clear_bulk_load_states_if_needed`)