### PR TITLE
fix(bulk-load): fix bug about concurrent downloading count

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -349,6 +349,7 @@ error_code replica_bulk_loader::start_download(const std::string &app_name,
     _stub->_counter_bulk_load_downloading_count->increment();
 
     // start download
+    _is_downloading = true;
     ddebug_replica("start to download sst files");
     error_code err = download_sst_files(app_name, cluster_name, provider_name);
     if (err != ERR_OK) {
@@ -487,7 +488,11 @@ void replica_bulk_loader::update_bulk_load_download_progress(uint64_t file_size,
 // ThreadPool: THREAD_POOL_REPLICATION, THREAD_POOL_REPLICATION_LONG
 void replica_bulk_loader::try_decrease_bulk_load_download_count()
 {
+    if (!_is_downloading) {
+        return;
+    }
     --_stub->_bulk_load_downloading_count;
+    _is_downloading = false;
     ddebug_replica("node[{}] has {} replica executing downloading",
                    _stub->_primary_address_str,
                    _stub->_bulk_load_downloading_count.load());
@@ -892,9 +897,9 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type new_status)
+void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type old_status,
+                                                           partition_status::type new_status)
 {
-    partition_status::type old_status = status();
     if ((new_status == partition_status::PS_PRIMARY ||
          new_status == partition_status::PS_SECONDARY) &&
         new_status != old_status) {

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -349,7 +349,7 @@ error_code replica_bulk_loader::start_download(const std::string &app_name,
     _stub->_counter_bulk_load_downloading_count->increment();
 
     // start download
-    _is_downloading = true;
+    _is_downloading.store(true);
     ddebug_replica("start to download sst files");
     error_code err = download_sst_files(app_name, cluster_name, provider_name);
     if (err != ERR_OK) {
@@ -488,11 +488,11 @@ void replica_bulk_loader::update_bulk_load_download_progress(uint64_t file_size,
 // ThreadPool: THREAD_POOL_REPLICATION, THREAD_POOL_REPLICATION_LONG
 void replica_bulk_loader::try_decrease_bulk_load_download_count()
 {
-    if (!_is_downloading) {
+    if (!_is_downloading.load()) {
         return;
     }
     --_stub->_bulk_load_downloading_count;
-    _is_downloading = false;
+    _is_downloading.store(false);
     ddebug_replica("node[{}] has {} replica executing downloading",
                    _stub->_primary_address_str,
                    _stub->_bulk_load_downloading_count.load());

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -897,9 +897,9 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type old_status,
-                                                           partition_status::type new_status)
+void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type new_status)
 {
+    partition_status::type old_status = status();
     if ((new_status == partition_status::PS_PRIMARY ||
          new_status == partition_status::PS_SECONDARY) &&
         new_status != old_status) {

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -89,8 +89,7 @@ private:
                                             /*out*/ group_bulk_load_response &response);
 
     // called by `update_local_configuration` to do possible states cleaning up
-    void clear_bulk_load_states_if_needed(partition_status::type old_status,
-                                          partition_status::type new_status);
+    void clear_bulk_load_states_if_needed(partition_status::type new_status);
 
     ///
     /// bulk load path on remote file provider:

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -89,7 +89,8 @@ private:
                                             /*out*/ group_bulk_load_response &response);
 
     // called by `update_local_configuration` to do possible states cleaning up
-    void clear_bulk_load_states_if_needed(partition_status::type new_status);
+    void clear_bulk_load_states_if_needed(partition_status::type old_status,
+                                          partition_status::type new_status);
 
     ///
     /// bulk load path on remote file provider:
@@ -141,6 +142,7 @@ private:
 
     bulk_load_status::type _status{bulk_load_status::BLS_INVALID};
     bulk_load_metadata _metadata;
+    std::atomic<bool> _is_downloading{false};
     std::atomic<uint64_t> _cur_downloaded_size{0};
     std::atomic<int32_t> _download_progress{0};
     std::atomic<error_code> _download_status{ERR_OK};

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -74,6 +74,7 @@ public:
 
     void test_update_download_progress(uint64_t file_size)
     {
+        _bulk_loader->_is_downloading = true;
         _bulk_loader->update_bulk_load_download_progress(file_size, "test_file_name");
         _bulk_loader->tracker()->wait_outstanding_tasks();
     }
@@ -91,9 +92,10 @@ public:
         _bulk_loader->handle_bulk_load_finish(req_status);
     }
 
-    void test_pause_bulk_load(bulk_load_status::type status, int32_t progress)
+    void test_pause_bulk_load(bulk_load_status::type status, int32_t progress, bool is_downloading)
     {
-        mock_replica_bulk_load_varieties(status, progress, ingestion_status::IS_INVALID);
+        mock_replica_bulk_load_varieties(
+            status, progress, ingestion_status::IS_INVALID, false, is_downloading);
         _bulk_loader->pause_bulk_load();
     }
 
@@ -289,10 +291,12 @@ public:
     void mock_replica_bulk_load_varieties(bulk_load_status::type status,
                                           int32_t download_progress,
                                           ingestion_status::type istatus,
-                                          bool is_ingestion = false)
+                                          bool is_ingestion = false,
+                                          bool is_downloading = false)
     {
         _bulk_loader->_status = status;
         _bulk_loader->_download_progress = download_progress;
+        _bulk_loader->_is_downloading = is_downloading;
         _replica->set_is_ingestion(is_ingestion);
         _replica->set_ingestion_status(istatus);
     }
@@ -639,6 +643,7 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
 // pause_bulk_load unit tests
 TEST_F(replica_bulk_loader_test, pause_bulk_load_test)
 {
+    const int32_t stub_downloading_count = 3;
     // Test cases:
     // pausing while not bulk load
     // pausing during downloading
@@ -647,17 +652,22 @@ TEST_F(replica_bulk_loader_test, pause_bulk_load_test)
     {
         bulk_load_status::type status;
         int32_t progress;
+        bool is_downloading;
         int32_t expected_progress;
+        int32_t expected_downloading_count;
     } tests[]{
-        {bulk_load_status::BLS_INVALID, 0, 0},
-        {bulk_load_status::BLS_DOWNLOADING, 10, 10},
-        {bulk_load_status::BLS_DOWNLOADED, 100, 100},
+        {bulk_load_status::BLS_INVALID, 0, false, 0, stub_downloading_count},
+        {bulk_load_status::BLS_DOWNLOADING, 10, true, 10, stub_downloading_count - 1},
+        {bulk_load_status::BLS_DOWNLOADING, 0, false, 0, stub_downloading_count},
+        {bulk_load_status::BLS_DOWNLOADED, 100, false, 100, stub_downloading_count},
     };
 
     for (auto test : tests) {
-        test_pause_bulk_load(test.status, test.progress);
+        stub->set_bulk_load_downloading_count(stub_downloading_count);
+        test_pause_bulk_load(test.status, test.progress, test.is_downloading);
         ASSERT_EQ(get_bulk_load_status(), bulk_load_status::BLS_PAUSED);
         ASSERT_EQ(get_download_progress(), test.expected_progress);
+        ASSERT_EQ(stub->get_bulk_load_downloading_count(), test.expected_downloading_count);
     }
 }
 

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -74,7 +74,7 @@ public:
 
     void test_update_download_progress(uint64_t file_size)
     {
-        _bulk_loader->_is_downloading = true;
+        _bulk_loader->_is_downloading.store(true);
         _bulk_loader->update_bulk_load_download_progress(file_size, "test_file_name");
         _bulk_loader->tracker()->wait_outstanding_tasks();
     }
@@ -296,7 +296,7 @@ public:
     {
         _bulk_loader->_status = status;
         _bulk_loader->_download_progress = download_progress;
-        _bulk_loader->_is_downloading = is_downloading;
+        _bulk_loader->_is_downloading.store(is_downloading);
         _replica->set_is_ingestion(is_ingestion);
         _replica->set_ingestion_status(istatus);
     }

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -750,7 +750,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             max_prepared_decree(),
             last_committed_decree());
 
-    _bulk_loader->clear_bulk_load_states_if_needed(old_status, config.status);
+    _bulk_loader->clear_bulk_load_states_if_needed(config.status);
 
     // Notice: there has five ways that primary can change its partition_status
     //   1, primary change partition config, such as add/remove secondary

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -750,7 +750,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             max_prepared_decree(),
             last_committed_decree());
 
-    _bulk_loader->clear_bulk_load_states_if_needed(config.status);
+    _bulk_loader->clear_bulk_load_states_if_needed(old_status, config.status);
 
     // Notice: there has five ways that primary can change its partition_status
     //   1, primary change partition config, such as add/remove secondary


### PR DESCRIPTION
This pull request fix the bug about concurrent bulk load downloading replica count.
The bug will be raised when bulk load failed or paused. In previous implementation, when bulk load failed or paused, if original status is downloading, we will decrease this count. However, the partition may be not doing exact downloading. For example, the max count is 5, this stub already have 5 partitions executing downloading, besides there are 8 partitions waiting for downloading, one of them meet unrecoverable error so the whole bulk load process failed, all 13 partition will try to decrease the count, which leads to wrong count -8.
To fix this bug, this pull request adds a `is_downloading` variety, only the partition who is executing downloading will decrease this count. Besides, this pull request adds unit test for this condition.