### PR TITLE
chore: remove usages of rdsn git commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ install/
 test_reports/
 Dockerfile
 include/thrift/
-include/dsn/git_commit.h
 DSN_ROOT
 
 rdsn.github.config

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -131,23 +131,6 @@ then
     cd ..
 fi
 
-cd $ROOT
-DSN_GIT_COMMIT=`git log | head -n 1 | awk '{print $2}'`
-if [ $? -ne 0 ] || [ -z "$DSN_GIT_COMMIT" ] 
-then
-    echo "ERROR: get DSN_GIT_COMMIT failed"
-    echo "HINT: check if rdsn is a git repo"
-    echo "   or check gitdir in .git (edit it or use \"git --git-dir='../.git/modules/rdsn' log\" to get commit)"
-    exit 1
-fi
-GIT_COMMIT_FILE=include/dsn/git_commit.h
-if [ ! -f $GIT_COMMIT_FILE ] || ! grep $DSN_GIT_COMMIT $GIT_COMMIT_FILE
-then
-    echo "Generating $GIT_COMMIT_FILE..."
-    echo "#pragma once" >$GIT_COMMIT_FILE
-    echo "#define DSN_GIT_COMMIT \"$DSN_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
-fi
-
 cd $BUILD_DIR
 echo "[$(date)] Building..."
 make install $MAKE_OPTIONS

--- a/src/runtime/core_main.cpp
+++ b/src/runtime/core_main.cpp
@@ -61,18 +61,6 @@ void dsn_core_init()
 }
 
 #if defined(__linux__)
-#include <dsn/git_commit.h>
 #define STR_I(var) #var
 #define STR(var) STR_I(var)
-static char const rcsid[] =
-    "$Version: rDSN (" DSN_GIT_COMMIT ")"
-#if defined(DSN_BUILD_TYPE)
-    " " STR(DSN_BUILD_TYPE)
-#endif
-        ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
-#if defined(DSN_BUILD_HOSTNAME)
-            ", built on " STR(DSN_BUILD_HOSTNAME)
-#endif
-                ", built at " __DATE__ " " __TIME__ " $";
-const char *dsn_rcsid() { return rcsid; }
 #endif


### PR DESCRIPTION
If we download the sources from github releases rather than using git clone, the git commit of rdsn will be missing. Because in this case rdsn is not a git repo. However, `DSN_GIT_COMMIT` relies strongly with the fact that rdsn is a git repo. This is not always be true.

In this PR I deleted include/dsn/git_commit.h and `DSN_GIT_COMMIT`. It has no effect.

## Manual Test

```
wget https://codeload.github.com/neverchanje/rdsn/zip/gcid
unzip rdsn-gcid
cd rdsn-gcid
./run.sh build -c -j 4
```

All success.