### PR TITLE
fix(bulk_load): fix bug of clear_bulk_load_states_if_needed

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -892,9 +892,9 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type new_status)
+void replica_bulk_loader::clear_bulk_load_states_if_needed(partition_status::type old_status,
+                                                           partition_status::type new_status)
 {
-    partition_status::type old_status = status();
     if ((new_status == partition_status::PS_PRIMARY ||
          new_status == partition_status::PS_SECONDARY) &&
         new_status != old_status) {

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -89,7 +89,8 @@ private:
                                             /*out*/ group_bulk_load_response &response);
 
     // called by `update_local_configuration` to do possible states cleaning up
-    void clear_bulk_load_states_if_needed(partition_status::type new_status);
+    void clear_bulk_load_states_if_needed(partition_status::type old_status,
+                                          partition_status::type new_status);
 
     ///
     /// bulk load path on remote file provider:

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -750,7 +750,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             max_prepared_decree(),
             last_committed_decree());
 
-    _bulk_loader->clear_bulk_load_states_if_needed(config.status);
+    _bulk_loader->clear_bulk_load_states_if_needed(old_status, config.status);
 
     // Notice: there has five ways that primary can change its partition_status
     //   1, primary change partition config, such as add/remove secondary


### PR DESCRIPTION
This pull request fix the bug about function `clear_bulk_load_states_if_needed`, it will be called by `update_local_configuration` when replica configuration changed. This function will compare current partition status and new_status in new configuration, if new_status is primary or secondary and current status is not two status, will clear bulk load states. However, when this function is called, the current status has already be updated to new_status, `status()` will always be equal to `new_status`, which will lead bulk load states not cleaned up in this condition.
To fix this bug, this pull request adds another parameter `old_status` for this function, which is the real partition status before updating configuration.
