### PR TITLE
feat(split): add split_status

### DIFF
--- a/include/dsn/dist/replication/replication_enums.h
+++ b/include/dsn/dist/replication/replication_enums.h
@@ -21,6 +21,7 @@ ENUM_REG(replication::partition_status::PS_ERROR)
 ENUM_REG(replication::partition_status::PS_PRIMARY)
 ENUM_REG(replication::partition_status::PS_SECONDARY)
 ENUM_REG(replication::partition_status::PS_POTENTIAL_SECONDARY)
+ENUM_REG(replication::partition_status::PS_PARTITION_SPLIT)
 ENUM_END2(replication::partition_status::type, partition_status)
 
 ENUM_BEGIN2(replication::read_semantic::type,
@@ -98,4 +99,12 @@ ENUM_BEGIN2(replication::detect_action::type, detect_action, replication::detect
 ENUM_REG(replication::detect_action::START)
 ENUM_REG(replication::detect_action::STOP)
 ENUM_END2(replication::detect_action::type, detect_action)
+
+ENUM_BEGIN2(replication::split_status::type, split_status, replication::split_status::NOT_SPLIT)
+ENUM_REG(replication::split_status::NOT_SPLIT)
+ENUM_REG(replication::split_status::SPLITTING)
+ENUM_REG(replication::split_status::PAUSING)
+ENUM_REG(replication::split_status::PAUSED)
+ENUM_REG(replication::split_status::CANCELING)
+ENUM_END2(replication::split_status::type, split_status)
 }

--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -77,6 +77,20 @@ struct learner_status
 
 extern const std::map<int, const char *> _learner_status_VALUES_TO_NAMES;
 
+struct split_status
+{
+    enum type
+    {
+        NOT_SPLIT = 0,
+        SPLITTING = 1,
+        PAUSING = 2,
+        PAUSED = 3,
+        CANCELING = 4
+    };
+};
+
+extern const std::map<int, const char *> _split_status_VALUES_TO_NAMES;
+
 struct config_type
 {
     enum type

--- a/src/common/replication_types.cpp
+++ b/src/common/replication_types.cpp
@@ -65,6 +65,16 @@ const std::map<int, const char *> _learner_status_VALUES_TO_NAMES(
     ::apache::thrift::TEnumIterator(6, _klearner_statusValues, _klearner_statusNames),
     ::apache::thrift::TEnumIterator(-1, NULL, NULL));
 
+int _ksplit_statusValues[] = {split_status::NOT_SPLIT,
+                              split_status::SPLITTING,
+                              split_status::PAUSING,
+                              split_status::PAUSED,
+                              split_status::CANCELING};
+const char *_ksplit_statusNames[] = {"NOT_SPLIT", "SPLITTING", "PAUSING", "PAUSED", "CANCELING"};
+const std::map<int, const char *> _split_status_VALUES_TO_NAMES(
+    ::apache::thrift::TEnumIterator(5, _ksplit_statusValues, _ksplit_statusNames),
+    ::apache::thrift::TEnumIterator(-1, NULL, NULL));
+
 int _kconfig_typeValues[] = {config_type::CT_INVALID,
                              config_type::CT_ASSIGN_PRIMARY,
                              config_type::CT_UPGRADE_TO_PRIMARY,

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -284,6 +284,19 @@ struct restore_state
     restore_state() : restore_status(dsn::ERR_OK), progress(0), reason() {}
 };
 
+// app partition_split states
+// when starting partition split, `splitting_count` will be equal to old_partition_count,
+// <parent_partition_index, SPLITTING> will be inserted into `status`.
+// if partition[0] finish split, `splitting_count` will decrease and <0, SPLITTING> will be removed
+// in `status`.
+struct split_state
+{
+    int32_t splitting_count;
+    // partition_index -> split_status
+    std::map<int32_t, split_status::type> status;
+    split_state() : splitting_count(0) {}
+};
+
 class app_state;
 class app_state_helper
 {
@@ -293,6 +306,7 @@ public:
     std::vector<config_context> contexts;
     dsn::message_ex *pending_response;
     std::vector<restore_state> restore_states;
+    split_state split_states;
 
 public:
     app_state_helper() : owner(nullptr), partitions_in_progress(0)

--- a/src/replica/split/replica_split_manager.h
+++ b/src/replica/split/replica_split_manager.h
@@ -35,8 +35,8 @@ public:
     void set_child_gpid(gpid pid) { _child_gpid = pid; }
 
 private:
-    // parent partition create child
-    void on_add_child(const group_check_request &request);
+    // parent partition start split
+    void parent_start_split(const group_check_request &request);
 
     // child replica initialize config and state info
     void child_init_replica(gpid parent_gpid, rpc_address primary_address, ballot init_ballot);
@@ -118,6 +118,8 @@ private:
     friend class replica;
     friend class replica_stub;
     friend class replica_split_test;
+
+    split_status::type _split_status{split_status::NOT_SPLIT};
 
     // _child_gpid = gpid({app_id},{pidx}+{old_partition_count}) for parent partition
     // _child_gpid.app_id = 0 for parent partition not in partition split and child partition

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -93,6 +93,7 @@ public:
 
     void mock_parent_split_context(partition_status::type status)
     {
+        parent_set_split_status(split_status::SPLITTING);
         _parent_split_mgr->_child_gpid = CHILD_GPID;
         _parent_split_mgr->_child_init_ballot = INIT_BALLOT;
         _parent_replica->set_partition_status(status);
@@ -182,15 +183,16 @@ public:
     }
 
     /// test functions
-
-    void test_on_add_child(ballot b, gpid req_child_gpid)
+    void test_parent_start_split(ballot b, gpid req_child_gpid, split_status::type status)
     {
+        parent_set_split_status(status);
+
         group_check_request req;
         req.config.ballot = b;
         req.config.status = partition_status::PS_PRIMARY;
         req.__set_child_gpid(req_child_gpid);
 
-        _parent_split_mgr->on_add_child(req);
+        _parent_split_mgr->parent_start_split(req);
         _parent_replica->tracker()->wait_outstanding_tasks();
     }
 
@@ -297,6 +299,12 @@ public:
     }
     bool child_is_caught_up() { return _child_replica->_split_states.is_caught_up; }
 
+    split_status::type parent_get_split_status() { return _parent_split_mgr->_split_status; }
+    void parent_set_split_status(split_status::type status)
+    {
+        _parent_split_mgr->_split_status = status;
+    }
+
     primary_context get_replica_primary_context(mock_replica_ptr rep)
     {
         return rep->_primary_states;
@@ -305,7 +313,12 @@ public:
     {
         return _parent_replica->_primary_states.sync_send_write_request;
     }
-    bool is_parent_not_in_split() { return (_parent_split_mgr->_child_gpid.get_app_id() == 0); }
+    bool is_parent_not_in_split()
+    {
+        return _parent_split_mgr->_child_gpid.get_app_id() == 0 &&
+               _parent_split_mgr->_child_init_ballot == 0 &&
+               _parent_split_mgr->_split_status == split_status::NOT_SPLIT;
+    }
 
 public:
     const std::string APP_NAME = "split_table";
@@ -335,29 +348,40 @@ public:
     learn_state _mock_learn_state;
 };
 
-// TODO(heyuchen): refactor add child unit tests
-TEST_F(replica_split_test, add_child_wrong_ballot)
-{
-    ballot WRONG_BALLOT = 2;
-    test_on_add_child(WRONG_BALLOT, CHILD_GPID);
-    ASSERT_EQ(stub->get_replica(CHILD_GPID), nullptr);
-}
-
-TEST_F(replica_split_test, add_child_with_child_existed)
-{
-    _parent_split_mgr->set_child_gpid(CHILD_GPID);
-    test_on_add_child(INIT_BALLOT, CHILD_GPID);
-    ASSERT_EQ(stub->get_replica(CHILD_GPID), nullptr);
-}
-
-TEST_F(replica_split_test, add_child_succeed)
+// parent_start_split tests
+TEST_F(replica_split_test, parent_start_split_tests)
 {
     fail::cfg("replica_stub_create_child_replica_if_not_found", "return()");
     fail::cfg("replica_child_init_replica", "return()");
 
-    test_on_add_child(INIT_BALLOT, CHILD_GPID);
-    ASSERT_NE(stub->get_replica(CHILD_GPID), nullptr);
-    stub->get_replica(CHILD_GPID)->tracker()->wait_outstanding_tasks();
+    ballot WRONG_BALLOT = 2;
+
+    // Test cases:
+    // - wrong ballot
+    // - partition has already executing splitting
+    // - old add child request
+    // - start succeed
+    struct start_split_test
+    {
+        ballot req_ballot;
+        gpid req_child_gpid;
+        split_status::type local_split_status;
+        split_status::type expected_split_status;
+        bool start_split_succeed;
+    } tests[] = {
+        {WRONG_BALLOT, CHILD_GPID, split_status::NOT_SPLIT, split_status::NOT_SPLIT, false},
+        {INIT_BALLOT, CHILD_GPID, split_status::SPLITTING, split_status::SPLITTING, false},
+        {INIT_BALLOT, PARENT_GPID, split_status::NOT_SPLIT, split_status::NOT_SPLIT, false},
+        {INIT_BALLOT, CHILD_GPID, split_status::NOT_SPLIT, split_status::SPLITTING, true}};
+    for (auto test : tests) {
+        test_parent_start_split(test.req_ballot, test.req_child_gpid, test.local_split_status);
+        ASSERT_EQ(parent_get_split_status(), test.expected_split_status);
+        if (test.start_split_succeed) {
+            ASSERT_EQ(_parent_split_mgr->get_partition_version(), OLD_PARTITION_COUNT - 1);
+            stub->get_replica(CHILD_GPID)->tracker()->wait_outstanding_tasks();
+            ASSERT_EQ(stub->get_replica(CHILD_GPID)->status(), partition_status::PS_INACTIVE);
+        }
+    }
 }
 
 // parent_check_states tests

--- a/src/replication.thrift
+++ b/src/replication.thrift
@@ -158,6 +158,16 @@ struct learn_notify_response
     3:i64                   signature; // learning signature
 }
 
+// partition split status
+enum split_status
+{
+    NOT_SPLIT,
+    SPLITTING,
+    PAUSING,
+    PAUSED,
+    CANCELING
+}
+
 struct group_check_request
 {
     1:dsn.layer2.app_info   app;


### PR DESCRIPTION
This pull request adds two sturctures to show split status.
### split_status (in replication.thirft)
Define five split_status for partition (not_split, splitting, pausing, paused, canceling), both replica and meta will use it.
- For replica, we used to use `_child_gpid` to distinguish whether a replica is executing splitting, if `_child_gpid.get_app_id() > 0`, the replica is splitting, otherwise not. It can only show two split status. Now, we use `_split_status` to describe partition split status.
- For meta, see split_state
### split_state (in meta_data.h)
Define sturct `split_state` to show app split progress, this sturcture include splitting partition count and each split_status for those splitting partitions. If `splitting_count = 0`, it means current app is not splitting or has finished splitting. 

This sturcture is helpful to query app split progress and easier to understand. In previous implementation, when an app is executing splitting, tha ballot of not-ready child partition is `invalid_ballot`( < 0), so we should traverse `app->partitions` to check if any partition whose ballot is invalid. Now, we just check the value of `splitting_count`.

This pr also update related unit tests.