### PR TITLE
fix: fix compile thrift error in compile_thrift.py

### DIFF
--- a/compile_thrift.py
+++ b/compile_thrift.py
@@ -50,7 +50,7 @@ thrift_description = [
         "path": "src/dist/replication",
         "file_move": {
             "_types.h": "include/dsn/dist/replication",
-            "_types.cpp": "src/dist/replication/common"
+            "_types.cpp": "src/common"
         },
         "include_fix": {
             "_types.h": {


### PR DESCRIPTION
In pr(#550 ), I forget to change the output directory of  `_types.cpp`. It will produce compile thrift error.