### PR TITLE
fix(backup): use existing block_service_manager when add backup policy

### DIFF
--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -36,8 +36,8 @@ block_service_manager::block_service_manager()
 block_service_manager::~block_service_manager()
 {
     zauto_write_lock l(_fs_lock);
-    ddebug("close block service manager.");
     _fs_map.clear();
+    ddebug("close block service manager.");
 }
 
 block_filesystem *block_service_manager::get_block_filesystem(const std::string &provider)

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -33,54 +33,49 @@ block_service_manager::block_service_manager()
 {
 }
 
+block_service_manager::~block_service_manager()
+{
+    zauto_write_lock l(_fs_lock);
+    ddebug("close block service manager.");
+    _fs_map.clear();
+}
+
 block_filesystem *block_service_manager::get_block_filesystem(const std::string &provider)
 {
-    {
-        zauto_read_lock l(_fs_lock);
-        auto iter = _fs_map.find(provider);
-        if (iter != _fs_map.end())
-            return iter->second.get();
+    zauto_write_lock l(_fs_lock);
+    auto iter = _fs_map.find(provider);
+    if (iter != _fs_map.end()) {
+        return iter->second.get();
     }
 
-    {
-        zauto_write_lock l(_fs_lock);
-        auto iter = _fs_map.find(provider);
-        if (iter != _fs_map.end())
-            return iter->second.get();
+    const char *provider_type = dsn_config_get_value_string(
+        (std::string("block_service.") + provider).c_str(), "type", "", "block service type");
 
-        const char *provider_type = dsn_config_get_value_string(
-            (std::string("block_service.") + provider).c_str(), "type", "", "block service type");
+    block_filesystem *fs =
+        utils::factory_store<block_filesystem>::create(provider_type, PROVIDER_TYPE_MAIN);
+    if (fs == nullptr) {
+        derror("acquire block filesystem failed, provider = %s, provider_type = %s",
+               provider.c_str(),
+               provider_type);
+        return nullptr;
+    }
 
-        block_filesystem *fs =
-            utils::factory_store<block_filesystem>::create(provider_type, PROVIDER_TYPE_MAIN);
-        if (fs == nullptr) {
-            derror("acquire block filesystem failed, provider = %s, provider_type = %s",
-                   provider.c_str(),
-                   provider_type);
-            return nullptr;
-        }
+    const char *arguments = dsn_config_get_value_string(
+        (std::string("block_service.") + provider).c_str(), "args", "", "args for block_service");
 
-        const char *arguments =
-            dsn_config_get_value_string((std::string("block_service.") + provider).c_str(),
-                                        "args",
-                                        "",
-                                        "args for block_service");
+    std::vector<std::string> args;
+    utils::split_args(arguments, args);
+    dsn::error_code err = fs->initialize(args);
 
-        std::vector<std::string> args;
-        utils::split_args(arguments, args);
-        dsn::error_code err = fs->initialize(args);
-
-        if (dsn::ERR_OK == err) {
-            ddebug("create block filesystem ok for provider(%s)", provider.c_str());
-            _fs_map.emplace(provider, std::unique_ptr<block_filesystem>(fs));
-            return fs;
-        } else {
-            derror("create block file system err(%s) for provider(%s)",
-                   err.to_string(),
-                   provider.c_str());
-            delete fs;
-            return nullptr;
-        }
+    if (dsn::ERR_OK == err) {
+        ddebug("create block filesystem ok for provider(%s)", provider.c_str());
+        _fs_map.emplace(provider, std::unique_ptr<block_filesystem>(fs));
+        return fs;
+    } else {
+        derror(
+            "create block file system err(%s) for provider(%s)", err.to_string(), provider.c_str());
+        delete fs;
+        return nullptr;
     }
 }
 

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -56,9 +56,9 @@ block_filesystem *block_service_manager::get_or_create_block_filesystem(const st
     block_filesystem *fs =
         utils::factory_store<block_filesystem>::create(provider_type, PROVIDER_TYPE_MAIN);
     if (fs == nullptr) {
-        derror("acquire block filesystem failed, provider = %s, provider_type = %s",
-               provider.c_str(),
-               provider_type);
+        derror_f("acquire block filesystem failed, provider = {}, provider_type = {}",
+                 provider,
+                 std::string(provider_type));
         return nullptr;
     }
 
@@ -70,16 +70,16 @@ block_filesystem *block_service_manager::get_or_create_block_filesystem(const st
     dsn::error_code err = fs->initialize(args);
 
     if (dsn::ERR_OK == err) {
-        ddebug("create block filesystem ok for provider(%s)", provider.c_str());
+        ddebug_f("create block filesystem ok for provider {}", provider);
         zauto_write_lock l(_fs_lock);
         _fs_map.emplace(provider, std::unique_ptr<block_filesystem>(fs));
-        return fs;
     } else {
-        derror(
-            "create block file system err(%s) for provider(%s)", err.to_string(), provider.c_str());
-        delete fs;
-        return nullptr;
+        derror_f("create block file system err {} for provider {}",
+                 std::string(err.to_string()),
+                 provider);
+        fs = nullptr;
     }
+    return fs;
 }
 
 static create_file_response create_block_file_sync(const std::string &remote_file_path,

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -42,12 +42,10 @@ block_service_manager::~block_service_manager()
 
 block_filesystem *block_service_manager::get_or_create_block_filesystem(const std::string &provider)
 {
-    {
-        zauto_write_lock l(_fs_lock);
-        auto iter = _fs_map.find(provider);
-        if (iter != _fs_map.end()) {
-            return iter->second.get();
-        }
+    zauto_write_lock l(_fs_lock);
+    auto iter = _fs_map.find(provider);
+    if (iter != _fs_map.end()) {
+        return iter->second.get();
     }
 
     const char *provider_type = dsn_config_get_value_string(
@@ -71,12 +69,12 @@ block_filesystem *block_service_manager::get_or_create_block_filesystem(const st
 
     if (dsn::ERR_OK == err) {
         ddebug_f("create block filesystem ok for provider {}", provider);
-        zauto_write_lock l(_fs_lock);
         _fs_map.emplace(provider, std::unique_ptr<block_filesystem>(fs));
     } else {
         derror_f("create block file system err {} for provider {}",
                  std::string(err.to_string()),
                  provider);
+        delete fs;
         fs = nullptr;
     }
     return fs;

--- a/src/block_service/block_service_manager.h
+++ b/src/block_service/block_service_manager.h
@@ -27,7 +27,7 @@ class block_service_manager
 public:
     block_service_manager();
     ~block_service_manager();
-    block_filesystem *get_block_filesystem(const std::string &provider);
+    block_filesystem *get_or_create_block_filesystem(const std::string &provider);
 
     // download files from remote file system
     // \return  ERR_FILE_OPERATION_FAILED: local file system error

--- a/src/block_service/block_service_manager.h
+++ b/src/block_service/block_service_manager.h
@@ -26,6 +26,7 @@ class block_service_manager
 {
 public:
     block_service_manager();
+    ~block_service_manager();
     block_filesystem *get_block_filesystem(const std::string &provider);
 
     // download files from remote file system

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -872,9 +872,9 @@ void policy_context::set_policy(const policy &p)
     const std::string old_backup_provider_type = _policy.backup_provider_type;
     _policy = p;
     if (_policy.backup_provider_type != old_backup_provider_type) {
-        _block_service =
-            _backup_service->get_meta_service()->get_block_service_manager().get_block_filesystem(
-                _policy.backup_provider_type);
+        _block_service = _backup_service->get_meta_service()
+                             ->get_block_service_manager()
+                             .get_or_create_block_filesystem(_policy.backup_provider_type);
     }
     dassert(_block_service,
             "can't initialize block filesystem by provider (%s)",
@@ -1263,7 +1263,7 @@ void backup_service::add_backup_policy(dsn::message_ex *msg)
             }
         }
 
-        if (_meta_svc->get_block_service_manager().get_block_filesystem(
+        if (_meta_svc->get_block_service_manager().get_or_create_block_filesystem(
                 request.backup_provider_type) == nullptr) {
             derror("invalid backup_provider_type(%s)", request.backup_provider_type.c_str());
             response.err = ERR_INVALID_PARAMETERS;

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -865,22 +865,6 @@ bool policy_context::is_under_backuping()
     return false;
 }
 
-void policy_context::set_policy(policy &&p)
-{
-    zauto_lock l(_lock);
-
-    const std::string old_backup_provider_type = _policy.backup_provider_type;
-    _policy = std::move(p);
-    if (_policy.backup_provider_type != old_backup_provider_type) {
-        _block_service =
-            _backup_service->get_meta_service()->get_block_service_manager().get_block_filesystem(
-                _policy.backup_provider_type);
-    }
-    dassert(_block_service,
-            "can't initialize block filesystem by provider (%s)",
-            _policy.backup_provider_type.c_str());
-}
-
 void policy_context::set_policy(const policy &p)
 {
     zauto_lock l(_lock);
@@ -1279,14 +1263,11 @@ void backup_service::add_backup_policy(dsn::message_ex *msg)
             }
         }
 
-        {
-            dist::block_service::block_service_manager _block_service_manager;
-            if (_block_service_manager.get_block_filesystem(request.backup_provider_type) ==
-                nullptr) {
-                derror("invalid backup_provider_type(%s)", request.backup_provider_type.c_str());
-                response.err = ERR_INVALID_PARAMETERS;
-                should_create_new_policy = false;
-            }
+        if (_meta_svc->get_block_service_manager().get_block_filesystem(
+                request.backup_provider_type) == nullptr) {
+            derror("invalid backup_provider_type(%s)", request.backup_provider_type.c_str());
+            response.err = ERR_INVALID_PARAMETERS;
+            should_create_new_policy = false;
         }
 
         if (should_create_new_policy) {

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -230,7 +230,6 @@ public:
     }
     mock_virtual ~policy_context() {}
 
-    void set_policy(policy &&p);
     void set_policy(const policy &p);
     policy get_policy();
     void add_backup_history(const backup_info &info);

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -95,7 +95,7 @@ error_code bulk_load_service::check_bulk_load_request_params(const std::string &
 
     // check file provider
     dsn::dist::block_service::block_filesystem *blk_fs =
-        _meta_svc->get_block_service_manager().get_block_filesystem(file_provider);
+        _meta_svc->get_block_service_manager().get_or_create_block_filesystem(file_provider);
     if (blk_fs == nullptr) {
         derror_f("invalid remote file provider type: {}", file_provider);
         hint_msg = "invalid file_provider";

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -47,7 +47,8 @@ void server_state::sync_app_from_backup_media(
             LPC_RESTORE_BACKGROUND, std::move(callback), 0));
 
     block_filesystem *blk_fs =
-        _meta_svc->get_block_service_manager().get_block_filesystem(request.backup_provider_name);
+        _meta_svc->get_block_service_manager().get_or_create_block_filesystem(
+            request.backup_provider_name);
     if (blk_fs == nullptr) {
         derror("acquire block_filesystem(%s) failed", request.backup_provider_name.c_str());
         callback_tsk->enqueue_with(ERR_INVALID_PARAMETERS, dsn::blob());

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -382,7 +382,7 @@ error_code replica_bulk_loader::download_sst_files(const std::string &app_name,
     const std::string remote_dir =
         get_remote_bulk_load_dir(app_name, cluster_name, get_gpid().get_partition_index());
     dist::block_service::block_filesystem *fs =
-        _stub->_block_service_manager.get_block_filesystem(provider_name);
+        _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
 
     // download metadata file synchronously
     uint64_t file_size = 0;

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -43,7 +43,7 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
         } else {
             /// TODO: policy may change provider
             dist::block_service::block_filesystem *block_service =
-                _stub->_block_service_manager.get_block_filesystem(
+                _stub->_block_service_manager.get_or_create_block_filesystem(
                     request.policy.backup_provider_type);
             if (block_service == nullptr) {
                 derror("%s: create cold backup block service failed, provider_type = %s, response "

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -99,7 +99,7 @@ error_code replica::download_checkpoint(const configuration_restore_request &req
                                         const std::string &local_chkpt_dir)
 {
     block_filesystem *fs =
-        _stub->_block_service_manager.get_block_filesystem(req.backup_provider_name);
+        _stub->_block_service_manager.get_or_create_block_filesystem(req.backup_provider_name);
 
     // download metadata file and parse it into cold_backup_meta
     cold_backup_metadata backup_metadata;
@@ -230,7 +230,7 @@ dsn::error_code replica::find_valid_checkpoint(const configuration_restore_reque
     std::string manifest_file = cold_backup::get_current_chkpt_file(
         backup_root, policy_name, req.app_name, old_gpid, backup_id);
     block_filesystem *fs =
-        _stub->_block_service_manager.get_block_filesystem(req.backup_provider_name);
+        _stub->_block_service_manager.get_or_create_block_filesystem(req.backup_provider_name);
     dassert(fs,
             "%s: get block filesystem by provider(%s) failed",
             name(),


### PR DESCRIPTION
The way we determine whether a backup provider is valid is to construct a `block_service_manager` and destroy it, which is not reasonable and may cause problems when use hdfs as backup provider.