### PR TITLE
fix(block_service): download file when local file is different from remote file

### DIFF
--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -118,13 +118,6 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
                                                 block_filesystem *fs,
                                                 /*out*/ uint64_t &download_file_size)
 {
-    // local file exists
-    const std::string local_file_name = utils::filesystem::path_combine(local_dir, file_name);
-    if (utils::filesystem::file_exists(local_file_name)) {
-        ddebug_f("local file({}) has been downloaded", local_file_name);
-        return ERR_OK;
-    }
-
     task_tracker tracker;
 
     // Create a block_file object.
@@ -137,6 +130,37 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
         return err;
     }
     block_file_ptr bf = create_resp.file_handle;
+
+    const std::string local_file_name = utils::filesystem::path_combine(local_dir, file_name);
+    if (utils::filesystem::file_exists(local_file_name)) {
+        std::string current_md5;
+        error_code e = utils::filesystem::md5sum(local_file_name, current_md5);
+        // local file exists
+        if (e == ERR_OK && current_md5 == bf->get_md5sum()) {
+            download_file_size = bf->get_size();
+            ddebug_f("local file({}) has been downloaded, file_size = {}",
+                     local_file_name,
+                     download_file_size);
+            return ERR_OK;
+        }
+        // local file has same file name with remote file, but there are different
+        // remove local file and download it from remote file provider
+        if (e != ERR_OK) {
+            dwarn_f("calculate file({}) md5 failed, should remove and redownload it",
+                    local_file_name);
+        } else {
+            dwarn_f("local file({}) is different from remote file({}), md5: local({}) VS "
+                    "remote({}), should remove and redownload it",
+                    local_file_name,
+                    bf->file_name(),
+                    current_md5,
+                    bf->get_md5sum());
+        }
+        if (!utils::filesystem::remove_path(local_file_name)) {
+            derror_f("failed to remove file({})", local_file_name);
+            return ERR_FILE_OPERATION_FAILED;
+        }
+    }
 
     download_response resp = download_block_file_sync(local_file_name, bf.get(), &tracker);
     if (resp.err != ERR_OK) {

--- a/src/block_service/test/block_service_manager_test.cpp
+++ b/src/block_service/test/block_service_manager_test.cpp
@@ -27,9 +27,8 @@ public:
     ~block_service_manager_test() { utils::filesystem::remove_path(LOCAL_DIR); }
 
 public:
-    error_code test_download_file()
+    error_code test_download_file(uint64_t &download_size)
     {
-        uint64_t download_size = 0;
         return _block_service_manager.download_file(
             PROVIDER, LOCAL_DIR, FILE_NAME, _fs.get(), download_size);
     }
@@ -82,14 +81,18 @@ TEST_F(block_service_manager_test, do_download_redownload_file)
     // expected to remove old local file and redownload it
     create_local_file(FILE_NAME);
     create_remote_file(FILE_NAME, 2333, "md5_not_match");
-    ASSERT_EQ(test_download_file(), ERR_OK);
+    uint64_t download_size = 0;
+    ASSERT_EQ(test_download_file(download_size), ERR_OK);
+    ASSERT_EQ(download_size, 2333);
 }
 
 TEST_F(block_service_manager_test, do_download_file_exist)
 {
     create_local_file(FILE_NAME);
     create_remote_file(FILE_NAME, _file_meta.size, _file_meta.md5);
-    ASSERT_EQ(test_download_file(), ERR_OK);
+    uint64_t download_size = 0;
+    ASSERT_EQ(test_download_file(download_size), ERR_OK);
+    ASSERT_EQ(download_size, _file_meta.size);
 }
 
 TEST_F(block_service_manager_test, do_download_succeed)
@@ -99,7 +102,9 @@ TEST_F(block_service_manager_test, do_download_succeed)
     // remove local file to mock condition that file not existed
     std::string file_name = utils::filesystem::path_combine(LOCAL_DIR, FILE_NAME);
     utils::filesystem::remove_path(file_name);
-    ASSERT_EQ(test_download_file(), ERR_OK);
+    uint64_t download_size = 0;
+    ASSERT_EQ(test_download_file(download_size), ERR_OK);
+    ASSERT_EQ(download_size, _file_meta.size);
 }
 
 } // namespace block_service

--- a/src/block_service/test/block_service_mock.h
+++ b/src/block_service/test/block_service_mock.h
@@ -26,7 +26,7 @@ public:
     {
     }
 
-    virtual uint64_t get_size() { return static_cast<uint64_t>(size); }
+    virtual uint64_t get_size() { return size; }
 
     virtual const std::string &get_md5sum() { return md5; }
 
@@ -89,6 +89,10 @@ public:
                                    const download_callback &cb,
                                    dsn::task_tracker *tracker = nullptr)
     {
+        download_response resp;
+        resp.err = ERR_OK;
+        resp.downloaded_size = size;
+        cb(resp);
         return task_ptr();
     }
 
@@ -116,7 +120,7 @@ public:
     void clear_context() { context = blob(); }
 
 public:
-    int64_t size;
+    uint64_t size;
     std::string md5;
     blob context;
     bool enable_write_fail;

--- a/src/block_service/test/block_service_mock.h
+++ b/src/block_service/test/block_service_mock.h
@@ -26,7 +26,7 @@ public:
     {
     }
 
-    virtual uint64_t get_size() { return size; }
+    virtual uint64_t get_size() { return static_cast<uint64_t>(size); }
 
     virtual const std::string &get_md5sum() { return md5; }
 
@@ -120,7 +120,7 @@ public:
     void clear_context() { context = blob(); }
 
 public:
-    uint64_t size;
+    int64_t size;
     std::string md5;
     blob context;
     bool enable_write_fail;


### PR DESCRIPTION
As the title shows, this pull request add check in `download_file`, when local file only has same file name with remote file, local file will be removed, and download from remote file provider. Besides, when local file is same as remote file, it will set `download_file_size` as file size.