### PR TITLE
refactor: remove support_write_vec in aio_task

### DIFF
--- a/include/dsn/tool-api/aio_task.h
+++ b/include/dsn/tool-api/aio_task.h
@@ -51,7 +51,6 @@ public:
     // filled by apps
     dsn_handle_t file;
     void *buffer;
-    std::vector<dsn_file_buffer_t> *write_buffer_vec;
     uint32_t buffer_size;
     uint64_t file_offset;
 
@@ -63,7 +62,6 @@ public:
     aio_context()
         : file(nullptr),
           buffer(nullptr),
-          write_buffer_vec(nullptr),
           buffer_size(0),
           file_offset(0),
           type(AIO_Invalid),

--- a/include/dsn/tool-api/aio_task.h
+++ b/include/dsn/tool-api/aio_task.h
@@ -51,8 +51,7 @@ public:
     // filled by apps
     dsn_handle_t file;
     void *buffer;
-    bool support_write_vec; // if the aio provider supports write buffer vector
-    std::vector<dsn_file_buffer_t> *write_buffer_vec; // only used if support_write_vec is true
+    std::vector<dsn_file_buffer_t> *write_buffer_vec;
     uint32_t buffer_size;
     uint64_t file_offset;
 
@@ -64,7 +63,6 @@ public:
     aio_context()
         : file(nullptr),
           buffer(nullptr),
-          support_write_vec(false),
           write_buffer_vec(nullptr),
           buffer_size(0),
           file_offset(0),

--- a/src/aio/aio_provider.cpp
+++ b/src/aio/aio_provider.cpp
@@ -33,12 +33,9 @@ aio_provider::aio_provider(disk_engine *disk) : _engine(disk) {}
 
 service_node *aio_provider::node() const { return _engine->node(); }
 
-void aio_provider::complete_io(aio_task *aio,
-                               error_code err,
-                               uint32_t bytes,
-                               int delay_milliseconds)
+void aio_provider::complete_io(aio_task *aio, error_code err, uint32_t bytes)
 {
-    _engine->complete_io(aio, err, bytes, delay_milliseconds);
+    _engine->complete_io(aio, err, bytes);
 }
 
 namespace tools {

--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -71,7 +71,7 @@ public:
 
     virtual aio_context *prepare_aio_context(aio_task *) = 0;
 
-    void complete_io(aio_task *aio, error_code err, uint32_t bytes, int delay_milliseconds = 0);
+    void complete_io(aio_task *aio, error_code err, uint32_t bytes);
 
 private:
     disk_engine *_engine;

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -207,10 +207,7 @@ void disk_engine::process_write(aio_task *aio, uint32_t sz)
 
     // no batching
     if (dio->buffer_size == sz) {
-        if (dio->buffer == nullptr) {
-            aio->collapse();
-        }
-        dassert(dio->buffer || dio->write_buffer_vec, "");
+        aio->collapse();
         _provider->submit_aio_task(aio);
     }
 

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -244,7 +244,7 @@ void disk_engine::process_write(aio_task *aio, uint32_t sz)
     }
 }
 
-void disk_engine::complete_io(aio_task *aio, error_code err, uint32_t bytes, int delay_milliseconds)
+void disk_engine::complete_io(aio_task *aio, error_code err, uint32_t bytes)
 {
     if (err != ERR_OK) {
         dinfo("disk operation failure with code %s, err = %s, aio_task_id = %016" PRIx64,

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -208,11 +208,7 @@ void disk_engine::process_write(aio_task *aio, uint32_t sz)
     // no batching
     if (dio->buffer_size == sz) {
         if (dio->buffer == nullptr) {
-            if (dio->support_write_vec) {
-                dio->write_buffer_vec = &aio->_unmerged_write_buffers;
-            } else {
-                aio->collapse();
-            }
+            aio->collapse();
         }
         dassert(dio->buffer || dio->write_buffer_vec, "");
         _provider->submit_aio_task(aio);

--- a/src/aio/disk_engine.h
+++ b/src/aio/disk_engine.h
@@ -82,7 +82,7 @@ private:
     ~disk_engine() = default;
 
     void process_write(aio_task *wk, uint32_t sz);
-    void complete_io(aio_task *aio, error_code err, uint32_t bytes, int delay_milliseconds = 0);
+    void complete_io(aio_task *aio, error_code err, uint32_t bytes);
 
     std::unique_ptr<aio_provider> _provider;
     service_node *_node;

--- a/src/aio/sim_aio_provider.cpp
+++ b/src/aio/sim_aio_provider.cpp
@@ -39,7 +39,7 @@ void sim_aio_provider::submit_aio_task(aio_task *aio)
     uint32_t bytes;
 
     err = aio_internal(aio, false, &bytes);
-    complete_io(aio, err, bytes, 0);
+    complete_io(aio, err, bytes);
 }
 
 } // namespace aio


### PR DESCRIPTION
`aio_task::support_write_vec` is initiated to false, and nowhere it's set to true. So I remove this variable to make the code clear.