### PR TITLE
feat(http): support parsing content-type of HTTP request

### DIFF
--- a/src/http/http_message_parser.h
+++ b/src/http/http_message_parser.h
@@ -47,6 +47,7 @@ DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_HTTP)
 //    msg->buffers[0] = header
 //    msg->buffers[1] = body
 //    msg->buffers[2] = url
+//    msg->buffers[3] = content-type
 //
 
 enum http_parser_stage
@@ -90,6 +91,7 @@ private:
     http_parser_settings _parser_setting;
     http_parser _parser;
 
+    bool _is_field_content_type{false};
     std::unique_ptr<message_ex> _current_message;
     http_parser_stage _stage{HTTP_INVALID};
     std::string _url;

--- a/src/http/test/http_server_test.cpp
+++ b/src/http/test/http_server_test.cpp
@@ -125,7 +125,7 @@ public:
             ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
             ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
             ASSERT_EQ(msg->header->context.u.is_request, 1);
-            ASSERT_EQ(msg->buffers.size(), 3);
+            ASSERT_EQ(msg->buffers.size(), 4);
             ASSERT_EQ(msg->buffers[2].size(), 1); // url
 
             // ensure states are reset
@@ -167,11 +167,12 @@ TEST_F(http_message_parser_test, parse_request)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_POST);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), 3);
+    ASSERT_EQ(msg->buffers.size(), 4);
     ASSERT_EQ(msg->buffers[1].to_string(), "Message Body sdfsdf"); // body
     ASSERT_EQ(                                                     // url
         msg->buffers[2].to_string(),
         std::string("/path/file.html?sdfsdf=sdfs&sldf1=sdf"));
+    ASSERT_EQ(msg->buffers[3].to_string(), std::string("json"));
 }
 
 TEST_F(http_message_parser_test, eof)
@@ -217,7 +218,7 @@ TEST_F(http_message_parser_test, eof)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), 3);
+    ASSERT_EQ(msg->buffers.size(), 4);
     ASSERT_EQ(msg->buffers[1].to_string(), ""); // body
     ASSERT_EQ(                                  // url
         msg->buffers[2].to_string(),
@@ -225,6 +226,7 @@ TEST_F(http_message_parser_test, eof)
                     "weather?location=%E6%B5%B7%E5%8D%97%E7%9C%81%E7%9B%B4%E8%BE%96%E5%8E%BF%E7%BA%"
                     "A7%E8%A1%8C%"
                     "E6%94%BF%E5%8D%95%E4%BD%8D&output=json&ak=0l3FSP6qA0WbOzGRaafbmczS"));
+    ASSERT_EQ(msg->buffers[3].to_string(), std::string("application/json;charset=utf8"));
 }
 
 TEST_F(http_message_parser_test, parse_bad_request) { parse_bad_request(); }
@@ -247,7 +249,7 @@ TEST_F(http_message_parser_test, parse_long_url)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), 3);
+    ASSERT_EQ(msg->buffers.size(), 4);
     ASSERT_EQ(msg->buffers[2].size(), 4097); // url
 }
 


### PR DESCRIPTION
rDSN `http_server` currently ignores entirely the HTTP body, headers, except for URL query-params. Therefore, only URL could be used for the HTTP-client to send arguments.

```sh
127.0.0.1/meta/app_envs?name=<app_name> # we can only use query-params as the request's arguments
```

In order to support serving HTTP post-form ("application/x-www-form-urlencoded")  requests, our HTTP server must be able to parse "Content-Type" field in the HTTP header.

```sh
~ $ http --form -v POST httpbin.org/post hello=world
POST /post HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 11
Content-Type: application/x-www-form-urlencoded; charset=utf-8 # post-form 
Host: httpbin.org
User-Agent: HTTPie/2.1.0
```

So in this PR, I add support to parse "Content-Type" in rdsn `http_message_parser`. The result will be inside `msg->buffers[3]`.
