### PR TITLE
fix: set the tracer type when init

### DIFF
--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -72,7 +72,7 @@ public:
     //  threshold < 0: don't dump any trace points
     //  threshold = 0: dump all trace points
     //  threshold > 0: dump the trace point when time_used > threshold
-    latency_tracer(const std::string &name, uint64_t threshold = 0);
+    latency_tracer(const std::string &name, bool is_sub = false, uint64_t threshold = 0);
 
     ~latency_tracer();
 

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -69,6 +69,10 @@ DSN_DECLARE_bool(enable_latency_tracer);
 class latency_tracer
 {
 public:
+    //-is_sub:
+    //  if `is_sub`=true means its points will be dumped by parent tracer and won't be dumped when
+    //  decontructor
+    //-threshold:
     //  threshold < 0: don't dump any trace points
     //  threshold = 0: dump all trace points
     //  threshold > 0: dump the trace point when time_used > threshold

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -70,8 +70,8 @@ class latency_tracer
 {
 public:
     //-is_sub:
-    //  if `is_sub`=true means its points will be dumped by parent tracer and won't be dumped when
-    //  decontructor
+    //  if `is_sub`=true means its points will be dumped by parent tracer and won't be dumped
+    //  repeatedly when decontructor
     //-threshold:
     //  threshold < 0: don't dump any trace points
     //  threshold = 0: dump all trace points

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -71,7 +71,7 @@ class latency_tracer
 public:
     //-is_sub:
     //  if `is_sub`=true means its points will be dumped by parent tracer and won't be dumped
-    //  repeatedly when decontructor
+    //  repeatedly in destructor
     //-threshold:
     //  threshold < 0: don't dump any trace points
     //  threshold = 0: dump all trace points

--- a/src/replica/mutation.cpp
+++ b/src/replica/mutation.cpp
@@ -59,8 +59,10 @@ mutation::mutation()
     _appro_data_bytes = sizeof(mutation_header);
     _create_ts_ns = dsn_now_ns();
     _tid = ++s_tid;
-    tracer = std::make_shared<dsn::utils::latency_tracer>(
-        fmt::format("{}[{}]", "mutation", _tid), FLAGS_abnormal_write_trace_latency_threshold);
+    tracer =
+        std::make_shared<dsn::utils::latency_tracer>(fmt::format("{}[{}]", "mutation", _tid),
+                                                     false,
+                                                     FLAGS_abnormal_write_trace_latency_threshold);
 }
 
 mutation_ptr mutation::copy_no_reply(const mutation_ptr &old_mu)

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -56,7 +56,7 @@ void latency_tracer::set_sub_tracer(const std::shared_ptr<latency_tracer> &trace
     if (!FLAGS_enable_latency_tracer) {
         return;
     }
-    
+
     _sub_tracer = tracer;
 }
 

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -25,8 +25,8 @@ namespace utils {
 
 DSN_DEFINE_bool("replication", enable_latency_tracer, false, "whether enable the latency tracer");
 
-latency_tracer::latency_tracer(const std::string &name, uint64_t threshold)
-    : _name(name), _threshold(threshold), _is_sub(false), _start_time(dsn_now_ns())
+latency_tracer::latency_tracer(const std::string &name, bool is_sub, uint64_t threshold)
+    : _name(name), _threshold(threshold), _is_sub(is_sub), _start_time(dsn_now_ns())
 {
 }
 
@@ -56,7 +56,6 @@ void latency_tracer::set_sub_tracer(const std::shared_ptr<latency_tracer> &trace
     if (!FLAGS_enable_latency_tracer) {
         return;
     }
-    tracer->_is_sub = true;
     _sub_tracer = tracer;
 }
 

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -56,6 +56,7 @@ void latency_tracer::set_sub_tracer(const std::shared_ptr<latency_tracer> &trace
     if (!FLAGS_enable_latency_tracer) {
         return;
     }
+    
     _sub_tracer = tracer;
 }
 

--- a/src/utils/test/latency_tracer_test.cpp
+++ b/src/utils/test/latency_tracer_test.cpp
@@ -41,12 +41,12 @@ public:
 
     void init_trace_points()
     {
-        _tracer1 = std::make_shared<latency_tracer>("name1", true);
+        _tracer1 = std::make_shared<latency_tracer>("name1");
         for (int i = 0; i < _tracer1_stage_count; i++) {
             ADD_CUSTOM_POINT(_tracer1, fmt::format("stage{}", i));
         }
 
-        _tracer2 = std::make_shared<latency_tracer>("name2", true);
+        _tracer2 = std::make_shared<latency_tracer>("name2");
 
         for (int i = 0; i < _tracer2_stage_count; i++) {
             ADD_CUSTOM_POINT(_tracer2, fmt::format("stage{}", i));


### PR DESCRIPTION
`_is_sub` control whether to dump the point when deconstructer, if one tracer isn't marked as `is_sub` at initialization, but wait `set_sub_tracer`, which will cause tracer that hoped `is_sub` but not be `set_sub_tracer` dump points. for example, `learn` and `log write` process will create `aio_task`, but only `log write` process `set_sub_tracer`,  the result is that `aio_task` of `learn` will dump points, which is not expected. So if we hope one tracer `is_sub`, we should init it at first constructer