### PR TITLE
thirdparty: update fmtlib

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -193,9 +193,9 @@ ExternalProject_Add(fds
         )
 
 ExternalProject_Add(fmt
-        URL ${OSS_URL_PREFIX}/fmt-7.1.2.zip
-        https://github.com/fmtlib/fmt/releases/download/7.1.2/fmt-7.1.2.zip
-        URL_MD5 cd838fb47c92b3221986a2f454331178
+        URL ${OSS_URL_PREFIX}/fmt-5.3.0.zip
+        https://github.com/fmtlib/fmt/releases/download/5.3.0/fmt-5.3.0.zip
+        URL_MD5 56717619dcd9fa8c470533eb4d7d33aa
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
         -DCMAKE_BUILD_TYPE=release
         -DFMT_TEST=false


### PR DESCRIPTION
The pull request #666 updates thirdparty fmtlib from 4.0.0 to latest 7.1.2, the later version will lead to compile error for gcc 5.4.0. This pull request updates fmtlib version to 5.3.0, the latest version who would not lead to compile problem.