### PR TITLE
feat(bulk-load): support user-define remote storage root path

### DIFF
--- a/include/dsn/dist/replication/replication_ddl_client.h
+++ b/include/dsn/dist/replication/replication_ddl_client.h
@@ -180,7 +180,8 @@ public:
 
     error_with<start_bulk_load_response> start_bulk_load(const std::string &app_name,
                                                          const std::string &cluster_name,
-                                                         const std::string &file_provider_type);
+                                                         const std::string &file_provider_type,
+                                                         const std::string &remote_root_path);
 
     error_with<control_bulk_load_response>
     control_bulk_load(const std::string &app_name, const bulk_load_control_type::type control_type);

--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -6708,12 +6708,13 @@ inline std::ostream &operator<<(std::ostream &out, const bulk_load_metadata &obj
 typedef struct _start_bulk_load_request__isset
 {
     _start_bulk_load_request__isset()
-        : app_name(false), cluster_name(false), file_provider_type(false)
+        : app_name(false), cluster_name(false), file_provider_type(false), remote_root_path(false)
     {
     }
     bool app_name : 1;
     bool cluster_name : 1;
     bool file_provider_type : 1;
+    bool remote_root_path : 1;
 } _start_bulk_load_request__isset;
 
 class start_bulk_load_request
@@ -6723,12 +6724,15 @@ public:
     start_bulk_load_request(start_bulk_load_request &&);
     start_bulk_load_request &operator=(const start_bulk_load_request &);
     start_bulk_load_request &operator=(start_bulk_load_request &&);
-    start_bulk_load_request() : app_name(), cluster_name(), file_provider_type() {}
+    start_bulk_load_request() : app_name(), cluster_name(), file_provider_type(), remote_root_path()
+    {
+    }
 
     virtual ~start_bulk_load_request() throw();
     std::string app_name;
     std::string cluster_name;
     std::string file_provider_type;
+    std::string remote_root_path;
 
     _start_bulk_load_request__isset __isset;
 
@@ -6738,6 +6742,8 @@ public:
 
     void __set_file_provider_type(const std::string &val);
 
+    void __set_remote_root_path(const std::string &val);
+
     bool operator==(const start_bulk_load_request &rhs) const
     {
         if (!(app_name == rhs.app_name))
@@ -6745,6 +6751,8 @@ public:
         if (!(cluster_name == rhs.cluster_name))
             return false;
         if (!(file_provider_type == rhs.file_provider_type))
+            return false;
+        if (!(remote_root_path == rhs.remote_root_path))
             return false;
         return true;
     }
@@ -6922,7 +6930,8 @@ typedef struct _bulk_load_request__isset
           cluster_name(false),
           ballot(false),
           meta_bulk_load_status(false),
-          query_bulk_load_metadata(false)
+          query_bulk_load_metadata(false),
+          remote_root_path(false)
     {
     }
     bool pid : 1;
@@ -6933,6 +6942,7 @@ typedef struct _bulk_load_request__isset
     bool ballot : 1;
     bool meta_bulk_load_status : 1;
     bool query_bulk_load_metadata : 1;
+    bool remote_root_path : 1;
 } _bulk_load_request__isset;
 
 class bulk_load_request
@@ -6948,7 +6958,8 @@ public:
           cluster_name(),
           ballot(0),
           meta_bulk_load_status((bulk_load_status::type)0),
-          query_bulk_load_metadata(0)
+          query_bulk_load_metadata(0),
+          remote_root_path()
     {
     }
 
@@ -6961,6 +6972,7 @@ public:
     int64_t ballot;
     bulk_load_status::type meta_bulk_load_status;
     bool query_bulk_load_metadata;
+    std::string remote_root_path;
 
     _bulk_load_request__isset __isset;
 
@@ -6980,6 +6992,8 @@ public:
 
     void __set_query_bulk_load_metadata(const bool val);
 
+    void __set_remote_root_path(const std::string &val);
+
     bool operator==(const bulk_load_request &rhs) const
     {
         if (!(pid == rhs.pid))
@@ -6997,6 +7011,8 @@ public:
         if (!(meta_bulk_load_status == rhs.meta_bulk_load_status))
             return false;
         if (!(query_bulk_load_metadata == rhs.query_bulk_load_metadata))
+            return false;
+        if (!(remote_root_path == rhs.remote_root_path))
             return false;
         return true;
     }
@@ -7163,7 +7179,8 @@ typedef struct _group_bulk_load_request__isset
           config(false),
           provider_name(false),
           cluster_name(false),
-          meta_bulk_load_status(false)
+          meta_bulk_load_status(false),
+          remote_root_path(false)
     {
     }
     bool app_name : 1;
@@ -7172,6 +7189,7 @@ typedef struct _group_bulk_load_request__isset
     bool provider_name : 1;
     bool cluster_name : 1;
     bool meta_bulk_load_status : 1;
+    bool remote_root_path : 1;
 } _group_bulk_load_request__isset;
 
 class group_bulk_load_request
@@ -7185,7 +7203,8 @@ public:
         : app_name(),
           provider_name(),
           cluster_name(),
-          meta_bulk_load_status((bulk_load_status::type)0)
+          meta_bulk_load_status((bulk_load_status::type)0),
+          remote_root_path()
     {
     }
 
@@ -7196,6 +7215,7 @@ public:
     std::string provider_name;
     std::string cluster_name;
     bulk_load_status::type meta_bulk_load_status;
+    std::string remote_root_path;
 
     _group_bulk_load_request__isset __isset;
 
@@ -7211,6 +7231,8 @@ public:
 
     void __set_meta_bulk_load_status(const bulk_load_status::type val);
 
+    void __set_remote_root_path(const std::string &val);
+
     bool operator==(const group_bulk_load_request &rhs) const
     {
         if (!(app_name == rhs.app_name))
@@ -7224,6 +7246,8 @@ public:
         if (!(cluster_name == rhs.cluster_name))
             return false;
         if (!(meta_bulk_load_status == rhs.meta_bulk_load_status))
+            return false;
+        if (!(remote_root_path == rhs.remote_root_path))
             return false;
         return true;
     }

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1552,12 +1552,14 @@ void replication_ddl_client::query_disk_info(
 error_with<start_bulk_load_response>
 replication_ddl_client::start_bulk_load(const std::string &app_name,
                                         const std::string &cluster_name,
-                                        const std::string &file_provider_type)
+                                        const std::string &file_provider_type,
+                                        const std::string &remote_root_path)
 {
     auto req = make_unique<start_bulk_load_request>();
     req->app_name = app_name;
     req->cluster_name = cluster_name;
     req->file_provider_type = file_provider_type;
+    req->remote_root_path = remote_root_path;
     return call_rpc_sync(start_bulk_load_rpc(std::move(req), RPC_CM_START_BULK_LOAD));
 }
 

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -514,11 +514,6 @@ void replication_options::initialize()
                                          cold_backup_checkpoint_reserve_minutes,
                                          "reserve minutes of cold backup checkpoint");
 
-    bulk_load_provider_root = dsn_config_get_value_string("replication",
-                                                          "bulk_load_provider_root",
-                                                          "bulk_load_provider_root",
-                                                          "bulk load root on remote file provider");
-
     max_concurrent_bulk_load_downloading_count = FLAGS_max_concurrent_bulk_load_downloading_count;
 
     replica_helper::load_meta_servers(meta_servers);

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -120,7 +120,6 @@ public:
     std::string cold_backup_root;
     int32_t cold_backup_checkpoint_reserve_minutes;
 
-    std::string bulk_load_provider_root;
     int32_t max_concurrent_bulk_load_downloading_count;
 
 public:

--- a/src/common/replication_types.cpp
+++ b/src/common/replication_types.cpp
@@ -15611,6 +15611,11 @@ void start_bulk_load_request::__set_file_provider_type(const std::string &val)
     this->file_provider_type = val;
 }
 
+void start_bulk_load_request::__set_remote_root_path(const std::string &val)
+{
+    this->remote_root_path = val;
+}
+
 uint32_t start_bulk_load_request::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -15654,6 +15659,14 @@ uint32_t start_bulk_load_request::read(::apache::thrift::protocol::TProtocol *ip
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 4:
+            if (ftype == ::apache::thrift::protocol::T_STRING) {
+                xfer += iprot->readString(this->remote_root_path);
+                this->__isset.remote_root_path = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -15684,6 +15697,10 @@ uint32_t start_bulk_load_request::write(::apache::thrift::protocol::TProtocol *o
     xfer += oprot->writeString(this->file_provider_type);
     xfer += oprot->writeFieldEnd();
 
+    xfer += oprot->writeFieldBegin("remote_root_path", ::apache::thrift::protocol::T_STRING, 4);
+    xfer += oprot->writeString(this->remote_root_path);
+    xfer += oprot->writeFieldEnd();
+
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -15695,6 +15712,7 @@ void swap(start_bulk_load_request &a, start_bulk_load_request &b)
     swap(a.app_name, b.app_name);
     swap(a.cluster_name, b.cluster_name);
     swap(a.file_provider_type, b.file_provider_type);
+    swap(a.remote_root_path, b.remote_root_path);
     swap(a.__isset, b.__isset);
 }
 
@@ -15703,6 +15721,7 @@ start_bulk_load_request::start_bulk_load_request(const start_bulk_load_request &
     app_name = other680.app_name;
     cluster_name = other680.cluster_name;
     file_provider_type = other680.file_provider_type;
+    remote_root_path = other680.remote_root_path;
     __isset = other680.__isset;
 }
 start_bulk_load_request::start_bulk_load_request(start_bulk_load_request &&other681)
@@ -15710,6 +15729,7 @@ start_bulk_load_request::start_bulk_load_request(start_bulk_load_request &&other
     app_name = std::move(other681.app_name);
     cluster_name = std::move(other681.cluster_name);
     file_provider_type = std::move(other681.file_provider_type);
+    remote_root_path = std::move(other681.remote_root_path);
     __isset = std::move(other681.__isset);
 }
 start_bulk_load_request &start_bulk_load_request::operator=(const start_bulk_load_request &other682)
@@ -15717,6 +15737,7 @@ start_bulk_load_request &start_bulk_load_request::operator=(const start_bulk_loa
     app_name = other682.app_name;
     cluster_name = other682.cluster_name;
     file_provider_type = other682.file_provider_type;
+    remote_root_path = other682.remote_root_path;
     __isset = other682.__isset;
     return *this;
 }
@@ -15725,6 +15746,7 @@ start_bulk_load_request &start_bulk_load_request::operator=(start_bulk_load_requ
     app_name = std::move(other683.app_name);
     cluster_name = std::move(other683.cluster_name);
     file_provider_type = std::move(other683.file_provider_type);
+    remote_root_path = std::move(other683.remote_root_path);
     __isset = std::move(other683.__isset);
     return *this;
 }
@@ -15737,6 +15759,8 @@ void start_bulk_load_request::printTo(std::ostream &out) const
         << "cluster_name=" << to_string(cluster_name);
     out << ", "
         << "file_provider_type=" << to_string(file_provider_type);
+    out << ", "
+        << "remote_root_path=" << to_string(remote_root_path);
     out << ")";
 }
 
@@ -16100,6 +16124,11 @@ void bulk_load_request::__set_query_bulk_load_metadata(const bool val)
     this->query_bulk_load_metadata = val;
 }
 
+void bulk_load_request::__set_remote_root_path(const std::string &val)
+{
+    this->remote_root_path = val;
+}
+
 uint32_t bulk_load_request::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -16185,6 +16214,14 @@ uint32_t bulk_load_request::read(::apache::thrift::protocol::TProtocol *iprot)
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 9:
+            if (ftype == ::apache::thrift::protocol::T_STRING) {
+                xfer += iprot->readString(this->remote_root_path);
+                this->__isset.remote_root_path = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -16236,6 +16273,10 @@ uint32_t bulk_load_request::write(::apache::thrift::protocol::TProtocol *oprot) 
     xfer += oprot->writeBool(this->query_bulk_load_metadata);
     xfer += oprot->writeFieldEnd();
 
+    xfer += oprot->writeFieldBegin("remote_root_path", ::apache::thrift::protocol::T_STRING, 9);
+    xfer += oprot->writeString(this->remote_root_path);
+    xfer += oprot->writeFieldEnd();
+
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -16252,6 +16293,7 @@ void swap(bulk_load_request &a, bulk_load_request &b)
     swap(a.ballot, b.ballot);
     swap(a.meta_bulk_load_status, b.meta_bulk_load_status);
     swap(a.query_bulk_load_metadata, b.query_bulk_load_metadata);
+    swap(a.remote_root_path, b.remote_root_path);
     swap(a.__isset, b.__isset);
 }
 
@@ -16265,6 +16307,7 @@ bulk_load_request::bulk_load_request(const bulk_load_request &other694)
     ballot = other694.ballot;
     meta_bulk_load_status = other694.meta_bulk_load_status;
     query_bulk_load_metadata = other694.query_bulk_load_metadata;
+    remote_root_path = other694.remote_root_path;
     __isset = other694.__isset;
 }
 bulk_load_request::bulk_load_request(bulk_load_request &&other695)
@@ -16277,6 +16320,7 @@ bulk_load_request::bulk_load_request(bulk_load_request &&other695)
     ballot = std::move(other695.ballot);
     meta_bulk_load_status = std::move(other695.meta_bulk_load_status);
     query_bulk_load_metadata = std::move(other695.query_bulk_load_metadata);
+    remote_root_path = std::move(other695.remote_root_path);
     __isset = std::move(other695.__isset);
 }
 bulk_load_request &bulk_load_request::operator=(const bulk_load_request &other696)
@@ -16289,6 +16333,7 @@ bulk_load_request &bulk_load_request::operator=(const bulk_load_request &other69
     ballot = other696.ballot;
     meta_bulk_load_status = other696.meta_bulk_load_status;
     query_bulk_load_metadata = other696.query_bulk_load_metadata;
+    remote_root_path = other696.remote_root_path;
     __isset = other696.__isset;
     return *this;
 }
@@ -16302,6 +16347,7 @@ bulk_load_request &bulk_load_request::operator=(bulk_load_request &&other697)
     ballot = std::move(other697.ballot);
     meta_bulk_load_status = std::move(other697.meta_bulk_load_status);
     query_bulk_load_metadata = std::move(other697.query_bulk_load_metadata);
+    remote_root_path = std::move(other697.remote_root_path);
     __isset = std::move(other697.__isset);
     return *this;
 }
@@ -16324,6 +16370,8 @@ void bulk_load_request::printTo(std::ostream &out) const
         << "meta_bulk_load_status=" << to_string(meta_bulk_load_status);
     out << ", "
         << "query_bulk_load_metadata=" << to_string(query_bulk_load_metadata);
+    out << ", "
+        << "remote_root_path=" << to_string(remote_root_path);
     out << ")";
 }
 
@@ -16714,6 +16762,11 @@ void group_bulk_load_request::__set_meta_bulk_load_status(const bulk_load_status
     this->meta_bulk_load_status = val;
 }
 
+void group_bulk_load_request::__set_remote_root_path(const std::string &val)
+{
+    this->remote_root_path = val;
+}
+
 uint32_t group_bulk_load_request::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -16783,6 +16836,14 @@ uint32_t group_bulk_load_request::read(::apache::thrift::protocol::TProtocol *ip
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 7:
+            if (ftype == ::apache::thrift::protocol::T_STRING) {
+                xfer += iprot->readString(this->remote_root_path);
+                this->__isset.remote_root_path = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -16825,6 +16886,10 @@ uint32_t group_bulk_load_request::write(::apache::thrift::protocol::TProtocol *o
     xfer += oprot->writeI32((int32_t)this->meta_bulk_load_status);
     xfer += oprot->writeFieldEnd();
 
+    xfer += oprot->writeFieldBegin("remote_root_path", ::apache::thrift::protocol::T_STRING, 7);
+    xfer += oprot->writeString(this->remote_root_path);
+    xfer += oprot->writeFieldEnd();
+
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -16839,6 +16904,7 @@ void swap(group_bulk_load_request &a, group_bulk_load_request &b)
     swap(a.provider_name, b.provider_name);
     swap(a.cluster_name, b.cluster_name);
     swap(a.meta_bulk_load_status, b.meta_bulk_load_status);
+    swap(a.remote_root_path, b.remote_root_path);
     swap(a.__isset, b.__isset);
 }
 
@@ -16850,6 +16916,7 @@ group_bulk_load_request::group_bulk_load_request(const group_bulk_load_request &
     provider_name = other712.provider_name;
     cluster_name = other712.cluster_name;
     meta_bulk_load_status = other712.meta_bulk_load_status;
+    remote_root_path = other712.remote_root_path;
     __isset = other712.__isset;
 }
 group_bulk_load_request::group_bulk_load_request(group_bulk_load_request &&other713)
@@ -16860,6 +16927,7 @@ group_bulk_load_request::group_bulk_load_request(group_bulk_load_request &&other
     provider_name = std::move(other713.provider_name);
     cluster_name = std::move(other713.cluster_name);
     meta_bulk_load_status = std::move(other713.meta_bulk_load_status);
+    remote_root_path = std::move(other713.remote_root_path);
     __isset = std::move(other713.__isset);
 }
 group_bulk_load_request &group_bulk_load_request::operator=(const group_bulk_load_request &other714)
@@ -16870,6 +16938,7 @@ group_bulk_load_request &group_bulk_load_request::operator=(const group_bulk_loa
     provider_name = other714.provider_name;
     cluster_name = other714.cluster_name;
     meta_bulk_load_status = other714.meta_bulk_load_status;
+    remote_root_path = other714.remote_root_path;
     __isset = other714.__isset;
     return *this;
 }
@@ -16881,6 +16950,7 @@ group_bulk_load_request &group_bulk_load_request::operator=(group_bulk_load_requ
     provider_name = std::move(other715.provider_name);
     cluster_name = std::move(other715.cluster_name);
     meta_bulk_load_status = std::move(other715.meta_bulk_load_status);
+    remote_root_path = std::move(other715.remote_root_path);
     __isset = std::move(other715.__isset);
     return *this;
 }
@@ -16899,6 +16969,8 @@ void group_bulk_load_request::printTo(std::ostream &out) const
         << "cluster_name=" << to_string(cluster_name);
     out << ", "
         << "meta_bulk_load_status=" << to_string(meta_bulk_load_status);
+    out << ", "
+        << "remote_root_path=" << to_string(remote_root_path);
     out << ")";
 }
 

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -23,8 +23,14 @@ struct app_bulk_load_info
     std::string cluster_name;
     std::string file_provider_type;
     bulk_load_status::type status;
-    DEFINE_JSON_SERIALIZATION(
-        app_id, partition_count, app_name, cluster_name, file_provider_type, status)
+    std::string remote_root_path;
+    DEFINE_JSON_SERIALIZATION(app_id,
+                              partition_count,
+                              app_name,
+                              cluster_name,
+                              file_provider_type,
+                              status,
+                              remote_root_path)
 };
 
 struct partition_bulk_load_info
@@ -110,6 +116,7 @@ private:
     error_code check_bulk_load_request_params(const std::string &app_name,
                                               const std::string &cluster_name,
                                               const std::string &file_provider,
+                                              const std::string &remote_root_path,
                                               const int32_t app_id,
                                               const int32_t partition_count,
                                               std::string &hint_msg);
@@ -264,13 +271,14 @@ private:
     /// helper functions
     ///
     // get bulk_load_info path on file provider
-    // <bulk_load_provider_root>/<cluster_name>/<app_name>/bulk_load_info
+    // <remote_root_path>/<cluster_name>/<app_name>/bulk_load_info
     inline std::string get_bulk_load_info_path(const std::string &app_name,
-                                               const std::string &cluster_name) const
+                                               const std::string &cluster_name,
+                                               const std::string &remote_root_path) const
     {
         std::ostringstream oss;
-        oss << _meta_svc->get_options().bulk_load_provider_root << "/" << cluster_name << "/"
-            << app_name << "/" << bulk_load_constant::BULK_LOAD_INFO;
+        oss << remote_root_path << "/" << cluster_name << "/" << app_name << "/"
+            << bulk_load_constant::BULK_LOAD_INFO;
         return oss.str();
     }
 

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -27,6 +27,7 @@ public:
         request->app_name = app_name;
         request->cluster_name = CLUSTER;
         request->file_provider_type = PROVIDER;
+        request->remote_root_path = ROOT_PATH;
 
         start_bulk_load_rpc rpc(std::move(request), RPC_CM_START_BULK_LOAD);
         bulk_svc().on_start_bulk_load(rpc);
@@ -40,7 +41,7 @@ public:
     {
         std::string hint_msg;
         return bulk_svc().check_bulk_load_request_params(
-            APP_NAME, CLUSTER, provider, app_id, partition_count, hint_msg);
+            APP_NAME, CLUSTER, provider, ROOT_PATH, app_id, partition_count, hint_msg);
     }
 
     error_code control_bulk_load(int32_t app_id,
@@ -298,6 +299,7 @@ public:
     int32_t PARTITION_COUNT = 8;
     std::string CLUSTER = "cluster";
     std::string PROVIDER = "local_service";
+    std::string ROOT_PATH = "bulk_load_root";
     int64_t BALLOT = 4;
 };
 
@@ -789,6 +791,7 @@ public:
         ainfo.app_name = app_name;
         ainfo.cluster_name = CLUSTER;
         ainfo.file_provider_type = PROVIDER;
+        ainfo.remote_root_path = ROOT_PATH;
         ainfo.partition_count = partition_count;
         ainfo.status = status;
         _app_bulk_load_info_map[app_id] = ainfo;

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -45,19 +45,21 @@ void replica_bulk_loader::on_bulk_load(const bulk_load_request &request,
         return;
     }
 
-    ddebug_replica(
-        "receive bulk load request, remote provider = {}, cluster_name = {}, app_name = {}, "
-        "meta_bulk_load_status = {}, local bulk_load_status = {}",
-        request.remote_provider_name,
-        request.cluster_name,
-        request.app_name,
-        enum_to_string(request.meta_bulk_load_status),
-        enum_to_string(_status));
+    ddebug_replica("receive bulk load request, remote provider = {}, remote_root_path = {}, "
+                   "cluster_name = {}, app_name = {}, "
+                   "meta_bulk_load_status = {}, local bulk_load_status = {}",
+                   request.remote_provider_name,
+                   request.remote_root_path,
+                   request.cluster_name,
+                   request.app_name,
+                   enum_to_string(request.meta_bulk_load_status),
+                   enum_to_string(_status));
 
     error_code ec = do_bulk_load(request.app_name,
                                  request.meta_bulk_load_status,
                                  request.cluster_name,
-                                 request.remote_provider_name);
+                                 request.remote_provider_name,
+                                 request.remote_root_path);
     if (ec != ERR_OK) {
         response.err = ec;
         response.primary_bulk_load_status = _status;
@@ -104,6 +106,7 @@ void replica_bulk_loader::broadcast_group_bulk_load(const bulk_load_request &met
         request->cluster_name = meta_req.cluster_name;
         request->provider_name = meta_req.remote_provider_name;
         request->meta_bulk_load_status = meta_req.meta_bulk_load_status;
+        request->remote_root_path = meta_req.remote_root_path;
 
         ddebug_replica("send group_bulk_load_request to {}", addr.to_string());
 
@@ -158,7 +161,8 @@ void replica_bulk_loader::on_group_bulk_load(const group_bulk_load_request &requ
     error_code ec = do_bulk_load(request.app_name,
                                  request.meta_bulk_load_status,
                                  request.cluster_name,
-                                 request.provider_name);
+                                 request.provider_name,
+                                 request.remote_root_path);
     if (ec != ERR_OK) {
         response.err = ec;
         response.status = _status;
@@ -216,7 +220,8 @@ void replica_bulk_loader::on_group_bulk_load_reply(error_code err,
 error_code replica_bulk_loader::do_bulk_load(const std::string &app_name,
                                              bulk_load_status::type meta_status,
                                              const std::string &cluster_name,
-                                             const std::string &provider_name)
+                                             const std::string &provider_name,
+                                             const std::string &remote_root_path)
 {
     if (status() != partition_status::PS_PRIMARY && status() != partition_status::PS_SECONDARY) {
         return ERR_INVALID_STATE;
@@ -237,7 +242,9 @@ error_code replica_bulk_loader::do_bulk_load(const std::string &app_name,
             local_status == bulk_load_status::BLS_PAUSED ||
             local_status == bulk_load_status::BLS_INGESTING ||
             local_status == bulk_load_status::BLS_SUCCEED) {
-            ec = start_download(app_name, cluster_name, provider_name);
+            const std::string remote_dir = get_remote_bulk_load_dir(
+                app_name, cluster_name, remote_root_path, get_gpid().get_partition_index());
+            ec = start_download(remote_dir, provider_name);
         }
         break;
     case bulk_load_status::BLS_INGESTING:
@@ -322,8 +329,7 @@ replica_bulk_loader::validate_status(const bulk_load_status::type meta_status,
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-error_code replica_bulk_loader::start_download(const std::string &app_name,
-                                               const std::string &cluster_name,
+error_code replica_bulk_loader::start_download(const std::string &remote_dir,
                                                const std::string &provider_name)
 {
     if (_stub->_bulk_load_downloading_count.load() >=
@@ -351,7 +357,7 @@ error_code replica_bulk_loader::start_download(const std::string &app_name,
     // start download
     _is_downloading.store(true);
     ddebug_replica("start to download sst files");
-    error_code err = download_sst_files(app_name, cluster_name, provider_name);
+    error_code err = download_sst_files(remote_dir, provider_name);
     if (err != ERR_OK) {
         try_decrease_bulk_load_download_count();
     }
@@ -359,8 +365,7 @@ error_code replica_bulk_loader::start_download(const std::string &app_name,
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-error_code replica_bulk_loader::download_sst_files(const std::string &app_name,
-                                                   const std::string &cluster_name,
+error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir,
                                                    const std::string &provider_name)
 {
     FAIL_POINT_INJECT_F("replica_bulk_loader_download_sst_files",
@@ -379,8 +384,8 @@ error_code replica_bulk_loader::download_sst_files(const std::string &app_name,
         return ERR_FILE_OPERATION_FAILED;
     }
 
-    const std::string remote_dir =
-        get_remote_bulk_load_dir(app_name, cluster_name, get_gpid().get_partition_index());
+    //    const std::string remote_dir =
+    //        get_remote_bulk_load_dir(app_name, cluster_name, get_gpid().get_partition_index());
     dist::block_service::block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
 
@@ -409,6 +414,10 @@ error_code replica_bulk_loader::download_sst_files(const std::string &app_name,
                 uint64_t f_size = 0;
                 error_code ec = _stub->_block_service_manager.download_file(
                     remote_dir, local_dir, f_meta.name, fs, f_size);
+                if (ec == ERR_OK && f_size == 0) {
+                    // file has already downloaded
+                    f_size = f_meta.size;
+                }
                 const std::string &file_name =
                     utils::filesystem::path_combine(local_dir, f_meta.name);
                 if (ec == ERR_OK &&
@@ -454,6 +463,9 @@ error_code replica_bulk_loader::parse_bulk_load_metadata(const std::string &fnam
                        _metadata.file_total_size);
         return ERR_CORRUPTION;
     }
+
+    ddebug_replica(
+        "hyc: total_size = {}, count = {}", _metadata.file_total_size, _metadata.files.size());
 
     return ERR_OK;
 }

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -413,7 +413,7 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
                 error_code ec = _stub->_block_service_manager.download_file(
                     remote_dir, local_dir, f_meta.name, fs, f_size);
                 if (ec == ERR_OK && f_size == 0) {
-                    // file has already downloaded
+                    // file has already been downloaded
                     f_size = f_meta.size;
                 }
                 const std::string &file_name =
@@ -461,9 +461,6 @@ error_code replica_bulk_loader::parse_bulk_load_metadata(const std::string &fnam
                        _metadata.file_total_size);
         return ERR_CORRUPTION;
     }
-
-    ddebug_replica(
-        "hyc: total_size = {}, count = {}", _metadata.file_total_size, _metadata.files.size());
 
     return ERR_OK;
 }

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -412,10 +412,6 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
                 uint64_t f_size = 0;
                 error_code ec = _stub->_block_service_manager.download_file(
                     remote_dir, local_dir, f_meta.name, fs, f_size);
-                if (ec == ERR_OK && f_size == 0) {
-                    // file has already been downloaded
-                    f_size = f_meta.size;
-                }
                 const std::string &file_name =
                     utils::filesystem::path_combine(local_dir, f_meta.name);
                 if (ec == ERR_OK &&

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -384,8 +384,6 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
         return ERR_FILE_OPERATION_FAILED;
     }
 
-    //    const std::string remote_dir =
-    //        get_remote_bulk_load_dir(app_name, cluster_name, get_gpid().get_partition_index());
     dist::block_service::block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
 

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -31,7 +31,8 @@ private:
     error_code do_bulk_load(const std::string &app_name,
                             bulk_load_status::type meta_status,
                             const std::string &cluster_name,
-                            const std::string &provider_name);
+                            const std::string &provider_name,
+                            const std::string &remote_root_path);
 
     // compare meta bulk load status and local bulk load status
     // \return ERR_INVALID_STATE if local status is invalid
@@ -43,18 +44,14 @@ private:
     // replica start or restart download sst files from remote provider
     // \return ERR_BUSY if node has already had enough replica executing downloading
     // \return download errors by function `download_sst_files`
-    error_code start_download(const std::string &app_name,
-                              const std::string &cluster_name,
-                              const std::string &provider_name);
+    error_code start_download(const std::string &remote_dir, const std::string &provider_name);
 
     // download metadata and sst files from remote provider
     // metadata and sst files will be downloaded in {_dir}/.bulk_load directory
     // \return ERR_FILE_OPERATION_FAILED: create local bulk load dir failed
     // \return download metadata file error, see function `do_download`
     // \return parse metadata file error, see function `parse_bulk_load_metadata`
-    error_code download_sst_files(const std::string &app_name,
-                                  const std::string &cluster_name,
-                                  const std::string &provider_name);
+    error_code download_sst_files(const std::string &remote_dir, const std::string &provider_name);
 
     // \return ERR_FILE_OPERATION_FAILED: file not exist, get size failed, open file failed
     // \return ERR_CORRUPTION: parse failed
@@ -94,18 +91,18 @@ private:
 
     ///
     /// bulk load path on remote file provider:
-    /// <bulk_load_root>/<cluster_name>/<app_name>/{bulk_load_info}
-    /// <bulk_load_root>/<cluster_name>/<app_name>/<partition_index>/<file_name>
-    /// <bulk_load_root>/<cluster_name>/<app_name>/<partition_index>/bulk_load_metadata
+    /// <remote_root_path>/<cluster_name>/<app_name>/{bulk_load_info}
+    /// <remote_root_path>/<cluster_name>/<app_name>/<partition_index>/<file_name>
+    /// <remote_root_path>/<cluster_name>/<app_name>/<partition_index>/bulk_load_metadata
     ///
     // get partition's file dir on remote file provider
     inline std::string get_remote_bulk_load_dir(const std::string &app_name,
                                                 const std::string &cluster_name,
+                                                const std::string &remote_root_path,
                                                 uint32_t pidx) const
     {
         std::ostringstream oss;
-        oss << _replica->_options->bulk_load_provider_root << "/" << cluster_name << "/" << app_name
-            << "/" << pidx;
+        oss << remote_root_path << "/" << cluster_name << "/" << app_name << "/" << pidx;
         return oss.str();
     }
 

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -44,7 +44,9 @@ public:
 
     error_code test_start_downloading()
     {
-        return _bulk_loader->start_download(APP_NAME, CLUSTER, PROVIDER);
+        const std::string remote_dir = _bulk_loader->get_remote_bulk_load_dir(
+            APP_NAME, CLUSTER, ROOT_PATH, PID.get_partition_index());
+        return _bulk_loader->start_download(remote_dir, PROVIDER);
     }
 
     void test_rollback_to_downloading(bulk_load_status::type cur_status)
@@ -172,6 +174,7 @@ public:
         _req.meta_bulk_load_status = status;
         _req.pid = PID;
         _req.remote_provider_name = PROVIDER;
+        _req.remote_root_path = ROOT_PATH;
         stub->set_bulk_load_downloading_count(downloading_count);
     }
 
@@ -407,6 +410,7 @@ public:
     std::string APP_NAME = "replica";
     std::string CLUSTER = "cluster";
     std::string PROVIDER = "local_service";
+    std::string ROOT_PATH = "bulk_load_root";
     gpid PID = gpid(1, 0);
     ballot BALLOT = 3;
     rpc_address PRIMARY = rpc_address("127.0.0.2", 34801);

--- a/src/replication.thrift
+++ b/src/replication.thrift
@@ -979,9 +979,10 @@ struct bulk_load_metadata
 // client -> meta, start bulk load
 struct start_bulk_load_request
 {
-    1:string        app_name;
-    2:string        cluster_name;
-    3:string        file_provider_type;
+    1:string    app_name;
+    2:string    cluster_name;
+    3:string    file_provider_type;
+    4:string    remote_root_path;
 }
 
 struct start_bulk_load_response
@@ -1020,6 +1021,7 @@ struct bulk_load_request
     6:i64               ballot;
     7:bulk_load_status  meta_bulk_load_status;
     8:bool              query_bulk_load_metadata;
+    9:string            remote_root_path;
 }
 
 struct bulk_load_response
@@ -1052,6 +1054,7 @@ struct group_bulk_load_request
     4:string                        provider_name;
     5:string                        cluster_name;
     6:bulk_load_status              meta_bulk_load_status;
+    7:string                        remote_root_path;
 }
 
 struct group_bulk_load_response


### PR DESCRIPTION
In previous implementation, bulk load will download files from specific remote storage path, which is defined in config file, name is `bulk_load_provider_root`. This pull request removes this config, and adds `remote_root_path` for starting bulk load request, server will use it as the root path of remote file storage.