### PR TITLE
fix(bulk-load): fix bug while check_all_partitions

### DIFF
--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -2344,11 +2344,6 @@ bool server_state::check_all_partitions()
                    ::dsn::enum_to_string(app->status));
             continue;
         }
-        if (app->is_bulk_loading) {
-            ddebug_f(
-                "ignore app({})({}) because it's executing bulk load", app->app_name, app->app_id);
-            continue;
-        }
         for (unsigned int i = 0; i != app->partition_count; ++i) {
             partition_configuration &pc = app->partitions[i];
             config_context &cc = app->helpers->contexts[i];


### PR DESCRIPTION
Pull request #571 add a check for load balance, apps who are executing bulk load should not be balanced. However, it raises a bug that the apps who are executing bulk load won't add secondary. This pull request fix this bug.