### PR TITLE
fix: compile error of zookeeper 3.4.10 on gcc9

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -132,7 +132,7 @@ ExternalProject_Add(zookeeper
         URL ${OSS_URL_PREFIX}/zookeeper-3.4.10.tar.gz
         http://ftp.jaist.ac.jp/pub/apache/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz
         URL_MD5 e4cf1b1593ca870bf1c7a75188f09678
-        CONFIGURE_COMMAND cd src/c && ./configure --enable-static=yes --enable-shared=no --prefix=${TP_OUTPUT} --with-pic=yes
+        CONFIGURE_COMMAND cd src/c && CFLAGS=-Wno-error=format-overflow ./configure --enable-static=yes --enable-shared=no --prefix=${TP_OUTPUT} --with-pic=yes
         BUILD_COMMAND cd src/c && make
         INSTALL_COMMAND cd src/c && make install
         BUILD_IN_SOURCE 1


### PR DESCRIPTION
## compilation error

```
src/zookeeper.c: In function 'format_endpoint_info':
src/zookeeper.c:3469:21: error: '%d' directive writing between 1 and 5 bytes into a region of size between 0 and 127 [-Werror=format-overflow=]
 3469 |     sprintf(buf,"%s:%d",addrstr,ntohs(port));
      |                     ^~
src/zookeeper.c:3469:17: note: directive argument in the range [0, 65535]
 3469 |     sprintf(buf,"%s:%d",addrstr,ntohs(port));
      |                 ^~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ./include/zookeeper.h:29,
                 from src/zookeeper.c:27:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: '__builtin___sprintf_chk' output between 3 and 134 bytes into a destination of size 128
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

GCC9 generates errors on the zookeeper c client 3.4.10. My previous attempt on this issue: https://github.com/XiaoMi/rdsn/pull/667
