### PR TITLE
fix: fmtlib incompatibility problems from 7.1.3 to 5.3.0

### DIFF
--- a/src/utils/time_utils.cpp
+++ b/src/utils/time_utils.cpp
@@ -19,6 +19,9 @@
 
 #include <dsn/utils/time_utils.h>
 #include <fmt/chrono.h>
+#if FMT_VERSION < 60000
+#include <fmt/time.h> // time.h was removed from fmtlib >=6.x
+#endif
 #include <fmt/printf.h>
 
 namespace dsn {

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -192,6 +192,7 @@ ExternalProject_Add(fds
         BUILD_IN_SOURCE 1
         )
 
+# fmtlib >=6.x requires c++14 support, do not update this library for now
 ExternalProject_Add(fmt
         URL ${OSS_URL_PREFIX}/fmt-5.3.0.zip
         https://github.com/fmtlib/fmt/releases/download/5.3.0/fmt-5.3.0.zip


### PR DESCRIPTION
time_utils.cpp was unable to compile because of the rollback of fmtlib in this PR https://github.com/XiaoMi/rdsn/pull/671.
Because in fmtlib <6.x versions, we need `fmt/time.h` to be included together for time format. This file was removed for 6.x+ versions.