### PR TITLE
feat(split): implement child_handle_split_error

### DIFF
--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -625,6 +625,13 @@ bool replica::is_same_ballot_status_change_allowed(partition_status::type olds,
 bool replica::update_local_configuration(const replica_configuration &config,
                                          bool same_ballot /* = false*/)
 {
+    FAIL_POINT_INJECT_F("replica_update_local_configuration", [=](dsn::string_view) -> bool {
+        auto old_status = status();
+        _config = config;
+        ddebug_replica("update status from {} to {}", enum_to_string(old_status), status());
+        return true;
+    });
+
     dassert(config.ballot > get_ballot() || (same_ballot && config.ballot == get_ballot()),
             "invalid ballot, %" PRId64 " VS %" PRId64 "",
             config.ballot,

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -805,10 +805,11 @@ void replica_split_manager::child_handle_split_error(
     const std::string &error_msg) // on child partition
 {
     if (status() != partition_status::PS_ERROR) {
-        dwarn_replica("partition split failed because {}", error_msg);
-        // TODO(heyuchen):
-        // convert child partition_status from PS_PARTITION_SPLIT to PS_ERROR in further pull
-        // request
+        derror_replica("child partition split failed because {}, parent = {}",
+                       error_msg,
+                       _replica->_split_states.parent_gpid);
+        // TODO(heyuchen): add perf-counter (split_failed_count)
+        _replica->update_local_configuration_with_no_ballot_change(partition_status::PS_ERROR);
     }
 }
 


### PR DESCRIPTION
If parent partition configuration changed or meet other error during partition split, the split process should be stopped, child partition status will turn from `partition_split` to `error` (this has been implemented in #391), this pull request only calls it in function `child_handle_split_error` and updates some unit tests.