### PR TITLE
feat: update meta_storage to support defining callback function thread pool

### DIFF
--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -150,7 +150,7 @@ error_code meta_service::remote_storage_initialize()
         return err;
     }
     _storage.reset(storage);
-    _meta_storage.reset(new mss::meta_storage(_storage.get(), &_tracker));
+    _meta_storage.reset(new mss::meta_storage(_storage.get(), &_tracker, LPC_META_STATE_HIGH));
 
     std::vector<std::string> slices;
     utils::split_args(_meta_opts.cluster_root.c_str(), slices, '/');

--- a/src/dist/replication/meta_server/meta_state_service_utils.cpp
+++ b/src/dist/replication/meta_server/meta_state_service_utils.cpp
@@ -35,8 +35,10 @@ namespace dsn {
 namespace replication {
 namespace mss {
 
-meta_storage::meta_storage(dist::meta_state_service *remote_storage, task_tracker *tracker)
-    : _remote(remote_storage), _tracker(tracker)
+meta_storage::meta_storage(dist::meta_state_service *remote_storage,
+                           task_tracker *tracker,
+                           task_code callback_code)
+    : _remote(remote_storage), _tracker(tracker), _cb_code(callback_code)
 {
     dassert(tracker != nullptr, "must set task tracker");
 }

--- a/src/dist/replication/meta_server/meta_state_service_utils.h
+++ b/src/dist/replication/meta_server/meta_state_service_utils.h
@@ -35,8 +35,6 @@ namespace mss { // abbreviation of meta_state_service
 /// This class is a convenience wrapper over meta_state_service.
 /// It wraps every operation with a simple error handling mechanism, and provides utilities
 /// like recursive node creation.
-/// Notice: The operations always run in THREAD_POOL_META_STATE: LPC_META_STATE_HIGH.
-///         This class is thread-safe.
 ///
 /// ERROR HANDLING:
 /// Currently it retries for every timeout(ERR_TIMEOUT) operation infinitely,
@@ -46,7 +44,9 @@ namespace mss { // abbreviation of meta_state_service
 /// \see meta_state_service_utils_impl.h # operation
 struct meta_storage
 {
-    meta_storage(dist::meta_state_service *remote_storage, task_tracker *tracker);
+    meta_storage(dist::meta_state_service *remote_storage,
+                 task_tracker *tracker,
+                 task_code callback_code);
 
     ~meta_storage();
 
@@ -81,6 +81,7 @@ private:
 
     dist::meta_state_service *_remote;
     dsn::task_tracker *_tracker;
+    task_code _cb_code;
 };
 
 } // namespace mss

--- a/src/dist/replication/test/meta_test/unit_test/meta_state_service_utils_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/meta_state_service_utils_test.cpp
@@ -44,7 +44,7 @@ struct meta_state_service_utils_test : ::testing::Test
         error_code err = _svc->initialize({});
         ASSERT_EQ(err, ERR_OK);
 
-        _storage = new mss::meta_storage(_svc, &_tracker);
+        _storage = new mss::meta_storage(_svc, &_tracker, LPC_META_STATE_HIGH);
     }
 
     void TearDown() override


### PR DESCRIPTION
`meta_storage` is a utility helpful updating structures on remote storage, the callback function is always executing in thread pool `THREAD_POOL_META_STATE`.
This pull request updates this utility to support defining callback function thread pool.