### PR TITLE
refactor(security): make send/recv message allowed when mandatory_auth is false

### DIFF
--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -188,6 +188,7 @@ void client_negotiation::succ_negotiation()
 {
     _status = negotiation_status::type::SASL_SUCC;
     _session->set_negotiation_succeed();
+    ddebug_f("{}: negotiation succeed", _name);
 }
 } // namespace security
 } // namespace dsn

--- a/src/runtime/security/negotiation_service.cpp
+++ b/src/runtime/security/negotiation_service.cpp
@@ -26,6 +26,7 @@
 namespace dsn {
 namespace security {
 DSN_DECLARE_bool(enable_auth);
+DSN_DECLARE_bool(mandatory_auth);
 
 inline bool is_negotiation_message(dsn::task_code code)
 {
@@ -92,13 +93,15 @@ void negotiation_service::on_rpc_disconnected(rpc_session *session)
 
 bool negotiation_service::on_rpc_recv_msg(message_ex *msg)
 {
-    return in_white_list(msg->rpc_code()) || msg->io_session->is_negotiation_succeed();
+    return !FLAGS_mandatory_auth || in_white_list(msg->rpc_code()) ||
+           msg->io_session->is_negotiation_succeed();
 }
 
 bool negotiation_service::on_rpc_send_msg(message_ex *msg)
 {
     // if try_pend_message return true, it means the msg is pended to the resend message queue
-    return in_white_list(msg->rpc_code()) || !msg->io_session->try_pend_message(msg);
+    return !FLAGS_mandatory_auth || in_white_list(msg->rpc_code()) ||
+           !msg->io_session->try_pend_message(msg);
 }
 
 void init_join_point()

--- a/src/runtime/security/server_negotiation.cpp
+++ b/src/runtime/security/server_negotiation.cpp
@@ -153,6 +153,7 @@ void server_negotiation::succ_negotiation(negotiation_rpc rpc)
     negotiation_response &response = rpc.response();
     _status = response.status = negotiation_status::type::SASL_SUCC;
     _session->set_negotiation_succeed();
+    ddebug_f("{}: negotiation succeed", _name);
 }
 } // namespace security
 } // namespace dsn

--- a/src/runtime/test/negotiation_service_test.cpp
+++ b/src/runtime/test/negotiation_service_test.cpp
@@ -27,6 +27,7 @@
 namespace dsn {
 namespace security {
 DSN_DECLARE_bool(enable_auth);
+DSN_DECLARE_bool(mandatory_auth);
 
 class negotiation_service_test : public testing::Test
 {
@@ -83,16 +84,18 @@ TEST_F(negotiation_service_test, on_rpc_recv_msg)
     {
         task_code rpc_code;
         bool negotiation_succeed;
+        bool mandatory_auth;
         bool return_value;
-    } tests[] = {{RPC_NEGOTIATION, true, true},
-                 {RPC_NEGOTIATION_ACK, true, true},
-                 {fd::RPC_FD_FAILURE_DETECTOR_PING, true, true},
-                 {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, true, true},
-                 {RPC_NEGOTIATION, false, true},
-                 {RPC_HTTP_SERVICE, true, true},
-                 {RPC_HTTP_SERVICE, false, false}};
+    } tests[] = {{RPC_NEGOTIATION, false, true, true},
+                 {RPC_NEGOTIATION_ACK, false, true, true},
+                 {fd::RPC_FD_FAILURE_DETECTOR_PING, false, true, true},
+                 {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, false, true, true},
+                 {RPC_HTTP_SERVICE, true, true, true},
+                 {RPC_HTTP_SERVICE, false, false, true},
+                 {RPC_HTTP_SERVICE, false, true, false}};
 
     for (const auto &test : tests) {
+        FLAGS_mandatory_auth = test.mandatory_auth;
         message_ptr msg = dsn::message_ex::create_request(test.rpc_code, 0, 0);
         auto sim_session = create_fake_session();
         msg->io_session = sim_session;
@@ -110,16 +113,18 @@ TEST_F(negotiation_service_test, on_rpc_send_msg)
     {
         task_code rpc_code;
         bool negotiation_succeed;
+        bool mandatory_auth;
         bool return_value;
-    } tests[] = {{RPC_NEGOTIATION, true, true},
-                 {RPC_NEGOTIATION_ACK, true, true},
-                 {fd::RPC_FD_FAILURE_DETECTOR_PING, true, true},
-                 {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, true, true},
-                 {RPC_NEGOTIATION, false, true},
-                 {RPC_HTTP_SERVICE, true, true},
-                 {RPC_HTTP_SERVICE, false, false}};
+    } tests[] = {{RPC_NEGOTIATION, false, true, true},
+                 {RPC_NEGOTIATION_ACK, false, true, true},
+                 {fd::RPC_FD_FAILURE_DETECTOR_PING, false, true, true},
+                 {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, false, true, true},
+                 {RPC_HTTP_SERVICE, true, true, true},
+                 {RPC_HTTP_SERVICE, false, false, true},
+                 {RPC_HTTP_SERVICE, false, true, false}};
 
     for (const auto &test : tests) {
+        FLAGS_mandatory_auth = test.mandatory_auth;
         message_ptr msg = dsn::message_ex::create_request(test.rpc_code, 0, 0);
         auto sim_session = create_fake_session();
         msg->io_session = sim_session;


### PR DESCRIPTION
In previous implementation, if message is not in white list and negotiation is not succeed, the message is not allowed to send or receive. But this will produce error when rolling update.

 For example: the `enable_auth` configuration of client session is false, and it is true on the server session side. So client session will not do negotiation work with server session. And when the server session receives one message from this client session , it will close this session connection because this message is not in white list and the negotiation is not succeed. 

In this pr, I make send/recv message allowed when mandatory_auth is false, so the message will be received successully in this situation. This will make our rolling update work to proceed smoothly.