### PR TITLE
feat(security): enable access replica when appenv `replica_access_controller.allowed_users` is empty

### DIFF
--- a/src/runtime/security/replica_access_controller.cpp
+++ b/src/runtime/security/replica_access_controller.cpp
@@ -34,7 +34,7 @@ bool replica_access_controller::allowed(message_ex *msg)
 
     {
         utils::auto_read_lock l(_lock);
-        if (_users.find(user_name) == _users.end()) {
+        if (!_users.empty() && _users.find(user_name) == _users.end()) {
             ddebug_f("{}: user_name {} doesn't exist in acls map", _name, user_name);
             return false;
         }

--- a/src/runtime/security/replica_access_controller.cpp
+++ b/src/runtime/security/replica_access_controller.cpp
@@ -34,6 +34,10 @@ bool replica_access_controller::allowed(message_ex *msg)
 
     {
         utils::auto_read_lock l(_lock);
+        // If the user didn't specify any ACL, it means this table is publicly accessible to
+        // everyone. This is a backdoor to allow old-version clients to gracefully upgrade. After
+        // they are finally ensured to be fully upgraded, they can specify some usernames to ACL and
+        // the table will be truly protected.
         if (!_users.empty() && _users.find(user_name) == _users.end()) {
             ddebug_f("{}: user_name {} doesn't exist in acls map", _name, user_name);
             return false;

--- a/src/runtime/test/replica_access_controller_test.cpp
+++ b/src/runtime/test/replica_access_controller_test.cpp
@@ -52,7 +52,7 @@ TEST_F(replica_access_controller_test, allowed)
         bool result;
     } tests[] = {{{"replica_user1", "replica_user2"}, "replica_user1", true},
                  {{"replica_user1", "replica_user2"}, "not_replica_user", false},
-                 {{}, "user_name", false}};
+                 {{}, "user_name", true}};
 
     bool origin_enable_acl = FLAGS_enable_acl;
     FLAGS_enable_acl = true;

--- a/src/utils/test/utils.cpp
+++ b/src/utils/test/utils.cpp
@@ -107,10 +107,19 @@ TEST(core, split_args)
     dsn::utils::split_args(value.c_str(), sargs_set, ',');
     EXPECT_EQ(sargs_set.size(), 3);
 
+    // test value = ""
     value = "";
     sargs.clear();
     dsn::utils::split_args(value.c_str(), sargs, ',');
     EXPECT_EQ(sargs.size(), 0);
+
+    sargs2.clear();
+    dsn::utils::split_args(value.c_str(), sargs2, ',');
+    EXPECT_EQ(sargs2.size(), 0);
+
+    sargs_set.clear();
+    dsn::utils::split_args(value.c_str(), sargs_set, ',');
+    EXPECT_EQ(sargs_set.size(), 0);
 }
 
 TEST(core, split_args_keep_place_holder)

--- a/src/utils/test/utils.cpp
+++ b/src/utils/test/utils.cpp
@@ -106,6 +106,11 @@ TEST(core, split_args)
     std::unordered_set<std::string> sargs_set;
     dsn::utils::split_args(value.c_str(), sargs_set, ',');
     EXPECT_EQ(sargs_set.size(), 3);
+
+    value = "";
+    sargs.clear();
+    dsn::utils::split_args(value.c_str(), sargs, ',');
+    EXPECT_EQ(sargs.size(), 0);
 }
 
 TEST(core, split_args_keep_place_holder)


### PR DESCRIPTION
enable access replica when appenv `replica_access_controller.allowed_users` is empty.
So the access to replica is enabled when the appenv is not set.