### PR TITLE
feat: support to build a portable rocksdb binary

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -61,6 +61,10 @@ function usage_build()
         echo "                         e.g., \"dsn_runtime_tests,dsn_meta_state_tests\","
         echo "                         if not set, then run all tests"
     fi
+
+    echo "   --enable_rocksdb_portable      build a portable rocksdb binary"
+    echo "   --enable_rocksdb_force_sse42   force building rocksdb binary with SSE4.2,"
+    echo "                                  even when portable is enabled"
 }
 function run_build()
 {
@@ -82,6 +86,8 @@ function run_build()
     CHECK=NO
     SANITIZER=""
     TEST_MODULE=""
+    ROCKSDB_PORTABLE=OFF
+    ROCKSDB_FORCE_SSE42=OFF
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
@@ -153,6 +159,12 @@ function run_build()
                 TEST_MODULE="$2"
                 shift
                 ;;
+            --enable_rocksdb_portable)
+                ROCKSDB_PORTABLE=ON
+                ;;
+            --enable_rocksdb_force_sse42)
+                ROCKSDB_FORCE_SSE42=ON
+                ;;
             *)
                 echo "ERROR: unknown option \"$key\""
                 echo
@@ -180,7 +192,8 @@ function run_build()
         echo "Start building third-parties..."
         mkdir -p build
         pushd build
-        cmake .. -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_BUILD_TYPE=Release \
+        -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE} -DROCKSDB_FORCE_SSE42=${ROCKSDB_FORCE_SSE42}
         make -j$JOB_NUM
         exit_if_fail $?
         popd

--- a/run.sh
+++ b/run.sh
@@ -63,8 +63,6 @@ function usage_build()
     fi
 
     echo "   --enable_rocksdb_portable      build a portable rocksdb binary"
-    echo "   --enable_rocksdb_force_sse42   force building rocksdb binary with SSE4.2,"
-    echo "                                  even when portable is enabled"
 }
 function run_build()
 {
@@ -87,7 +85,6 @@ function run_build()
     SANITIZER=""
     TEST_MODULE=""
     ROCKSDB_PORTABLE=OFF
-    ROCKSDB_FORCE_SSE42=OFF
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
@@ -162,9 +159,6 @@ function run_build()
             --enable_rocksdb_portable)
                 ROCKSDB_PORTABLE=ON
                 ;;
-            --enable_rocksdb_force_sse42)
-                ROCKSDB_FORCE_SSE42=ON
-                ;;
             *)
                 echo "ERROR: unknown option \"$key\""
                 echo
@@ -193,7 +187,7 @@ function run_build()
         mkdir -p build
         pushd build
         cmake .. -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_BUILD_TYPE=Release \
-        -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE} -DROCKSDB_FORCE_SSE42=${ROCKSDB_FORCE_SSE42}
+        -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE}
         make -j$JOB_NUM
         exit_if_fail $?
         popd

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -293,7 +293,6 @@ ExternalProject_Add(s2geometry
         )
 
 option(ROCKSDB_PORTABLE "build a portable binary" OFF)
-option(ROCKSDB_FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
 
 ExternalProject_Add(rocksdb
         URL ${OSS_URL_PREFIX}/pegasus-rocksdb-6.6.4-compatible.zip
@@ -310,7 +309,6 @@ ExternalProject_Add(rocksdb
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         -DPORTABLE=${ROCKSDB_PORTABLE}
-        -DFORCE_SSE42=${ROCKSDB_FORCE_SSE42}
         )
 
 # kerberos

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -292,6 +292,9 @@ ExternalProject_Add(s2geometry
         DEPENDS googletest
         )
 
+option(ROCKSDB_PORTABLE "build a portable binary" OFF)
+option(ROCKSDB_FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
+
 ExternalProject_Add(rocksdb
         URL ${OSS_URL_PREFIX}/pegasus-rocksdb-6.6.4-compatible.zip
         https://github.com/XiaoMi/pegasus-rocksdb/archive/v6.6.4-compatible.zip
@@ -306,6 +309,8 @@ ExternalProject_Add(rocksdb
         -DUSE_RTTI=ON
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DPORTABLE=${ROCKSDB_PORTABLE}
+        -DFORCE_SSE42=${ROCKSDB_FORCE_SSE42}
         )
 
 # kerberos


### PR DESCRIPTION
The process exits with "Illegal instruction (core dumped)" while trying to launch pegasus server on certain nodes. By trouble-shooting, we find "PORTABLE" is disabled while rocksdb is built. The pegasus server can be built and run normally on standard nodes with "PORTABLE" disabled. However, hardware varies in some other nodes where certain instructions are not supported. We have to achieve portability for these nodes at the cost of a little of performance.