### PR TITLE
feat(security): treat negotiation succeed if server is old version

### DIFF
--- a/include/dsn/utility/defer.h
+++ b/include/dsn/utility/defer.h
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
 #include <utility>
 
 namespace dsn {

--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -50,10 +50,10 @@ void client_negotiation::list_mechanisms()
 void client_negotiation::handle_response(error_code err, const negotiation_response &&response)
 {
     if (err != ERR_OK) {
-        // ERR_HANDLER_NOT_FOUND means server is old version, which doesn't support authentiation
+        // ERR_HANDLER_NOT_FOUND means server is old version, which doesn't support authentication
         if (ERR_HANDLER_NOT_FOUND == err && !FLAGS_mandatory_auth) {
             ddebug_f("{}: treat negotiation succeed because server is old version, which doesn't "
-                     "support authentiation",
+                     "support authentication",
                      _name);
             succ_negotiation();
         } else {

--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -50,7 +50,15 @@ void client_negotiation::list_mechanisms()
 void client_negotiation::handle_response(error_code err, const negotiation_response &&response)
 {
     if (err != ERR_OK) {
-        fail_negotiation();
+        // ERR_HANDLER_NOT_FOUND means server is old version, which doesn't support authentiation
+        if (ERR_HANDLER_NOT_FOUND == err && !FLAGS_mandatory_auth) {
+            ddebug_f("{}: treat negotiation succeed because server is old version, which doesn't "
+                     "support authentiation",
+                     _name);
+            succ_negotiation();
+        } else {
+            fail_negotiation();
+        }
         return;
     }
 


### PR DESCRIPTION
When you rolling_update a cluster, if the new config set enable_auth = true. The new version server will send negotiation message to the server which has old version. And it will return `ERR_HANDLER_NOT_FOUND` to the new version server, so the negotiation will always fail. 