### PR TITLE
refactor: make server_state to be a singleton

### DIFF
--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -78,7 +78,7 @@ public:
     dist::meta_state_service *get_remote_storage() const { return _storage.get(); }
     mss::meta_storage *get_meta_storage() const { return _meta_storage.get(); }
 
-    server_state *get_server_state() { return _state.get(); }
+    server_state *get_server_state() { return _state; }
     server_load_balancer *get_balancer() { return _balancer.get(); }
     dist::block_service::block_service_manager &get_block_service_manager()
     {
@@ -211,7 +211,7 @@ private:
     uint64_t _node_live_percentage_threshold_for_update;
     dsn_handle_t _ctrl_node_live_percentage_threshold_for_update = nullptr;
 
-    std::shared_ptr<server_state> _state;
+    server_state *_state;
     std::shared_ptr<meta_server_failure_detector> _failure_detector;
 
     std::shared_ptr<dist::meta_state_service> _storage;

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -106,13 +106,12 @@ class meta_service;
 // D. thread-model of meta server
 // E. load balancer
 
-class server_state
+class server_state : public utils::singleton<server_state>
 {
 public:
     static const int sStateHash = 0;
 
 public:
-    server_state();
     ~server_state();
 
     void initialize(meta_service *meta_svc, const std::string &apps_root);
@@ -186,6 +185,8 @@ public:
     void wait_all_task() { _tracker.wait_outstanding_tasks(); }
 
 private:
+    server_state();
+
     //-1 means waiting forever
     bool spin_wait_staging(int timeout_seconds = -1);
     bool can_run_balancer();
@@ -301,6 +302,7 @@ private:
     friend class meta_split_service;
     friend class bulk_load_service;
     friend class bulk_load_service_test;
+    friend class utils::singleton<server_state>;
 
     dsn::task_tracker _tracker;
 

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -192,6 +192,7 @@ void meta_service_test_app::policy_context_test()
     dsn::error_code ec = s->remote_storage_initialize();
     ASSERT_EQ(ec, dsn::ERR_OK);
     server_state *state = s->_state;
+    state->_all_apps.clear();
     s->_started = true;
     s->_backup_handler = std::make_shared<backup_service>(s.get(), policy_root, ".", nullptr);
     s->_backup_handler->backup_option().app_dropped_retry_delay_ms = 500_ms;
@@ -639,6 +640,7 @@ void meta_service_test_app::backup_service_test()
 {
     std::shared_ptr<meta_service> meta_svc = std::make_shared<fake_receiver_meta_service>();
     meta_options &opt = meta_svc->_meta_opts;
+    meta_svc->_state->_all_apps.clear();
     opt.cluster_root = "/meta_test";
     opt.meta_state_service_type = "meta_state_service_simple";
     meta_svc->remote_storage_initialize();

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -191,7 +191,7 @@ void meta_service_test_app::policy_context_test()
     std::shared_ptr<meta_service> s = std::make_shared<progress_liar>();
     dsn::error_code ec = s->remote_storage_initialize();
     ASSERT_EQ(ec, dsn::ERR_OK);
-    server_state *state = s->_state.get();
+    server_state *state = s->_state;
     s->_started = true;
     s->_backup_handler = std::make_shared<backup_service>(s.get(), policy_root, ".", nullptr);
     s->_backup_handler->backup_option().app_dropped_retry_delay_ms = 500_ms;

--- a/src/meta/test/data_definition_test.cpp
+++ b/src/meta/test/data_definition_test.cpp
@@ -44,7 +44,7 @@ void meta_service_test_app::data_definition_op_test()
 
     svc->_balancer.reset(new simple_load_balancer(svc.get()));
     svc->_failure_detector.reset(new meta_server_failure_detector(svc.get()));
-    server_state *state = svc->_state.get();
+    server_state *state = svc->_state;
 
     state->initialize(svc.get(), svc->_cluster_root + "/apps");
     ec = state->initialize_data_structure();

--- a/src/meta/test/meta_load_balance_test.cpp
+++ b/src/meta/test/meta_load_balance_test.cpp
@@ -84,8 +84,7 @@ public:
         dsn::tasking::enqueue(
             LPC_META_STATE_HIGH,
             nullptr,
-            std::bind(
-                &server_state::on_update_configuration, svc->_state.get(), request, fake_request),
+            std::bind(&server_state::on_update_configuration, svc->_state, request, fake_request),
             server_state::sStateHash);
     }
 };
@@ -130,7 +129,7 @@ void meta_load_balance_test::simple_lb_cure_test()
     ASSERT_EQ(ec, dsn::ERR_OK);
     svc->_balancer.reset(new simple_load_balancer(svc.get()));
 
-    server_state *state = svc->_state.get();
+    server_state *state = svc->_state;
     state->initialize(svc.get(), meta_options::concat_path_unix_style(svc->_cluster_root, "apps"));
     dsn::app_info info;
     info.is_stateful = true;

--- a/src/meta/test/meta_load_balance_test.cpp
+++ b/src/meta/test/meta_load_balance_test.cpp
@@ -121,6 +121,7 @@ void meta_load_balance_test::simple_lb_cure_test()
     dsn::error_code ec;
     dsn::task_ptr t;
     std::shared_ptr<message_filter> svc(new message_filter(this));
+    svc->_state->_all_apps.clear();
     svc->_failure_detector.reset(new dsn::replication::meta_server_failure_detector(svc.get()));
     bool proposal_sent;
     dsn::rpc_address last_addr;
@@ -700,6 +701,8 @@ void meta_load_balance_test::simple_lb_cure_test()
     t->wait();
     PROPOSAL_FLAG_CHECK;
     CONDITION_CHECK([&] { return pc.primary == nodes[0]; });
+
+    state->_all_apps.clear();
 }
 
 static void check_nodes_loads(node_mapper &nodes)

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -63,7 +63,7 @@ void meta_test_base::TearDown()
         delete_all_on_meta_storage();
     }
 
-    _ss.reset();
+    _ss = nullptr;
     _ms.reset(nullptr);
 }
 
@@ -94,7 +94,7 @@ void meta_test_base::create_app(const std::string &name, uint32_t partition_coun
     req.options.is_stateful = true;
     req.options.envs["value_version"] = "1";
 
-    auto result = fake_create_app(_ss.get(), req);
+    auto result = fake_create_app(_ss, req);
     fake_wait_rpc(result, resp);
     ASSERT_EQ(resp.err, ERR_OK) << resp.err.to_string() << " " << name;
 
@@ -110,7 +110,7 @@ void meta_test_base::drop_app(const std::string &name)
     req.app_name = name;
     req.options.success_if_not_exist = false;
 
-    auto result = fake_drop_app(_ss.get(), req);
+    auto result = fake_drop_app(_ss, req);
     fake_wait_rpc(result, resp);
     ASSERT_EQ(resp.err, ERR_OK) << resp.err.to_string() << " " << name;
 

--- a/src/meta/test/meta_test_base.h
+++ b/src/meta/test/meta_test_base.h
@@ -54,7 +54,7 @@ public:
 
     bulk_load_service &bulk_svc();
 
-    std::shared_ptr<server_state> _ss;
+    server_state *_ss;
     std::unique_ptr<meta_service> _ms;
     std::string _app_root;
 };

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -59,6 +59,7 @@ void meta_service_test_app::app_envs_basic_test()
     // create meta_service
     std::shared_ptr<meta_service> meta_svc = std::make_shared<meta_service>();
     meta_service *svc = meta_svc.get();
+    svc->_state->_all_apps.clear();
 
     svc->_meta_opts.cluster_root = "/meta_test";
     svc->_meta_opts.meta_state_service_type = "meta_state_service_simple";

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -65,7 +65,7 @@ void meta_service_test_app::app_envs_basic_test()
     svc->remote_storage_initialize();
 
     std::string apps_root = "/meta_test/apps";
-    std::shared_ptr<server_state> ss = svc->_state;
+    server_state *ss = svc->_state;
     ss->initialize(svc, apps_root);
 
     ss->_all_apps.emplace(std::make_pair(fake_app->app_id, fake_app));

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -87,12 +87,12 @@ void meta_service_test_app::state_sync_test()
     svc->remote_storage_initialize();
 
     std::string apps_root = "/meta_test/apps";
-    std::shared_ptr<server_state> ss1 = svc->_state;
+    server_state *ss1 = svc->_state;
 
     // create apss randomly, and sync it to meta state service simple
     std::cerr << "testing create apps and sync to remote storage" << std::endl;
     {
-        server_state *ss = ss1.get();
+        server_state *ss = ss1;
         ss->initialize(svc, apps_root);
 
         drop_set.clear();
@@ -132,7 +132,7 @@ void meta_service_test_app::state_sync_test()
     // then we sync from meta_state_service_simple, and dump to local file
     std::cerr << "testing sync from remote storage and dump to local file" << std::endl;
     {
-        std::shared_ptr<server_state> ss2 = std::make_shared<server_state>();
+        std::unique_ptr<server_state> ss2 = std::unique_ptr<server_state>(new server_state);
         ss2->initialize(svc, apps_root);
         dsn::error_code ec = ss2->sync_apps_from_remote_storage();
         ASSERT_EQ(ec, dsn::ERR_OK);
@@ -152,7 +152,7 @@ void meta_service_test_app::state_sync_test()
     // dump another way
     std::cerr << "testing directly dump to local file" << std::endl;
     {
-        std::shared_ptr<server_state> ss2 = std::make_shared<server_state>();
+        std::unique_ptr<server_state> ss2 = std::unique_ptr<server_state>(new server_state);
         ss2->initialize(svc, apps_root);
         dsn::error_code ec = ss2->dump_from_remote_storage("meta_state.dump2", true);
 
@@ -180,7 +180,7 @@ void meta_service_test_app::state_sync_test()
     std::cerr << "test sync to zookeeper's remote storage" << std::endl;
     // restore from the local file, and restore to zookeeper
     {
-        std::shared_ptr<server_state> ss2 = std::make_shared<server_state>();
+        std::unique_ptr<server_state> ss2 = std::unique_ptr<server_state>(new server_state);
 
         ss2->initialize(svc, apps_root);
         dsn::error_code ec = ss2->restore_from_local_storage("meta_state.dump2");
@@ -190,7 +190,7 @@ void meta_service_test_app::state_sync_test()
     // then sync from zookeeper
     std::cerr << "test sync from zookeeper's storage" << std::endl;
     {
-        std::shared_ptr<server_state> ss2 = std::make_shared<server_state>();
+        std::unique_ptr<server_state> ss2 = std::unique_ptr<server_state>(new server_state);
         ss2->initialize(svc, apps_root);
 
         dsn::error_code ec = ss2->initialize_data_structure();
@@ -210,7 +210,7 @@ void meta_service_test_app::state_sync_test()
 
     // then we restore from local storage and restore to remote
     {
-        std::shared_ptr<server_state> ss2 = std::make_shared<server_state>();
+        std::unique_ptr<server_state> ss2 = std::unique_ptr<server_state>(new server_state);
 
         ss2->initialize(svc, apps_root);
         dsn::error_code ec = ss2->restore_from_local_storage("meta_state.dump3");
@@ -283,7 +283,7 @@ void meta_service_test_app::state_sync_test()
     // simulate the half creating
     std::cerr << "test some node for a app is not create on remote storage" << std::endl;
     {
-        std::shared_ptr<server_state> ss2 = std::make_shared<server_state>();
+        std::unique_ptr<server_state> ss2 = std::unique_ptr<server_state>(new server_state);
         dsn::error_code ec;
         ss2->initialize(svc, apps_root);
 

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -301,6 +301,8 @@ void meta_service_test_app::state_sync_test()
         ASSERT_EQ(ec, dsn::ERR_OK);
         ASSERT_TRUE(ss2->spin_wait_staging(30));
     }
+
+    ss1->_all_apps.clear();
 }
 
 static dsn::app_info create_app_info(dsn::app_status::type status,
@@ -333,6 +335,7 @@ void meta_service_test_app::construct_apps_test()
     resp.err = dsn::ERR_OK;
 
     std::shared_ptr<meta_service> svc(new meta_service());
+    svc->_state->_all_apps.clear();
 
     std::vector<dsn::rpc_address> nodes;
     std::string hint_message;

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -130,7 +130,7 @@ void meta_service_test_app::call_update_configuration(
     dsn::tasking::enqueue(
         LPC_META_STATE_HIGH,
         nullptr,
-        std::bind(&server_state::on_update_configuration, svc->_state.get(), request, fake_request),
+        std::bind(&server_state::on_update_configuration, svc->_state, request, fake_request),
         server_state::sStateHash);
 }
 
@@ -147,7 +147,7 @@ void meta_service_test_app::call_config_sync(
                           configuration_query_by_node_response>::auto_reply(recvd_request);
     dsn::tasking::enqueue(LPC_META_STATE_HIGH,
                           nullptr,
-                          std::bind(&server_state::on_config_sync, svc->_state.get(), rpc),
+                          std::bind(&server_state::on_config_sync, svc->_state, rpc),
                           server_state::sStateHash);
 }
 
@@ -181,7 +181,7 @@ void meta_service_test_app::update_configuration_test()
     ASSERT_EQ(ec, dsn::ERR_OK);
     svc->_balancer.reset(new simple_load_balancer(svc.get()));
 
-    server_state *ss = svc->_state.get();
+    server_state *ss = svc->_state;
     ss->initialize(svc.get(), meta_options::concat_path_unix_style(svc->_cluster_root, "apps"));
     dsn::app_info info;
     info.is_stateful = true;
@@ -258,7 +258,7 @@ void meta_service_test_app::adjust_dropped_size()
     ASSERT_EQ(ec, dsn::ERR_OK);
     svc->_balancer.reset(new simple_load_balancer(svc.get()));
 
-    server_state *ss = svc->_state.get();
+    server_state *ss = svc->_state;
     ss->initialize(svc.get(), meta_options::concat_path_unix_style(svc->_cluster_root, "apps"));
     dsn::app_info info;
     info.is_stateful = true;
@@ -364,7 +364,7 @@ void meta_service_test_app::apply_balancer_test()
     std::vector<dsn::rpc_address> node_list;
     generate_node_list(node_list, 5, 10);
 
-    server_state *ss = meta_svc->_state.get();
+    server_state *ss = meta_svc->_state;
     generate_apps(ss->_all_apps, node_list, 5, 5, std::pair<uint32_t, uint32_t>(2, 5), false);
 
     app_mapper backed_app;

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -247,6 +247,8 @@ void meta_service_test_app::update_configuration_test()
     svc->_meta_opts._lb_opts.replica_assign_delay_ms_for_dropouts = 0;
     svc->_balancer.reset(new simple_load_balancer(svc.get()));
     ASSERT_TRUE(wait_state(ss, validator3, 10));
+
+    ss->_all_apps.clear();
 }
 
 void meta_service_test_app::adjust_dropped_size()

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -133,7 +133,7 @@ void test_checker::control_balancer(bool disable_it)
 {
     checker_load_balancer::s_disable_balancer = disable_it;
     if (disable_it && meta_leader()) {
-        server_state *ss = meta_leader()->_service->_state.get();
+        server_state *ss = meta_leader()->_service->_state;
         for (auto &kv : ss->_exist_apps) {
             std::shared_ptr<app_state> &app = kv.second;
             app->helpers->clear_proposals();
@@ -369,6 +369,6 @@ void install_checkers()
     dsn::tools::simulator::register_checker("simple_kv.checker",
                                             dsn::tools::checker::create<wrap_checker>);
 }
-}
-}
-}
+} // namespace test
+} // namespace replication
+} // namespace dsn


### PR DESCRIPTION
`server_state` need to be a singleton, so in this pull request, `server_state` was made to be a singleton 