### PR TITLE
fix(bulk-load): fix bug while check app bulk load states

### DIFF
--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1668,7 +1668,7 @@ void bulk_load_service::check_app_bulk_load_states(std::shared_ptr<app_state> ap
     std::string app_path = get_app_bulk_load_path(app->app_id);
     _meta_svc->get_remote_storage()->node_exist(
         app_path, LPC_META_CALLBACK, [this, app_path, app, is_app_bulk_loading](error_code err) {
-            if (err != ERR_OK && err != ERR_PATH_NOT_FOUND) {
+            if (err != ERR_OK && err != ERR_OBJECT_NOT_FOUND) {
                 dwarn_f("check app({}) bulk load dir({}) failed, error = {}, try later",
                         app->app_name,
                         app_path,
@@ -1684,7 +1684,7 @@ void bulk_load_service::check_app_bulk_load_states(std::shared_ptr<app_state> ap
                 return;
             }
 
-            if (err == ERR_PATH_NOT_FOUND && is_app_bulk_loading) {
+            if (err == ERR_OBJECT_NOT_FOUND && is_app_bulk_loading) {
                 derror_f("app({}): bulk load dir({}) not exist, but is_bulk_loading = {}, reset "
                          "app is_bulk_loading flag",
                          app->app_name,
@@ -1705,7 +1705,7 @@ void bulk_load_service::check_app_bulk_load_states(std::shared_ptr<app_state> ap
             }
 
             // Normal cases:
-            // err = ERR_PATH_NOT_FOUND, is_app_bulk_load = false: app is not executing bulk load
+            // err = ERR_OBJECT_NOT_FOUND, is_app_bulk_load = false: app is not executing bulk load
             // err = ERR_OK, is_app_bulk_load = true: app used to be executing bulk load
         });
 }

--- a/src/meta/meta_state_service_simple.cpp
+++ b/src/meta/meta_state_service_simple.cpp
@@ -444,8 +444,8 @@ task_ptr meta_state_service_simple::node_exist(const std::string &node,
     error_code err;
     {
         zauto_lock _(_state_lock);
-        err =
-            _quick_map.find(normalize_path(node)) != _quick_map.end() ? ERR_OK : ERR_PATH_NOT_FOUND;
+        err = _quick_map.find(normalize_path(node)) != _quick_map.end() ? ERR_OK
+                                                                        : ERR_OBJECT_NOT_FOUND;
     }
     return tasking::enqueue(cb_code, tracker, [=]() { cb_exist(err); });
 }


### PR DESCRIPTION
For zk `node_exist` interface, if node not exist, it will return error `ERR_OBJECT_NOT_FOUND`, for mock remote storage, it will return error `ERR_PATH_NOT_FOUND`.
In previous implementation, I use `ERR_PATH_NOT_FOUND`, however, we should use `ERR_OBJECT_NOT_FOUND`. This pull request fix this bug and update error code for mock remote storage.