### PR TITLE
fix(http): fix parse path from message

### DIFF
--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -151,7 +151,27 @@ void http_server::serve(message_ex *msg)
     if (!unresolved_path.empty() && *unresolved_path.crbegin() == '\0') {
         unresolved_path.pop_back();
     }
-    ret.path = std::move(unresolved_path);
+
+    // parse path
+    std::vector<std::string> args;
+    boost::split(args, unresolved_path, boost::is_any_of("/"));
+    std::vector<std::string> real_args;
+    for (std::string &arg : args) {
+        if (!arg.empty()) {
+            real_args.emplace_back(std::move(arg));
+        }
+    }
+    if (real_args.size() == 0) {
+        ret.path = "";
+    } else {
+        std::string path = real_args[0];
+        for (int i = 1; i < real_args.size(); i++) {
+            path += '/';
+            path += real_args[i];
+        }
+        ddebug("hyc: path = %s", path.c_str());
+        ret.path = std::move(path);
+    }
 
     // find if there are method args (<ip>:<port>/<service>/<method>?<arg>=<val>&<arg>=<val>)
     if (!unresolved_query.empty()) {

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -169,7 +169,6 @@ void http_server::serve(message_ex *msg)
             path += '/';
             path += real_args[i];
         }
-        ddebug("hyc: path = %s", path.c_str());
         ret.path = std::move(path);
     }
 

--- a/src/http/test/http_server_test.cpp
+++ b/src/http/test/http_server_test.cpp
@@ -21,14 +21,14 @@ TEST(http_server, parse_url)
         std::string path;
     } tests[] = {
         {"http://127.0.0.1:34601", ERR_OK, ""},
-        {"http://127.0.0.1:34601/", ERR_OK, "/"},
-        {"http://127.0.0.1:34601///", ERR_OK, "///"},
-        {"http://127.0.0.1:34601/threads", ERR_OK, "/threads"},
-        {"http://127.0.0.1:34601/threads/?detail", ERR_OK, "/threads/"},
-        {"http://127.0.0.1:34601//pprof/heap/", ERR_OK, "//pprof/heap/"},
-        {"http://127.0.0.1:34601//pprof///heap?detailed=true", ERR_OK, "//pprof///heap"},
-        {"http://127.0.0.1:34601/pprof/heap/arg/", ERR_OK, "/pprof/heap/arg/"},
-        {"http://127.0.0.1:34601/pprof///heap///arg/", ERR_OK, "/pprof///heap///arg/"},
+        {"http://127.0.0.1:34601/", ERR_OK, ""},
+        {"http://127.0.0.1:34601///", ERR_OK, ""},
+        {"http://127.0.0.1:34601/threads", ERR_OK, "threads"},
+        {"http://127.0.0.1:34601/threads/?detail", ERR_OK, "threads"},
+        {"http://127.0.0.1:34601//pprof/heap/", ERR_OK, "pprof/heap"},
+        {"http://127.0.0.1:34601//pprof///heap?detailed=true", ERR_OK, "pprof/heap"},
+        {"http://127.0.0.1:34601/pprof/heap/arg/", ERR_OK, "pprof/heap/arg"},
+        {"http://127.0.0.1:34601/pprof///heap///arg/", ERR_OK, "pprof/heap/arg"},
     };
 
     for (auto tt : tests) {


### PR DESCRIPTION
In #594, it simplified http path, but it left a problem. For example:
The http request sent to meta server to list all apps is like `ip:port/meta/apps`, http server will add a tuple like `<'meta/apps', 'apps_handler'>`, when server receives a http request, it will parse path from request, and find the handler by path. 
In current implementation, the registered path is like `meta/apps`, and the path parsed from request is `/meta/apps`, as a result, the handler can not be found. 
This pr fix this problem, the path parsed from request will be `meta/apps` as the implementation before #594.

