### PR TITLE
feat: add remote command for fds read batch size

### DIFF
--- a/include/dsn/utility/string_conv.h
+++ b/include/dsn/utility/string_conv.h
@@ -111,6 +111,11 @@ inline bool buf2int32(string_view buf, int32_t &result)
     return internal::buf2signed(buf, result);
 }
 
+inline bool buf2uint32(string_view buf, uint32_t &result)
+{
+    return internal::buf2unsigned(buf, result);
+}
+
 inline bool buf2int64(string_view buf, int64_t &result)
 {
     return internal::buf2signed(buf, result);

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -101,7 +101,7 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
     task_tracker tracker;
 
     auto download_file_callback_func = [&download_err, &download_file_size](
-            const download_response &resp, block_file_ptr bf, const std::string &local_file_name) {
+        const download_response &resp, block_file_ptr bf, const std::string &local_file_name) {
         if (resp.err != ERR_OK) {
             // during bulk load process, ERR_OBJECT_NOT_FOUND will be considered as a recoverable
             // error, however, if file damaged on remote file provider, bulk load should stop,

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -252,7 +252,7 @@ std::string block_service_manager::set_read_batch_size(const std::vector<std::st
 
     uint32_t value = 0;
     if (!dsn::buf2uint32(args[0], value) || value < 0) {
-        return "invalid arguments of " + args[0];
+        return "invalid argument of " + args[0];
     }
 
     FLAGS_fds_read_batch_size = value;

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -100,10 +100,8 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
     error_code download_err = ERR_OK;
     task_tracker tracker;
 
-    auto download_file_callback_func = [&download_err,
-                                        &download_file_size](const download_response &resp,
-                                                             block_file_ptr bf,
-                                                             const std::string &local_file_name) {
+    auto download_file_callback_func = [&download_err, &download_file_size](
+            const download_response &resp, block_file_ptr bf, const std::string &local_file_name) {
         if (resp.err != ERR_OK) {
             // during bulk load process, ERR_OBJECT_NOT_FOUND will be considered as a recoverable
             // error, however, if file damaged on remote file provider, bulk load should stop,

--- a/src/block_service/block_service_manager.h
+++ b/src/block_service/block_service_manager.h
@@ -26,6 +26,7 @@ class block_service_manager
 {
 public:
     block_service_manager();
+    ~block_service_manager();
     block_filesystem *get_block_filesystem(const std::string &provider);
 
     // download files from remote file system
@@ -40,10 +41,18 @@ public:
                              /*out*/ uint64_t &download_file_size);
 
 private:
+    void register_ctrl_commands();
+    void unregister_ctrl_commands();
+    std::string set_read_batch_size(const std::vector<std::string> &args);
+    std::string get_read_batch_size(const std::vector<std::string> &args);
+
+private:
     block_service_registry &_registry_holder;
 
     mutable zrwlock_nr _fs_lock;
     std::map<std::string, std::unique_ptr<block_filesystem>> _fs_map;
+    dsn_handle_t _set_fds_read_batch_size = nullptr;
+    dsn_handle_t _get_fds_read_batch_size = nullptr;
 
     friend class block_service_manager_mock;
 };

--- a/src/block_service/fds/fds_service.cpp
+++ b/src/block_service/fds/fds_service.cpp
@@ -22,6 +22,7 @@
 #include <dsn/utility/TokenBucket.h>
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/flags.h>
+#include <dsn/tool-api/command_manager.h>
 
 namespace dsn {
 namespace dist {
@@ -137,9 +138,50 @@ fds_service::fds_service()
     _write_token_bucket.reset(new folly::TokenBucket(FLAGS_fds_write_limit_rate << 20, burst_size));
     burst_size = 2 * FLAGS_fds_read_limit_rate << 20;
     _read_token_bucket.reset(new folly::TokenBucket(FLAGS_fds_read_limit_rate << 20, burst_size));
+
+    register_ctrl_commands();
 }
 
-fds_service::~fds_service() {}
+fds_service::~fds_service() { unregister_ctrl_commands(); }
+
+void fds_service::register_ctrl_commands()
+{
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        _set_fds_rate_limit = command_manager::instance().register_command(
+            {"fds.set_rate_limit"},
+            "fds.set_rate_limit",
+            "set rate limit of fds. w: write limit rate. r: read limit rate. b: batch size",
+            [this](const std::vector<std::string> &args) { return set_rate_limit(args); });
+    });
+}
+
+void fds_service::unregister_ctrl_commands() { UNREGISTER_VALID_HANDLER(_set_fds_rate_limit); }
+
+std::string fds_service::set_rate_limit(const std::vector<std::string> &args)
+{
+    if (args.size() % 2 != 0) {
+        return "invalid argument count";
+    }
+
+    for (int i = 0; i < args.size(); i += 2) {
+        uint32_t value = 0;
+        if (!dsn::buf2uint32(args[i + 1], value) || value < 0) {
+            return "invalid arguments of " + args[i + 1];
+        }
+
+        if ("w" == args[i]) {
+            FLAGS_fds_write_limit_rate = value;
+        } else if ("r" == args[i]) {
+            FLAGS_fds_read_limit_rate = value;
+        } else if ("b" == args[i]) {
+            FLAGS_fds_read_batch_size = value;
+        } else {
+            return "invalid argument of " + args[i];
+        }
+    }
+    return "ok";
+}
 
 /**
  * @brief fds_service::initialize

--- a/src/block_service/fds/fds_service.cpp
+++ b/src/block_service/fds/fds_service.cpp
@@ -22,7 +22,6 @@
 #include <dsn/utility/TokenBucket.h>
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/flags.h>
-#include <dsn/tool-api/command_manager.h>
 
 namespace dsn {
 namespace dist {

--- a/src/block_service/fds/fds_service.h
+++ b/src/block_service/fds/fds_service.h
@@ -33,9 +33,6 @@ public:
 
     galaxy::fds::GalaxyFDSClient *get_client() { return _client.get(); }
     const std::string &get_bucket_name() { return _bucket_name; }
-    void register_ctrl_commands();
-    void unregister_ctrl_commands();
-    std::string set_rate_limit(const std::vector<std::string> &args);
     virtual error_code initialize(const std::vector<std::string> &args) override;
     virtual dsn::task_ptr list_dir(const ls_request &req,
                                    dsn::task_code code,
@@ -76,7 +73,6 @@ private:
     std::string _bucket_name;
     std::unique_ptr<folly::TokenBucket> _read_token_bucket;
     std::unique_ptr<folly::TokenBucket> _write_token_bucket;
-    dsn_handle_t _set_fds_rate_limit = nullptr;
 
     friend class fds_file_object;
 };
@@ -134,6 +130,7 @@ private:
     std::string _md5sum;
     uint64_t _size;
     bool _has_meta_synced;
+    dsn_handle_t _set_fds_rate_limit = nullptr;
 
     static const size_t PIECE_SIZE = 16384; // 16k
 };

--- a/src/block_service/fds/fds_service.h
+++ b/src/block_service/fds/fds_service.h
@@ -8,13 +8,13 @@ template <typename Clock>
 class BasicTokenBucket;
 
 using TokenBucket = BasicTokenBucket<std::chrono::steady_clock>;
-}
+} // namespace folly
 
 namespace galaxy {
 namespace fds {
 class GalaxyFDSClient;
 }
-}
+} // namespace galaxy
 
 namespace dsn {
 namespace dist {
@@ -29,10 +29,13 @@ public:
 
 public:
     fds_service();
+    virtual ~fds_service() override;
+
     galaxy::fds::GalaxyFDSClient *get_client() { return _client.get(); }
     const std::string &get_bucket_name() { return _bucket_name; }
-
-    virtual ~fds_service() override;
+    void register_ctrl_commands();
+    void unregister_ctrl_commands();
+    std::string set_rate_limit(const std::vector<std::string> &args);
     virtual error_code initialize(const std::vector<std::string> &args) override;
     virtual dsn::task_ptr list_dir(const ls_request &req,
                                    dsn::task_code code,
@@ -73,6 +76,7 @@ private:
     std::string _bucket_name;
     std::unique_ptr<folly::TokenBucket> _read_token_bucket;
     std::unique_ptr<folly::TokenBucket> _write_token_bucket;
+    dsn_handle_t _set_fds_rate_limit = nullptr;
 
     friend class fds_file_object;
 };
@@ -133,7 +137,7 @@ private:
 
     static const size_t PIECE_SIZE = 16384; // 16k
 };
-}
-}
-}
+} // namespace block_service
+} // namespace dist
+} // namespace dsn
 #endif // FDS_SERVICE_H


### PR DESCRIPTION
Add remote command to get/change fds read batch size.
1. We must add the remote command in `block_service_manager` but not `fds_service`. Because `fds_service` is not created when the server is bootstrap. So if we register remote command in `fds_service`, these commands will not registered when the `fds_service` is not create.

2. We can't add remote command to change the rate limit of `token_bucket`. Because if we change the config of rate limit, we should change the it in `token_bucket` synchronously. But the corresponding interface is not thread safe.