### PR TITLE
feat(split): add ddl interface start_partition_split

### DIFF
--- a/include/dsn/dist/replication/replication_ddl_client.h
+++ b/include/dsn/dist/replication/replication_ddl_client.h
@@ -191,6 +191,10 @@ public:
                              detect_hotkey_request &req,
                              detect_hotkey_response &resp);
 
+    // partition split
+    error_with<start_partition_split_response> start_partition_split(const std::string &app_name,
+                                                                     int partition_count);
+
 private:
     bool static valid_app_char(int c);
 

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1593,5 +1593,14 @@ error_code replication_ddl_client::detect_hotkey(const dsn::rpc_address &target,
     return resps.begin()->second.get_error().code();
 }
 
+error_with<start_partition_split_response>
+replication_ddl_client::start_partition_split(const std::string &app_name, int new_partition_count)
+{
+    auto req = make_unique<start_partition_split_request>();
+    req->__set_app_name(app_name);
+    req->__set_new_partition_count(new_partition_count);
+    return call_rpc_sync(start_split_rpc(std::move(req), RPC_CM_START_PARTITION_SPLIT));
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -40,6 +40,8 @@ typedef rpc_holder<bulk_load_request, bulk_load_response> bulk_load_rpc;
 typedef rpc_holder<control_bulk_load_request, control_bulk_load_response> control_bulk_load_rpc;
 typedef rpc_holder<query_bulk_load_request, query_bulk_load_response> query_bulk_load_rpc;
 
+typedef rpc_holder<start_partition_split_request, start_partition_split_response> start_split_rpc;
+
 class replication_options
 {
 public:

--- a/src/meta/meta_rpc_types.h
+++ b/src/meta/meta_rpc_types.h
@@ -26,7 +26,6 @@ namespace replication {
 typedef rpc_holder<configuration_update_app_env_request, configuration_update_app_env_response>
     app_env_rpc;
 typedef rpc_holder<ddd_diagnose_request, ddd_diagnose_response> ddd_diagnose_rpc;
-typedef rpc_holder<start_partition_split_request, start_partition_split_response> start_split_rpc;
 typedef rpc_holder<configuration_query_by_node_request, configuration_query_by_node_response>
     configuration_query_by_node_rpc;
 typedef rpc_holder<configuration_query_by_index_request, configuration_query_by_index_response>


### PR DESCRIPTION
This function add a ddl interface `start_partition_split`, it will send start_split_rpc to meta server.