### PR TITLE
feat(split): parent group update partition count

### DIFF
--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -176,7 +176,7 @@ void replica::on_group_check(const group_check_request &request,
         if (request.last_committed_decree > last_committed_decree()) {
             _prepare_list->commit(request.last_committed_decree, COMMIT_TO_DECREE_HARD);
         }
-        // the group check may trigger split on the secondary.
+        // the group check may trigger starting/canceling/pausing a split on the secondary.
         _split_mgr->trigger_secondary_parent_split(request, response);
         break;
     case partition_status::PS_POTENTIAL_SECONDARY:

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -176,7 +176,8 @@ void replica::on_group_check(const group_check_request &request,
         if (request.last_committed_decree > last_committed_decree()) {
             _prepare_list->commit(request.last_committed_decree, COMMIT_TO_DECREE_HARD);
         }
-        _split_mgr->secondary_parent_handle_split(request, response);
+        // the group check may trigger split on the secondary.
+        _split_mgr->trigger_secondary_parent_split(request, response);
         break;
     case partition_status::PS_POTENTIAL_SECONDARY:
         init_learn(request.config.learner_signature);

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -176,7 +176,7 @@ void replica::on_group_check(const group_check_request &request,
         if (request.last_committed_decree > last_committed_decree()) {
             _prepare_list->commit(request.last_committed_decree, COMMIT_TO_DECREE_HARD);
         }
-        // the group check may trigger starting/canceling/pausing a split on the secondary.
+        // the group check may trigger start/finish/cancel/pause a split on the secondary.
         _split_mgr->trigger_secondary_parent_split(request, response);
         break;
     case partition_status::PS_POTENTIAL_SECONDARY:

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -39,6 +39,7 @@
 #include "replica_stub.h"
 
 #include "duplication/replica_duplicator_manager.h"
+#include "split/replica_split_manager.h"
 
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/dist/replication/replication_app_base.h>
@@ -175,6 +176,7 @@ void replica::on_group_check(const group_check_request &request,
         if (request.last_committed_decree > last_committed_decree()) {
             _prepare_list->commit(request.last_committed_decree, COMMIT_TO_DECREE_HARD);
         }
+        _split_mgr->secondary_parent_handle_split(request, response);
         break;
     case partition_status::PS_POTENTIAL_SECONDARY:
         init_learn(request.config.learner_signature);

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -1104,7 +1104,7 @@ void replica_split_manager::child_handle_async_learn_error() // on child partiti
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica_split_manager::secondary_parent_handle_split(
+void replica_split_manager::trigger_secondary_parent_split(
     const group_check_request &request,
     /*out*/ group_check_response &response) // on secondary parent partition
 {

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -1050,7 +1050,9 @@ void replica_split_manager::on_register_child_on_meta_reply(
     _replica->_primary_states.register_child_task = nullptr;
     _replica->_primary_states.sync_send_write_request = false;
 
-    // TODO(heyuchen): TBD - update parent group partition_count
+    // update primary parent group partition_count
+    update_local_partition_count(_replica->_app_info.partition_count * 2);
+    _replica->broadcast_group_check();
 
     parent_cleanup_split_context();
 }
@@ -1099,6 +1101,21 @@ void replica_split_manager::child_handle_async_learn_error() // on child partiti
         std::bind(&replica_split_manager::parent_cleanup_split_context, std::placeholders::_1));
     child_handle_split_error("meet error when execute child_learn_states");
     _replica->_split_states.async_learn_task = nullptr;
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_split_manager::secondary_parent_handle_split(
+    const group_check_request &request,
+    /*out*/ group_check_response &response) // on secondary parent partition
+{
+    if (request.app.partition_count ==
+        _replica->_app_info.partition_count * 2) { // secondary update partition count
+        update_local_partition_count(request.app.partition_count);
+        parent_cleanup_split_context();
+        return;
+    }
+
+    // TODO(heyuchen): add other split_status check, response will be used in future
 }
 
 } // namespace replication

--- a/src/replica/split/replica_split_manager.h
+++ b/src/replica/split/replica_split_manager.h
@@ -127,8 +127,8 @@ private:
 
     // called by `on_group_check` in `replica_check.cpp`
     // secondary parent check whether should start or stop split
-    void secondary_parent_handle_split(const group_check_request &request,
-                                       /*out*/ group_check_response &response);
+    void trigger_secondary_parent_split(const group_check_request &request,
+                                        /*out*/ group_check_response &response);
 
     //
     // helper functions

--- a/src/replica/split/replica_split_manager.h
+++ b/src/replica/split/replica_split_manager.h
@@ -125,6 +125,11 @@ private:
     // child handle error while async learn parent states
     void child_handle_async_learn_error();
 
+    // called by `on_group_check` in `replica_check.cpp`
+    // secondary parent check whether should start or stop split
+    void secondary_parent_handle_split(const group_check_request &request,
+                                       /*out*/ group_check_response &response);
+
     //
     // helper functions
     //

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -341,8 +341,8 @@ public:
         _child_replica->tracker()->wait_outstanding_tasks();
     }
 
-    group_check_response test_secondary_parent_handle_split(split_status::type meta_split_status,
-                                                            split_status::type local_split_status)
+    group_check_response test_trigger_secondary_parent_split(split_status::type meta_split_status,
+                                                             split_status::type local_split_status)
     {
         _parent_replica->set_partition_status(partition_status::PS_SECONDARY);
         parent_set_split_status(local_split_status);
@@ -357,7 +357,7 @@ public:
         }
 
         group_check_response resp;
-        _parent_split_mgr->secondary_parent_handle_split(req, resp);
+        _parent_split_mgr->trigger_secondary_parent_split(req, resp);
         _parent_replica->tracker()->wait_outstanding_tasks();
 
         return resp;
@@ -735,7 +735,7 @@ TEST_F(replica_split_test, register_child_reply_test)
     }
 }
 
-// secondary_parent_handle_split unit test
+// trigger_secondary_parent_split unit test
 TEST_F(replica_split_test, secondary_handle_split_test)
 {
     generate_child();
@@ -743,7 +743,7 @@ TEST_F(replica_split_test, secondary_handle_split_test)
     // Test cases:
     // - secondary parent update partition_count
     // TODO(heyuchen): add more cases
-    struct secondary_parent_handle_split_test
+    struct trigger_secondary_parent_split_test
     {
         split_status::type meta_split_status;
         split_status::type local_split_status;
@@ -756,7 +756,7 @@ TEST_F(replica_split_test, secondary_handle_split_test)
             mock_parent_split_context(partition_status::PS_SECONDARY);
         }
         auto resp =
-            test_secondary_parent_handle_split(test.meta_split_status, test.local_split_status);
+            test_trigger_secondary_parent_split(test.meta_split_status, test.local_split_status);
         ASSERT_EQ(resp.err, ERR_OK);
         ASSERT_TRUE(is_parent_not_in_split());
         ASSERT_EQ(_parent_split_mgr->get_partition_version(), test.expected_partition_version);

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -340,6 +340,28 @@ public:
         _parent_replica->tracker()->wait_outstanding_tasks();
     }
 
+    group_check_response test_secondary_parent_handle_split(split_status::type meta_split_status,
+                                                            split_status::type local_split_status)
+    {
+        _parent_replica->set_partition_status(partition_status::PS_SECONDARY);
+        parent_set_split_status(local_split_status);
+
+        group_check_request req;
+        req.app = _parent_replica->_app_info;
+        req.config.ballot = INIT_BALLOT;
+        req.config.status = partition_status::PS_SECONDARY;
+        req.node = SECONDARY;
+        if (meta_split_status == split_status::NOT_SPLIT) {
+            req.app.partition_count *= 2;
+        }
+
+        group_check_response resp;
+        _parent_split_mgr->secondary_parent_handle_split(req, resp);
+        _parent_replica->tracker()->wait_outstanding_tasks();
+
+        return resp;
+    }
+
     /// helper functions
     void cleanup_prepare_list(mock_replica_ptr rep) { rep->_prepare_list->reset(0); }
     void cleanup_child_split_context()
@@ -690,9 +712,7 @@ TEST_F(replica_split_test, register_child_reply_test)
     // - wrong partition status
     // - response error = INVALID_STATE
     // - response error = CHILD_REGISTERED
-    // - TODO(heyuchen): add response error = OK
-    //   ({partition_status::PS_INACTIVE, ERR_OK, NEW_PARTITION_COUNT - 1})
-    //   after implement parent update group partition count
+    // - response error = OK
     struct register_child_reply_test
     {
         partition_status::type parent_partition_status;
@@ -700,7 +720,8 @@ TEST_F(replica_split_test, register_child_reply_test)
         int32_t expected_parent_partition_version;
     } tests[] = {{partition_status::PS_PRIMARY, ERR_OK, -1},
                  {partition_status::PS_INACTIVE, ERR_INVALID_STATE, -1},
-                 {partition_status::PS_INACTIVE, ERR_CHILD_REGISTERED, -1}};
+                 {partition_status::PS_INACTIVE, ERR_CHILD_REGISTERED, -1},
+                 {partition_status::PS_INACTIVE, ERR_OK, NEW_PARTITION_COUNT - 1}};
     for (auto test : tests) {
         mock_child_split_context(true, true);
         test_on_register_child_reply(test.parent_partition_status, test.resp_err);
@@ -710,6 +731,34 @@ TEST_F(replica_split_test, register_child_reply_test)
             ASSERT_EQ(_parent_split_mgr->get_partition_version(),
                       test.expected_parent_partition_version);
         }
+    }
+}
+
+// secondary_parent_handle_split unit test
+TEST_F(replica_split_test, secondary_handle_split_test)
+{
+    generate_child();
+
+    // Test cases:
+    // - secondary parent update partition_count
+    // TODO(heyuchen): add more cases
+    struct secondary_parent_handle_split_test
+    {
+        split_status::type meta_split_status;
+        split_status::type local_split_status;
+        int32_t expected_partition_version;
+    } tests[]{{split_status::NOT_SPLIT, split_status::SPLITTING, NEW_PARTITION_COUNT - 1}};
+
+    for (auto test : tests) {
+        if (test.local_split_status == split_status::SPLITTING) {
+            mock_child_split_context(true, true);
+            mock_parent_split_context(partition_status::PS_SECONDARY);
+        }
+        auto resp =
+            test_secondary_parent_handle_split(test.meta_split_status, test.local_split_status);
+        ASSERT_EQ(resp.err, ERR_OK);
+        ASSERT_TRUE(is_parent_not_in_split());
+        ASSERT_EQ(_parent_split_mgr->get_partition_version(), test.expected_partition_version);
     }
 }
 


### PR DESCRIPTION
## Simple partition split process
1. meta receives client partition split request, and change partition count #286
2. replica notices partition count changed during on_config_sync #653 
3. parent partition create child partition #291
4. parent prepare states for child to learn #299
5. child partition async learn states from parent #309 #319
6. child notify parent catch up #390
7. update child group partition count #645 
8. register child partition #391
9. **update parent group partition count**

More partition split discussion in issue #69 and partition split design doc
This pr solves the part of ninth step of partition split, which is bold in process description.

## What this pr solve
When primary parent registers child succeed, it will update its own partition_count, then broadcast this to secondary through group_check. Besides, this pull request also adds related unit test.

