### PR TITLE
fix(bulk-load): fix bug during ingestion

### DIFF
--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1019,6 +1019,14 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
                                                      const std::string &app_name,
                                                      const gpid &pid)
 {
+    if (err == ERR_NO_NEED_OPERATE) {
+        dwarn_f(
+            "app({}) partition({}) has already executing ingestion, ignore this repeated request",
+            app_name,
+            pid);
+        return;
+    }
+
     // if meet 2pc error, ingesting will rollback to downloading, no need to retry here
     if (err != ERR_OK) {
         derror_f("app({}) partition({}) ingestion files failed, error = {}", app_name, pid, err);

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -695,6 +695,20 @@ TEST_F(bulk_load_process_test, ingest_rpc_error)
     ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_DOWNLOADING);
 }
 
+TEST_F(bulk_load_process_test, repeated_ingest_rpc)
+{
+    mock_ingestion_context(ERR_OK, 1, _partition_count);
+    test_on_partition_ingestion_reply(_ingestion_resp, gpid(_app_id, _pidx), ERR_NO_NEED_OPERATE);
+    ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_INGESTING);
+}
+
+TEST_F(bulk_load_process_test, ingest_wrong_state)
+{
+    mock_ingestion_context(ERR_OK, 1, _partition_count);
+    test_on_partition_ingestion_reply(_ingestion_resp, gpid(_app_id, _pidx), ERR_INVALID_STATE);
+    ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_DOWNLOADING);
+}
+
 TEST_F(bulk_load_process_test, ingest_empty_write_error)
 {
     fail::cfg("meta_bulk_load_partition_ingestion", "return()");


### PR DESCRIPTION
This pull request fixs the bug of bulk load ingestion.
In previous implementation, when replica is executing ingestion request, it will reject normal write request by returning `ERR_OPERATION_DISABLED`. When replica received repeated ingestion request, it will also return `ERR_OPERATION_DISABLED`, meta will rollback to downloading if receiving a response with this error code. However, meta needn't to rollback to downloading, it should just wait for this ingestion. This pull request separates those different case. When replica is executing ingestion request, if it receives normal write request, it will still return `ERR_OPERATION_DISABLED` to user client, if it receives repeated ingestion request, it will return `ERR_NO_NEED_OPERATE` to meta server, meta server will ignore this repeated request. Besides, this pull request also adds bulk load status check while receiving ingestion request, if it is invalid, it will return `ERR_INVALID_STATE` to meta server.