### PR TITLE
refactor(security): close the connection when something is wrong with sever_negotiation

### DIFF
--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -129,12 +129,6 @@ void client_negotiation::send(std::unique_ptr<negotiation_request> request)
     });
 }
 
-void client_negotiation::fail_negotiation()
-{
-    _status = negotiation_status::type::SASL_AUTH_FAIL;
-    _session->on_failure(true);
-}
-
 void client_negotiation::succ_negotiation()
 {
     _status = negotiation_status::type::SASL_SUCC;

--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -63,7 +63,7 @@ void client_negotiation::handle_response(error_code err, const negotiation_respo
 
     switch (_status) {
     case negotiation_status::type::SASL_LIST_MECHANISMS:
-        recv_mechanisms(response);
+        on_recv_mechanisms(response);
         break;
     case negotiation_status::type::SASL_SELECT_MECHANISMS:
         // TBD(zlw)
@@ -77,7 +77,7 @@ void client_negotiation::handle_response(error_code err, const negotiation_respo
     }
 }
 
-void client_negotiation::recv_mechanisms(const negotiation_response &resp)
+void client_negotiation::on_recv_mechanisms(const negotiation_response &resp)
 {
     if (resp.status != negotiation_status::type::SASL_LIST_MECHANISMS_RESP) {
         dwarn_f("{}: get message({}) while expect({})",

--- a/src/runtime/security/client_negotiation.h
+++ b/src/runtime/security/client_negotiation.h
@@ -35,7 +35,6 @@ private:
     void recv_mechanisms(const negotiation_response &resp);
     void select_mechanism(const std::string &mechanism);
     void send(std::unique_ptr<negotiation_request> request);
-    void fail_negotiation();
     void succ_negotiation();
 };
 

--- a/src/runtime/security/client_negotiation.h
+++ b/src/runtime/security/client_negotiation.h
@@ -31,8 +31,9 @@ public:
 
 private:
     void handle_response(error_code err, const negotiation_response &&response);
+    void on_recv_mechanisms(const negotiation_response &resp);
+
     void list_mechanisms();
-    void recv_mechanisms(const negotiation_response &resp);
     void select_mechanism(const std::string &mechanism);
     void send(std::unique_ptr<negotiation_request> request);
     void succ_negotiation();

--- a/src/runtime/security/negotiation.cpp
+++ b/src/runtime/security/negotiation.cpp
@@ -42,5 +42,10 @@ std::unique_ptr<negotiation> create_negotiation(bool is_client, rpc_session *ses
     }
 }
 
+void negotiation::fail_negotiation() {
+    _status = negotiation_status::type::SASL_AUTH_FAIL;
+    _session->on_failure(true);
+}
+
 } // namespace security
 } // namespace dsn

--- a/src/runtime/security/negotiation.cpp
+++ b/src/runtime/security/negotiation.cpp
@@ -42,7 +42,8 @@ std::unique_ptr<negotiation> create_negotiation(bool is_client, rpc_session *ses
     }
 }
 
-void negotiation::fail_negotiation() {
+void negotiation::fail_negotiation()
+{
     _status = negotiation_status::type::SASL_AUTH_FAIL;
     _session->on_failure(true);
 }

--- a/src/runtime/security/negotiation.h
+++ b/src/runtime/security/negotiation.h
@@ -39,6 +39,7 @@ public:
 
     virtual void start() = 0;
     bool negotiation_succeed() const { return _status == negotiation_status::type::SASL_SUCC; }
+    void fail_negotiation();
 
 protected:
     // The ownership of the negotiation instance is held by rpc_session.

--- a/src/runtime/security/server_negotiation.cpp
+++ b/src/runtime/security/server_negotiation.cpp
@@ -50,7 +50,7 @@ void server_negotiation::handle_request(negotiation_rpc rpc)
         // TBD(zlw)
         break;
     default:
-        fail_negotiation(rpc, "wrong status");
+        fail_negotiation();
     }
 }
 
@@ -66,7 +66,7 @@ void server_negotiation::on_list_mechanisms(negotiation_rpc rpc)
                  _name,
                  enum_to_string(rpc.request().status),
                  enum_to_string(negotiation_status::type::SASL_LIST_MECHANISMS));
-        fail_negotiation(rpc, "invalid_client_message_status");
+        fail_negotiation();
     }
     return;
 }
@@ -80,7 +80,7 @@ void server_negotiation::on_select_mechanism(negotiation_rpc rpc)
             std::string error_msg =
                 fmt::format("the mechanism of {} is not supported", _selected_mechanism);
             dwarn_f("{}", error_msg);
-            fail_negotiation(rpc, error_msg);
+            fail_negotiation();
             return;
         }
 
@@ -90,7 +90,7 @@ void server_negotiation::on_select_mechanism(negotiation_rpc rpc)
                     _name,
                     err_s.code().to_string(),
                     err_s.description());
-            fail_negotiation(rpc, err_s.description());
+            fail_negotiation();
             return;
         }
 
@@ -101,7 +101,7 @@ void server_negotiation::on_select_mechanism(negotiation_rpc rpc)
                 _name,
                 enum_to_string(request.status),
                 negotiation_status::type::SASL_SELECT_MECHANISMS);
-        fail_negotiation(rpc, "invalid_client_message_status");
+        fail_negotiation();
         return;
     }
 }
@@ -110,13 +110,6 @@ error_s server_negotiation::do_sasl_server_init()
 {
     // TBD(zlw)
     return error_s::make(ERR_OK);
-}
-
-void server_negotiation::fail_negotiation(negotiation_rpc rpc, const std::string &reason)
-{
-    negotiation_response &response = rpc.response();
-    _status = response.status = negotiation_status::type::SASL_AUTH_FAIL;
-    response.msg = reason;
 }
 
 } // namespace security

--- a/src/runtime/security/server_negotiation.h
+++ b/src/runtime/security/server_negotiation.h
@@ -37,7 +37,6 @@ private:
     void on_list_mechanisms(negotiation_rpc rpc);
     void on_select_mechanism(negotiation_rpc rpc);
     error_s do_sasl_server_init();
-    void fail_negotiation(negotiation_rpc rpc, const std::string &reason);
 };
 
 } // namespace security

--- a/src/runtime/security/server_negotiation.h
+++ b/src/runtime/security/server_negotiation.h
@@ -36,6 +36,7 @@ public:
 private:
     void on_list_mechanisms(negotiation_rpc rpc);
     void on_select_mechanism(negotiation_rpc rpc);
+
     error_s do_sasl_server_init();
 };
 


### PR DESCRIPTION
In previous implementation, when something is wrong in `server_negotiation`, it send a message to `client_negotiation`, and the `client_negotiation` will close the connection when it receives the message.
So I think we can directly close the connection in this case, no need to send a message.