### PR TITLE
refactor: move rpc handler on_query_configuration_by_index from meta_service to server_state 

### DIFF
--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -243,7 +243,6 @@ private:
     friend class test::test_checker;
     friend class meta_service_test_app;
     friend class bulk_load_service_test;
-    friend class server_state;
 
     replication_options _opts;
     meta_options _meta_opts;

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -47,12 +47,12 @@
 #include "meta_backup_service.h"
 #include "meta_state_service_utils.h"
 #include "block_service/block_service_manager.h"
+#include "meta_server_failure_detector.h"
 
 namespace dsn {
 namespace replication {
 
 class server_state;
-class meta_server_failure_detector;
 class server_load_balancer;
 class meta_duplication_service;
 class meta_split_service;
@@ -128,13 +128,31 @@ public:
 
     dsn::task_tracker *tracker() { return &_tracker; }
 
+    template <typename TRpcHolder>
+    bool check_status(TRpcHolder rpc, /*out*/ rpc_address *forward_address = nullptr)
+    {
+        int result = check_leader(rpc, forward_address);
+        if (result == 0)
+            return false;
+        if (result == -1 || !_started) {
+            if (result == -1) {
+                rpc.response().err = ERR_FORWARD_TO_OTHERS;
+            } else if (_recovering) {
+                rpc.response().err = ERR_UNDER_RECOVERY;
+            } else {
+                rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
+            }
+            ddebug("reject request with %s", rpc.response().err.to_string());
+            return false;
+        }
+
+        return true;
+    }
+
 private:
     void register_rpc_handlers();
     void register_ctrl_commands();
     void unregister_ctrl_commands();
-
-    // client => meta server
-    void on_query_configuration_by_index(configuration_query_by_index_rpc rpc);
 
     // partition server => meta server
     void on_config_sync(configuration_query_by_node_rpc rpc);
@@ -195,9 +213,29 @@ private:
     // if return -1 and `forward_address' != nullptr, then return leader by `forward_address'.
     int check_leader(dsn::message_ex *req, dsn::rpc_address *forward_address);
     template <typename TRpcHolder>
-    int check_leader(TRpcHolder rpc, /*out*/ rpc_address *forward_address);
-    template <typename TRpcHolder>
-    bool check_status(TRpcHolder rpc, /*out*/ rpc_address *forward_address = nullptr);
+    int check_leader(TRpcHolder rpc, rpc_address *forward_address)
+    {
+        dsn::rpc_address leader;
+        if (!_failure_detector->get_leader(&leader)) {
+            if (!rpc.dsn_request()->header->context.u.is_forward_supported) {
+                if (forward_address != nullptr)
+                    *forward_address = leader;
+                return -1;
+            }
+
+            dinfo("leader address: %s", leader.to_string());
+            if (!leader.is_invalid()) {
+                rpc.forward(leader);
+                return 0;
+            } else {
+                if (forward_address != nullptr)
+                    forward_address->set_invalid();
+                return -1;
+            }
+        }
+        return 1;
+    }
+
     error_code remote_storage_initialize();
     bool check_freeze() const;
 
@@ -205,6 +243,7 @@ private:
     friend class test::test_checker;
     friend class meta_service_test_app;
     friend class bulk_load_service_test;
+    friend class server_state;
 
     replication_options _opts;
     meta_options _meta_opts;

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -60,7 +60,8 @@ static const char *lock_state = "lock";
 static const char *unlock_state = "unlock";
 
 server_state::server_state()
-    : _meta_svc(nullptr),
+    : serverlet("server_state"),
+      _meta_svc(nullptr),
       _add_secondary_enable_flow_control(false),
       _add_secondary_max_count_for_one_node(0),
       _cli_dump_handle(nullptr),
@@ -86,6 +87,8 @@ server_state::~server_state()
             _ctrl_add_secondary_max_count_for_one_node);
         _ctrl_add_secondary_max_count_for_one_node = nullptr;
     }
+
+    unregister_rpc_handlers();
 }
 
 void server_state::register_cli_commands()
@@ -194,6 +197,8 @@ void server_state::initialize(meta_service *meta_svc, const std::string &apps_ro
         "recent_partition_change_writable_count",
         COUNTER_TYPE_VOLATILE_NUMBER,
         "partition change to writable count in the recent period");
+
+    register_rpc_handlers();
 }
 
 bool server_state::spin_wait_staging(int timeout_seconds)
@@ -560,8 +565,9 @@ dsn::error_code server_state::sync_apps_from_remote_storage()
     dsn::task_tracker tracker;
 
     dist::meta_state_service *storage = _meta_svc->get_remote_storage();
-    auto sync_partition = [this, storage, &err, &tracker](
-        std::shared_ptr<app_state> &app, int partition_id, const std::string &partition_path) {
+    auto sync_partition = [this, storage, &err, &tracker](std::shared_ptr<app_state> &app,
+                                                          int partition_id,
+                                                          const std::string &partition_path) {
         storage->get_data(
             partition_path,
             LPC_META_CALLBACK,
@@ -2076,8 +2082,9 @@ error_code server_state::construct_partitions(
                     std::ostringstream oss;
                     if (skip_lost_partitions) {
                         oss << "WARNING: partition(" << app->app_id << "."
-                            << pc.pid.get_partition_index() << ") has no replica collected, force "
-                                                               "recover the lost partition to empty"
+                            << pc.pid.get_partition_index()
+                            << ") has no replica collected, force "
+                               "recover the lost partition to empty"
                             << std::endl;
                     } else {
                         oss << "ERROR: partition(" << app->app_id << "."
@@ -2571,8 +2578,7 @@ void server_state::do_update_app_info(const std::string &app_path,
 {
     // persistent envs to zookeeper
     blob value = dsn::json::json_forwarder<app_info>::encode(info);
-    auto new_cb = [ this, app_path, info, user_cb = std::move(cb) ](error_code ec)
-    {
+    auto new_cb = [this, app_path, info, user_cb = std::move(cb)](error_code ec) {
         if (ec == ERR_OK) {
             user_cb(ec);
         } else if (ec == ERR_TIMEOUT) {
@@ -2829,6 +2835,40 @@ void server_state::clear_app_envs(const app_env_rpc &env_rpc)
                    old_envs.c_str(),
                    new_envs.c_str());
         });
+}
+
+void server_state::register_rpc_handlers()
+{
+    register_rpc_handler_with_rpc_holder(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX,
+                                         "query_configuration_by_index",
+                                         &server_state::on_query_configuration_by_index);
+}
+
+void server_state::unregister_rpc_handlers()
+{
+    unregister_rpc_handler(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX);
+}
+
+void server_state::on_query_configuration_by_index(configuration_query_by_index_rpc rpc)
+{
+    configuration_query_by_index_response &response = rpc.response();
+    rpc_address forward_address;
+    if (!_meta_svc->check_status(rpc, &forward_address)) {
+        if (!forward_address.is_invalid()) {
+            partition_configuration config;
+            config.primary = forward_address;
+            response.partitions.push_back(std::move(config));
+        }
+        return;
+    }
+
+    query_configuration_by_index(rpc.request(), response);
+    if (ERR_OK == response.err) {
+        ddebug_f("client {} queried an available app {} with appid {}",
+                 rpc.dsn_request()->header->from_address.to_string(),
+                 rpc.request().app_name,
+                 response.app_id);
+    }
 }
 } // namespace replication
 } // namespace dsn

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -2839,9 +2839,12 @@ void server_state::clear_app_envs(const app_env_rpc &env_rpc)
 
 void server_state::register_rpc_handlers()
 {
-    register_rpc_handler_with_rpc_holder(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX,
-                                         "query_configuration_by_index",
-                                         &server_state::on_query_configuration_by_index);
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        register_rpc_handler_with_rpc_holder(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX,
+                                             "query_configuration_by_index",
+                                             &server_state::on_query_configuration_by_index);
+    });
 }
 
 void server_state::unregister_rpc_handlers()

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -106,7 +106,7 @@ class meta_service;
 // D. thread-model of meta server
 // E. load balancer
 
-class server_state
+class server_state : public serverlet<server_state>
 {
 public:
     static const int sStateHash = 0;
@@ -290,6 +290,12 @@ private:
 
     void process_one_partition(std::shared_ptr<app_state> &app);
     void transition_staging_state(std::shared_ptr<app_state> &app);
+
+    void register_rpc_handlers();
+    void unregister_rpc_handlers();
+
+    // client => meta server
+    void on_query_configuration_by_index(configuration_query_by_index_rpc rpc);
 
 private:
     friend class test::test_checker;


### PR DESCRIPTION
In previous implementation, all rpc_handlers in meta server is registered in `meta_service`. And then the rpc request is forwarded to `server_state`、`bulk_load_service` and so on, to handle this request.
In this pull request, the rpc handler `on_query_configuration_by_index` is put to `server_state`, no need to forward by `meta_service`