### PR TITLE
fix(http): fix message buffers size check

### DIFF
--- a/src/http/http_message_parser.cpp
+++ b/src/http/http_message_parser.cpp
@@ -77,7 +77,7 @@ http_message_parser::http_message_parser()
         // msg->buffers[0] = header
         // msg->buffers[1] = body (blob())
         msg.reset(message_ex::create_receive_message_with_standalone_header(blob()));
-        msg->buffers.resize(BUFFER_SIZE);
+        msg->buffers.resize(HTTP_MSG_BUFFERS_NUM);
 
         message_header *header = msg->header;
         header->hdr_length = sizeof(message_header);

--- a/src/http/http_message_parser.cpp
+++ b/src/http/http_message_parser.cpp
@@ -77,7 +77,7 @@ http_message_parser::http_message_parser()
         // msg->buffers[0] = header
         // msg->buffers[1] = body (blob())
         msg.reset(message_ex::create_receive_message_with_standalone_header(blob()));
-        msg->buffers.resize(4);
+        msg->buffers.resize(BUFFER_SIZE);
 
         message_header *header = msg->header;
         header->hdr_length = sizeof(message_header);

--- a/src/http/http_message_parser.h
+++ b/src/http/http_message_parser.h
@@ -38,6 +38,8 @@ namespace dsn {
 
 DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_HTTP)
 
+#define BUFFER_SIZE 4
+
 // Incoming HTTP requests will be parsed into:
 //
 //    msg->header->rpc_name = "RPC_HTTP_SERVICE"

--- a/src/http/http_message_parser.h
+++ b/src/http/http_message_parser.h
@@ -38,7 +38,8 @@ namespace dsn {
 
 DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_HTTP)
 
-#define BUFFER_SIZE 4
+// Number of blobs that a message_ex contains.
+#define HTTP_MSG_BUFFERS_NUM 4
 
 // Incoming HTTP requests will be parsed into:
 //

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -104,7 +104,7 @@ void http_server::serve(message_ex *msg)
 
 /*static*/ error_with<http_request> http_request::parse(message_ex *m)
 {
-    if (m->buffers.size() != BUFFER_SIZE) {
+    if (m->buffers.size() != HTTP_MSG_BUFFERS_NUM) {
         return error_s::make(ERR_INVALID_DATA,
                              std::string("buffer size is: ") + std::to_string(m->buffers.size()));
     }

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -104,7 +104,7 @@ void http_server::serve(message_ex *msg)
 
 /*static*/ error_with<http_request> http_request::parse(message_ex *m)
 {
-    if (m->buffers.size() != 3) {
+    if (m->buffers.size() != BUFFER_SIZE) {
         return error_s::make(ERR_INVALID_DATA,
                              std::string("buffer size is: ") + std::to_string(m->buffers.size()));
     }

--- a/src/http/test/http_server_test.cpp
+++ b/src/http/test/http_server_test.cpp
@@ -35,7 +35,7 @@ TEST(http_server, parse_url)
         ref_ptr<message_ex> m = message_ex::create_receive_message_with_standalone_header(
             blob::create_from_bytes(std::string("POST")));
         m->buffers.emplace_back(blob::create_from_bytes(std::string(tt.url)));
-        m->buffers.resize(BUFFER_SIZE);
+        m->buffers.resize(HTTP_MSG_BUFFERS_NUM);
 
         auto res = http_request::parse(m.get());
         if (res.is_ok()) {
@@ -137,7 +137,7 @@ public:
             ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
             ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
             ASSERT_EQ(msg->header->context.u.is_request, 1);
-            ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
+            ASSERT_EQ(msg->buffers.size(), HTTP_MSG_BUFFERS_NUM);
             ASSERT_EQ(msg->buffers[2].size(), 1); // url
 
             // ensure states are reset
@@ -178,7 +178,7 @@ TEST_F(http_message_parser_test, parse_request)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_POST);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
+    ASSERT_EQ(msg->buffers.size(), HTTP_MSG_BUFFERS_NUM);
     ASSERT_EQ(msg->buffers[1].to_string(), "Message Body sdfsdf"); // body
     ASSERT_EQ(                                                     // url
         msg->buffers[2].to_string(),
@@ -229,7 +229,7 @@ TEST_F(http_message_parser_test, eof)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
+    ASSERT_EQ(msg->buffers.size(), HTTP_MSG_BUFFERS_NUM);
     ASSERT_EQ(msg->buffers[1].to_string(), ""); // body
     ASSERT_EQ(                                  // url
         msg->buffers[2].to_string(),
@@ -260,7 +260,7 @@ TEST_F(http_message_parser_test, parse_long_url)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
+    ASSERT_EQ(msg->buffers.size(), HTTP_MSG_BUFFERS_NUM);
     ASSERT_EQ(msg->buffers[2].size(), 4097); // url
 }
 
@@ -292,7 +292,7 @@ TEST_F(http_message_parser_test, parse_query_params)
         ref_ptr<message_ex> m = message_ex::create_receive_message_with_standalone_header(
             blob::create_from_bytes(std::string("POST")));
         m->buffers.emplace_back(blob::create_from_bytes(std::string(tt.url)));
-        m->buffers.resize(BUFFER_SIZE);
+        m->buffers.resize(HTTP_MSG_BUFFERS_NUM);
 
         auto res = http_request::parse(m.get());
         if (res.is_ok()) {

--- a/src/http/test/http_server_test.cpp
+++ b/src/http/test/http_server_test.cpp
@@ -35,6 +35,7 @@ TEST(http_server, parse_url)
         ref_ptr<message_ex> m = message_ex::create_receive_message_with_standalone_header(
             blob::create_from_bytes(std::string("POST")));
         m->buffers.emplace_back(blob::create_from_bytes(std::string(tt.url)));
+        m->buffers.resize(BUFFER_SIZE);
 
         auto res = http_request::parse(m.get());
         if (res.is_ok()) {
@@ -136,7 +137,7 @@ public:
             ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
             ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
             ASSERT_EQ(msg->header->context.u.is_request, 1);
-            ASSERT_EQ(msg->buffers.size(), 4);
+            ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
             ASSERT_EQ(msg->buffers[2].size(), 1); // url
 
             // ensure states are reset
@@ -177,7 +178,7 @@ TEST_F(http_message_parser_test, parse_request)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_POST);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), 4);
+    ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
     ASSERT_EQ(msg->buffers[1].to_string(), "Message Body sdfsdf"); // body
     ASSERT_EQ(                                                     // url
         msg->buffers[2].to_string(),
@@ -228,7 +229,7 @@ TEST_F(http_message_parser_test, eof)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), 4);
+    ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
     ASSERT_EQ(msg->buffers[1].to_string(), ""); // body
     ASSERT_EQ(                                  // url
         msg->buffers[2].to_string(),
@@ -259,7 +260,7 @@ TEST_F(http_message_parser_test, parse_long_url)
     ASSERT_EQ(msg->hdr_format, NET_HDR_HTTP);
     ASSERT_EQ(msg->header->hdr_type, http_method::HTTP_METHOD_GET);
     ASSERT_EQ(msg->header->context.u.is_request, 1);
-    ASSERT_EQ(msg->buffers.size(), 4);
+    ASSERT_EQ(msg->buffers.size(), BUFFER_SIZE);
     ASSERT_EQ(msg->buffers[2].size(), 4097); // url
 }
 
@@ -291,6 +292,7 @@ TEST_F(http_message_parser_test, parse_query_params)
         ref_ptr<message_ex> m = message_ex::create_receive_message_with_standalone_header(
             blob::create_from_bytes(std::string("POST")));
         m->buffers.emplace_back(blob::create_from_bytes(std::string(tt.url)));
+        m->buffers.resize(BUFFER_SIZE);
 
         auto res = http_request::parse(m.get());
         if (res.is_ok()) {


### PR DESCRIPTION
In previous pr #593, http server can parse content-type of HTTP request. The incoming http request will parse into message_ex structure, msg->buffers[3] indicate the content-type, the msg->buffers will be resized as 4. When parsing message into http _request, the size of buffers will be checked. However, function `parse` still consider the right size of buffers is 3, it will reject all requests. This pull request fix it, add BUFFER_SIZE and update related unit tests.