### PR TITLE
refactor(backup): remove 'policy_name' from remote files' paths

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -249,6 +249,9 @@ public:
         resp.__set_err_hint("on_detect_hotkey implementation not found");
     }
 
+    // query pegasus data version
+    virtual uint32_t query_data_version() const = 0;
+
 public:
     //
     // utility functions to be used by app

--- a/include/dsn/dist/replication/replication_types.h
+++ b/include/dsn/dist/replication/replication_types.h
@@ -249,7 +249,8 @@ struct detect_action
     enum type
     {
         START = 0,
-        STOP = 1
+        STOP = 1,
+        QUERY = 2
     };
 };
 
@@ -7740,9 +7741,10 @@ inline std::ostream &operator<<(std::ostream &out, const detect_hotkey_request &
 
 typedef struct _detect_hotkey_response__isset
 {
-    _detect_hotkey_response__isset() : err(false), err_hint(false) {}
+    _detect_hotkey_response__isset() : err(false), err_hint(false), hotkey_result(false) {}
     bool err : 1;
     bool err_hint : 1;
+    bool hotkey_result : 1;
 } _detect_hotkey_response__isset;
 
 class detect_hotkey_response
@@ -7752,17 +7754,20 @@ public:
     detect_hotkey_response(detect_hotkey_response &&);
     detect_hotkey_response &operator=(const detect_hotkey_response &);
     detect_hotkey_response &operator=(detect_hotkey_response &&);
-    detect_hotkey_response() : err_hint() {}
+    detect_hotkey_response() : err_hint(), hotkey_result() {}
 
     virtual ~detect_hotkey_response() throw();
     ::dsn::error_code err;
     std::string err_hint;
+    std::string hotkey_result;
 
     _detect_hotkey_response__isset __isset;
 
     void __set_err(const ::dsn::error_code &val);
 
     void __set_err_hint(const std::string &val);
+
+    void __set_hotkey_result(const std::string &val);
 
     bool operator==(const detect_hotkey_response &rhs) const
     {
@@ -7771,6 +7776,10 @@ public:
         if (__isset.err_hint != rhs.__isset.err_hint)
             return false;
         else if (__isset.err_hint && !(err_hint == rhs.err_hint))
+            return false;
+        if (__isset.hotkey_result != rhs.__isset.hotkey_result)
+            return false;
+        else if (__isset.hotkey_result && !(hotkey_result == rhs.hotkey_result))
             return false;
         return true;
     }

--- a/include/dsn/http/http_server.h
+++ b/include/dsn/http/http_server.h
@@ -6,10 +6,15 @@
 
 #include <dsn/utility/errors.h>
 #include <dsn/utility/flags.h>
+#include <dsn/tool-api/task_code.h>
 
 namespace dsn {
 
 DSN_DECLARE_bool(enable_http_server);
+
+/// The rpc code for all the HTTP RPCs.
+/// Since http is used only for system monitoring, it is restricted to lowest priority.
+DEFINE_TASK_CODE_RPC(RPC_HTTP_SERVICE, TASK_PRIORITY_LOW, THREAD_POOL_DEFAULT);
 
 enum http_method
 {
@@ -104,4 +109,8 @@ extern void start_http_server();
 // TODO(wutao): pass `svc` as a std::unique_ptr.
 extern void register_http_service(http_service *svc);
 
+inline bool is_http_message(dsn::task_code code)
+{
+    return code == RPC_HTTP_SERVICE || code == RPC_HTTP_SERVICE_ACK;
+}
 } // namespace dsn

--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -7,6 +7,13 @@
 #include <string>
 #include <cstdint>
 #include <functional>
+#include "errors.h"
+#include "utils.h"
+
+enum class flag_tag
+{
+    FT_MUTABLE = 0, /** flag data is mutable */
+};
 
 // Example:
 //    DSN_DEFINE_string("core", filename, "my_file.txt", "The file to read");
@@ -52,6 +59,10 @@
         dassert(FLAGS_VALIDATOR_FN_##name(FLAGS_##name), "validation failed: %s", #name);          \
     })
 
+#define DSN_TAG_VARIABLE(name, tag)                                                                \
+    COMPILE_ASSERT(sizeof(decltype(FLAGS_##name)), exist_##name##_##tag);                          \
+    static dsn::flag_tagger FLAGS_TAGGER_##name##_##tag(#name, flag_tag::tag)
+
 namespace dsn {
 
 // An utility class that registers a flag upon initialization.
@@ -74,7 +85,18 @@ public:
     flag_validator(const char *name, std::function<void()>);
 };
 
+class flag_tagger
+{
+public:
+    flag_tagger(const char *name, const flag_tag &tag);
+};
+
 // Loads all the flags from configuration.
 extern void flags_initialize();
 
+// update the specified flag to val
+extern error_s update_flag(const std::string &name, const std::string &val);
+
+// determine if the tag is exist for the specified flag
+extern bool has_tag(const std::string &name, const flag_tag &tag);
 } // namespace dsn

--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -15,6 +15,16 @@ enum class flag_tag
     FT_MUTABLE = 0, /** flag data is mutable */
 };
 
+// support std::hash with enum types is implemented since gcc 6.1
+// so we should define hash for flag_tag to compatible with gcc < 6.1
+namespace std {
+template <>
+struct hash<flag_tag>
+{
+    size_t operator()(const flag_tag &t) const { return size_t(t); }
+};
+} // namespace std
+
 // Example:
 //    DSN_DEFINE_string("core", filename, "my_file.txt", "The file to read");
 //    DSN_DEFINE_validator(filename, [](const char *fname){ return is_file(fname); });

--- a/include/dsn/utility/string_conv.h
+++ b/include/dsn/utility/string_conv.h
@@ -116,6 +116,11 @@ inline bool buf2int64(string_view buf, int64_t &result)
     return internal::buf2signed(buf, result);
 }
 
+inline bool buf2uint32(string_view buf, uint32_t &result)
+{
+    return internal::buf2unsigned(buf, result);
+}
+
 inline bool buf2uint64(string_view buf, uint64_t &result)
 {
     return internal::buf2unsigned(buf, result);

--- a/include/dsn/utility/utils.h
+++ b/include/dsn/utility/utils.h
@@ -43,6 +43,26 @@
 
 #define TIME_MS_MAX 0xffffffff
 
+// The COMPILE_ASSERT macro can be used to verify that a compile time
+// expression is true. For example, you could use it to verify the
+// size of a static array:
+//
+//   COMPILE_ASSERT(ARRAYSIZE(content_type_names) == CONTENT_NUM_TYPES,
+//                  content_type_names_incorrect_size);
+//
+// or to make sure a struct is smaller than a certain size:
+//
+//   COMPILE_ASSERT(sizeof(foo) < 128, foo_too_large);
+//
+// The second argument to the macro is the name of the variable. If
+// the expression is false, most compilers will issue a warning/error
+// containing the name of the variable.
+struct CompileAssert
+{
+};
+
+#define COMPILE_ASSERT(expr, msg) static const CompileAssert msg[bool(expr) ? 1 : -1]
+
 namespace dsn {
 namespace utils {
 
@@ -88,5 +108,5 @@ bool hostname(const dsn::rpc_address &address, std::string *hostname_result);
 // valid_ip_network_order -> return TRUE && hostname_result=hostname	|
 // invalid_ip_network_order -> return FALSE
 bool hostname_from_ip(uint32_t ip, std::string *hostname_result);
-}
-}
+} // namespace utils
+} // namespace dsn

--- a/scripts/linux/clear_zk.sh
+++ b/scripts/linux/clear_zk.sh
@@ -11,7 +11,7 @@ fi
 
 cd $INSTALL_DIR
 
-ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.6
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then

--- a/scripts/linux/start_zk.sh
+++ b/scripts/linux/start_zk.sh
@@ -34,7 +34,7 @@ if [ ! -f ${ZOOKEEPER_PKG} ]; then
     exit 1
 fi
 
-if [ ! -d zookeeper-3.4.6 ]; then
+if [ ! -d zookeeper-3.4.10 ]; then
     echo "Decompressing zookeeper..."
     cp ${ZOOKEEPER_PKG} .
     tar xf zookeeper-3.4.10.tar.gz

--- a/scripts/linux/stop_zk.sh
+++ b/scripts/linux/stop_zk.sh
@@ -11,7 +11,7 @@ fi
 
 cd $INSTALL_DIR
 
-ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.6
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -118,13 +118,6 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
                                                 block_filesystem *fs,
                                                 /*out*/ uint64_t &download_file_size)
 {
-    // local file exists
-    const std::string local_file_name = utils::filesystem::path_combine(local_dir, file_name);
-    if (utils::filesystem::file_exists(local_file_name)) {
-        ddebug_f("local file({}) has been downloaded", local_file_name);
-        return ERR_OK;
-    }
-
     task_tracker tracker;
 
     // Create a block_file object.
@@ -137,6 +130,37 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
         return err;
     }
     block_file_ptr bf = create_resp.file_handle;
+
+    const std::string local_file_name = utils::filesystem::path_combine(local_dir, file_name);
+    if (utils::filesystem::file_exists(local_file_name)) {
+        std::string current_md5;
+        error_code e = utils::filesystem::md5sum(local_file_name, current_md5);
+        // local file exists
+        if (e == ERR_OK && current_md5 == bf->get_md5sum()) {
+            download_file_size = bf->get_size();
+            ddebug_f("local file({}) has been downloaded, file_size = {}",
+                     local_file_name,
+                     download_file_size);
+            return ERR_OK;
+        }
+        // local file has same file name with remote file, but there are different
+        // remove local file and download it from remote file provider
+        if (e != ERR_OK) {
+            dwarn_f("calculate file({}) md5 failed, should remove and redownload it",
+                    local_file_name);
+        } else {
+            dwarn_f("local file({}) is different from remote file({}), md5: local({}) VS "
+                    "remote({}), should remove and redownload it",
+                    local_file_name,
+                    bf->file_name(),
+                    current_md5,
+                    bf->get_md5sum());
+        }
+        if (!utils::filesystem::remove_path(local_file_name)) {
+            derror_f("failed to remove file({})", local_file_name);
+            return ERR_FILE_OPERATION_FAILED;
+        }
+    }
 
     download_response resp = download_block_file_sync(local_file_name, bf.get(), &tracker);
     if (resp.err != ERR_OK) {

--- a/src/block_service/test/block_service_manager_test.cpp
+++ b/src/block_service/test/block_service_manager_test.cpp
@@ -27,9 +27,8 @@ public:
     ~block_service_manager_test() { utils::filesystem::remove_path(LOCAL_DIR); }
 
 public:
-    error_code test_download_file()
+    error_code test_download_file(uint64_t &download_size)
     {
-        uint64_t download_size = 0;
         return _block_service_manager.download_file(
             PROVIDER, LOCAL_DIR, FILE_NAME, _fs.get(), download_size);
     }
@@ -82,14 +81,18 @@ TEST_F(block_service_manager_test, do_download_redownload_file)
     // expected to remove old local file and redownload it
     create_local_file(FILE_NAME);
     create_remote_file(FILE_NAME, 2333, "md5_not_match");
-    ASSERT_EQ(test_download_file(), ERR_OK);
+    uint64_t download_size = 0;
+    ASSERT_EQ(test_download_file(download_size), ERR_OK);
+    ASSERT_EQ(download_size, 2333);
 }
 
 TEST_F(block_service_manager_test, do_download_file_exist)
 {
     create_local_file(FILE_NAME);
     create_remote_file(FILE_NAME, _file_meta.size, _file_meta.md5);
-    ASSERT_EQ(test_download_file(), ERR_OK);
+    uint64_t download_size = 0;
+    ASSERT_EQ(test_download_file(download_size), ERR_OK);
+    ASSERT_EQ(download_size, _file_meta.size);
 }
 
 TEST_F(block_service_manager_test, do_download_succeed)
@@ -99,7 +102,9 @@ TEST_F(block_service_manager_test, do_download_succeed)
     // remove local file to mock condition that file not existed
     std::string file_name = utils::filesystem::path_combine(LOCAL_DIR, FILE_NAME);
     utils::filesystem::remove_path(file_name);
-    ASSERT_EQ(test_download_file(), ERR_OK);
+    uint64_t download_size = 0;
+    ASSERT_EQ(test_download_file(download_size), ERR_OK);
+    ASSERT_EQ(download_size, _file_meta.size);
 }
 
 } // namespace block_service

--- a/src/block_service/test/block_service_mock.h
+++ b/src/block_service/test/block_service_mock.h
@@ -89,6 +89,10 @@ public:
                                    const download_callback &cb,
                                    dsn::task_tracker *tracker = nullptr)
     {
+        download_response resp;
+        resp.err = ERR_OK;
+        resp.downloaded_size = size;
+        cb(resp);
         return task_ptr();
     }
 

--- a/src/common/backup_utils.cpp
+++ b/src/common/backup_utils.cpp
@@ -29,123 +29,86 @@ const int32_t cold_backup_constant::PROGRESS_FINISHED = 1000;
 
 namespace cold_backup {
 
-std::string get_policy_path(const std::string &root, const std::string &policy_name)
+std::string get_backup_path(const std::string &root, int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << root << "/" << policy_name;
-    return ss.str();
+    return root + "/" + std::to_string(backup_id);
 }
 
-std::string
-get_backup_path(const std::string &root, const std::string &policy_name, int64_t backup_id)
+std::string get_backup_info_file(const std::string &root, int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_policy_path(root, policy_name) << "/" << backup_id;
-    return ss.str();
-}
-
-std::string get_app_backup_path(const std::string &root,
-                                const std::string &policy_name,
-                                const std::string &app_name,
-                                int32_t app_id,
-                                int64_t backup_id)
-{
-    std::stringstream ss;
-    ss << get_backup_path(root, policy_name, backup_id) << "/" << app_name << "_" << app_id;
-    return ss.str();
+    return get_backup_path(root, backup_id) + "/" + cold_backup_constant::BACKUP_INFO;
 }
 
 std::string get_replica_backup_path(const std::string &root,
-                                    const std::string &policy_name,
                                     const std::string &app_name,
                                     gpid pid,
                                     int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_policy_path(root, policy_name) << "/" << backup_id << "/" << app_name << "_"
-       << pid.get_app_id() << "/" << pid.get_partition_index();
-    return ss.str();
+    std::string str_app = app_name + "_" + std::to_string(pid.get_app_id());
+    return get_backup_path(root, backup_id) + "/" + str_app + "/" +
+           std::to_string(pid.get_partition_index());
 }
 
 std::string get_app_meta_backup_path(const std::string &root,
-                                     const std::string &policy_name,
                                      const std::string &app_name,
                                      int32_t app_id,
                                      int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_policy_path(root, policy_name) << "/" << backup_id << "/" << app_name << "_" << app_id
-       << "/meta";
-    return ss.str();
+    std::string str_app = app_name + "_" + std::to_string(app_id);
+    return get_backup_path(root, backup_id) + "/" + str_app + "/meta";
 }
 
 std::string get_app_metadata_file(const std::string &root,
-                                  const std::string &policy_name,
                                   const std::string &app_name,
                                   int32_t app_id,
                                   int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_app_meta_backup_path(root, policy_name, app_name, app_id, backup_id) << "/"
-       << cold_backup_constant::APP_METADATA;
-    return ss.str();
+    return get_app_meta_backup_path(root, app_name, app_id, backup_id) + "/" +
+           cold_backup_constant::APP_METADATA;
 }
 
 std::string get_app_backup_status_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        int32_t app_id,
                                        int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_app_meta_backup_path(root, policy_name, app_name, app_id, backup_id) << "/"
-       << cold_backup_constant::APP_BACKUP_STATUS;
-    return ss.str();
+    return get_app_meta_backup_path(root, app_name, app_id, backup_id) + "/" +
+           cold_backup_constant::APP_BACKUP_STATUS;
 }
 
 std::string get_current_chkpt_file(const std::string &root,
-                                   const std::string &policy_name,
                                    const std::string &app_name,
                                    gpid pid,
                                    int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_replica_backup_path(root, policy_name, app_name, pid, backup_id) << "/"
-       << cold_backup_constant::CURRENT_CHECKPOINT;
-    return ss.str();
+    return get_replica_backup_path(root, app_name, pid, backup_id) + "/" +
+           cold_backup_constant::CURRENT_CHECKPOINT;
 }
 
 std::string get_remote_chkpt_dirname()
 {
     // here using server address as suffix of remote_chkpt_dirname
-    rpc_address local_address = dsn_primary_address();
-    std::stringstream ss;
-    ss << "chkpt_" << local_address.ipv4_str() << "_" << local_address.port();
-    return ss.str();
+    std::string local_address = dsn_primary_address().ipv4_str();
+    std::string port = std::to_string(dsn_primary_address().port());
+    return "chkpt_" + local_address + "_" + port;
 }
 
 std::string get_remote_chkpt_dir(const std::string &root,
-                                 const std::string &policy_name,
                                  const std::string &app_name,
                                  gpid pid,
                                  int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_replica_backup_path(root, policy_name, app_name, pid, backup_id) << "/"
-       << get_remote_chkpt_dirname();
-    return ss.str();
+    return get_replica_backup_path(root, app_name, pid, backup_id) + "/" +
+           get_remote_chkpt_dirname();
 }
 
 std::string get_remote_chkpt_meta_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        gpid pid,
                                        int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_remote_chkpt_dir(root, policy_name, app_name, pid, backup_id) << "/"
-       << cold_backup_constant::BACKUP_METADATA;
-    return ss.str();
+    return get_remote_chkpt_dir(root, app_name, pid, backup_id) + "/" +
+           cold_backup_constant::BACKUP_METADATA;
 }
 
 } // namespace cold_backup

--- a/src/common/backup_utils.h
+++ b/src/common/backup_utils.h
@@ -45,19 +45,19 @@ namespace cold_backup {
 
 // The directory structure on block service
 //
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_metadata
-//                                                      /meta/app_backup_status
-//                                                      /partition_1/checkpoint@ip:port/***.sst
-//                                                      /partition_1/checkpoint@ip:port/CURRENT
-//                                                      /partition_1/checkpoint@ip:port/backup_metadata
-//                                                      /partition_1/current_checkpoint
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_metadata
-//                                                      /meta/app_backup_status
-//                                                      /partition_1/checkpoint@ip:port/***.sst
-//                                                      /partition_1/checkpoint@ip:port/CURRENT
-//                                                      /partition_1/checkpoint@ip:port/backup_metadata
-//                                                      /partition_1/current_checkpoint
-//      <root>/<policy_name>/<backup_id>/backup_info
+//      <root>/<backup_id>/<appname_appid>/meta/app_metadata
+//                                        /meta/app_backup_status
+//                                        /partition_1/checkpoint@ip:port/***.sst
+//                                        /partition_1/checkpoint@ip:port/CURRENT
+//                                        /partition_1/checkpoint@ip:port/backup_metadata
+//                                        /partition_1/current_checkpoint
+//      <root>/<backup_id>/<appname_appid>/meta/app_metadata
+//                                        /meta/app_backup_status
+//                                        /partition_1/checkpoint@ip:port/***.sst
+//                                        /partition_1/checkpoint@ip:port/CURRENT
+//                                        /partition_1/checkpoint@ip:port/backup_metadata
+//                                        /partition_1/current_checkpoint
+//      <root>/<backup_id>/backup_info
 //
 
 //
@@ -72,39 +72,22 @@ namespace cold_backup {
 //      5, backup_info : recording the information of this backup
 //
 
-// compose the path for policy on block service
-// input:
-//  -- root: the prefix of path
-// return:
-//      the path: <root>/<policy_name>
-std::string get_policy_path(const std::string &root, const std::string &policy_name);
-
 // compose the path for app on block service
 // input:
 //  -- root:  the prefix of path
 // return:
-//      the path: <root>/<policy_name>/<backup_id>
-std::string
-get_backup_path(const std::string &root, const std::string &policy_name, int64_t backup_id);
+//      the path: <root>/<backup_id>
+std::string get_backup_path(const std::string &root, int64_t backup_id);
 
-// compose the path for app on block service
-// input:
-//  -- root:  the prefix of path
-// return:
-//      the path: <root>/<policy_name>/<backup_id>/<appname_appid>
-std::string get_app_backup_path(const std::string &root,
-                                const std::string &policy_name,
-                                const std::string &app_name,
-                                int32_t app_id,
-                                int64_t backup_id);
+// return: <root>/<backup_id>/backup_info
+std::string get_backup_info_file(const std::string &root, int64_t backup_id);
 
 // compose the path for replica on block service
 // input:
 //  -- root:  the prefix of the path
 // return:
-//      the path: <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>
+//      the path: <root>/<backup_id>/<appname_appid>/<partition_index>
 std::string get_replica_backup_path(const std::string &root,
-                                    const std::string &policy_name,
                                     const std::string &app_name,
                                     gpid pid,
                                     int64_t backup_id);
@@ -113,9 +96,8 @@ std::string get_replica_backup_path(const std::string &root,
 // input:
 //  -- root:  the prefix of the path
 // return:
-//      the path: <root>/<policy_name>/<backup_id>/<appname_appid>/meta
+//      the path: <root>/<backup_id>/<appname_appid>/meta
 std::string get_app_meta_backup_path(const std::string &root,
-                                     const std::string &policy_name,
                                      const std::string &app_name,
                                      int32_t app_id,
                                      int64_t backup_id);
@@ -125,9 +107,8 @@ std::string get_app_meta_backup_path(const std::string &root,
 //  -- prefix:      the prefix of AP
 // return:
 //      the AP of app meta data file:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_metadata
+//      <root>/<backup_id>/<appname_appid>/meta/app_metadata
 std::string get_app_metadata_file(const std::string &root,
-                                  const std::string &policy_name,
                                   const std::string &app_name,
                                   int32_t app_id,
                                   int64_t backup_id);
@@ -137,9 +118,8 @@ std::string get_app_metadata_file(const std::string &root,
 //  -- prefix:      the prefix of AP
 // return:
 //      the AP of flag-file, which represent whether the app have finished backup:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_backup_status
+//      <root>/<backup_id>/<appname_appid>/meta/app_backup_status
 std::string get_app_backup_status_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        int32_t app_id,
                                        int64_t backup_id);
@@ -150,9 +130,8 @@ std::string get_app_backup_status_file(const std::string &root,
 //  -- pid:         gpid of replica
 // return:
 //      the AP of current checkpoint file:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>/current_checkpoint
+//      <root>/<backup_id>/<appname_appid>/<partition_index>/current_checkpoint
 std::string get_current_chkpt_file(const std::string &root,
-                                   const std::string &policy_name,
                                    const std::string &app_name,
                                    gpid pid,
                                    int64_t backup_id);
@@ -168,9 +147,8 @@ std::string get_remote_chkpt_dirname();
 //  -- pid:          gpid of replcia
 // return:
 //      the AP of the checkpoint dir:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>
+//      <root>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>
 std::string get_remote_chkpt_dir(const std::string &root,
-                                 const std::string &policy_name,
                                  const std::string &app_name,
                                  gpid pid,
                                  int64_t backup_id);
@@ -181,9 +159,8 @@ std::string get_remote_chkpt_dir(const std::string &root,
 //  -- pid:          gpid of replcia
 // return:
 //      the AP of the checkpoint file metadata:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>/backup_metadata
+//      <root>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>/backup_metadata
 std::string get_remote_chkpt_meta_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        gpid pid,
                                        int64_t backup_id);

--- a/src/common/replication_types.cpp
+++ b/src/common/replication_types.cpp
@@ -206,10 +206,10 @@ const std::map<int, const char *> _hotkey_type_VALUES_TO_NAMES(
     ::apache::thrift::TEnumIterator(2, _khotkey_typeValues, _khotkey_typeNames),
     ::apache::thrift::TEnumIterator(-1, NULL, NULL));
 
-int _kdetect_actionValues[] = {detect_action::START, detect_action::STOP};
-const char *_kdetect_actionNames[] = {"START", "STOP"};
+int _kdetect_actionValues[] = {detect_action::START, detect_action::STOP, detect_action::QUERY};
+const char *_kdetect_actionNames[] = {"START", "STOP", "QUERY"};
 const std::map<int, const char *> _detect_action_VALUES_TO_NAMES(
-    ::apache::thrift::TEnumIterator(2, _kdetect_actionValues, _kdetect_actionNames),
+    ::apache::thrift::TEnumIterator(3, _kdetect_actionValues, _kdetect_actionNames),
     ::apache::thrift::TEnumIterator(-1, NULL, NULL));
 
 int _kdisk_migration_statusValues[] = {disk_migration_status::IDLE,
@@ -18157,6 +18157,12 @@ void detect_hotkey_response::__set_err_hint(const std::string &val)
     __isset.err_hint = true;
 }
 
+void detect_hotkey_response::__set_hotkey_result(const std::string &val)
+{
+    this->hotkey_result = val;
+    __isset.hotkey_result = true;
+}
+
 uint32_t detect_hotkey_response::read(::apache::thrift::protocol::TProtocol *iprot)
 {
 
@@ -18192,6 +18198,14 @@ uint32_t detect_hotkey_response::read(::apache::thrift::protocol::TProtocol *ipr
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 3:
+            if (ftype == ::apache::thrift::protocol::T_STRING) {
+                xfer += iprot->readString(this->hotkey_result);
+                this->__isset.hotkey_result = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -18219,6 +18233,11 @@ uint32_t detect_hotkey_response::write(::apache::thrift::protocol::TProtocol *op
         xfer += oprot->writeString(this->err_hint);
         xfer += oprot->writeFieldEnd();
     }
+    if (this->__isset.hotkey_result) {
+        xfer += oprot->writeFieldBegin("hotkey_result", ::apache::thrift::protocol::T_STRING, 3);
+        xfer += oprot->writeString(this->hotkey_result);
+        xfer += oprot->writeFieldEnd();
+    }
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -18229,6 +18248,7 @@ void swap(detect_hotkey_response &a, detect_hotkey_response &b)
     using ::std::swap;
     swap(a.err, b.err);
     swap(a.err_hint, b.err_hint);
+    swap(a.hotkey_result, b.hotkey_result);
     swap(a.__isset, b.__isset);
 }
 
@@ -18236,18 +18256,21 @@ detect_hotkey_response::detect_hotkey_response(const detect_hotkey_response &oth
 {
     err = other774.err;
     err_hint = other774.err_hint;
+    hotkey_result = other774.hotkey_result;
     __isset = other774.__isset;
 }
 detect_hotkey_response::detect_hotkey_response(detect_hotkey_response &&other775)
 {
     err = std::move(other775.err);
     err_hint = std::move(other775.err_hint);
+    hotkey_result = std::move(other775.hotkey_result);
     __isset = std::move(other775.__isset);
 }
 detect_hotkey_response &detect_hotkey_response::operator=(const detect_hotkey_response &other776)
 {
     err = other776.err;
     err_hint = other776.err_hint;
+    hotkey_result = other776.hotkey_result;
     __isset = other776.__isset;
     return *this;
 }
@@ -18255,6 +18278,7 @@ detect_hotkey_response &detect_hotkey_response::operator=(detect_hotkey_response
 {
     err = std::move(other777.err);
     err_hint = std::move(other777.err_hint);
+    hotkey_result = std::move(other777.hotkey_result);
     __isset = std::move(other777.__isset);
     return *this;
 }
@@ -18266,6 +18290,9 @@ void detect_hotkey_response::printTo(std::ostream &out) const
     out << ", "
         << "err_hint=";
     (__isset.err_hint ? (out << to_string(err_hint)) : (out << "<null>"));
+    out << ", "
+        << "hotkey_result=";
+    (__isset.hotkey_result ? (out << to_string(hotkey_result)) : (out << "<null>"));
     out << ")";
 }
 }

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -72,6 +72,11 @@ namespace dsn {
             get_perf_counter_handler(req, resp);
         })
         .with_help("Gets the value of a perf counter");
+
+    register_http_call("updateConfig")
+        .with_callback(
+            [](const http_request &req, http_response &resp) { update_config(req, resp); })
+        .with_help("Updates the value of a config");
 }
 
 } // namespace dsn

--- a/src/http/http_server_impl.h
+++ b/src/http/http_server_impl.h
@@ -35,8 +35,4 @@ public:
 
 extern void http_response_reply(const http_response &resp, message_ex *req);
 
-/// The rpc code for all the HTTP RPCs.
-/// Since http is used only for system monitoring, it is restricted to lowest priority.
-DEFINE_TASK_CODE_RPC(RPC_HTTP_SERVICE, TASK_PRIORITY_LOW, THREAD_POOL_DEFAULT);
-
 } // namespace dsn

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -15,16 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <dsn/dist/fmt_logging.h>
+#include <dsn/http/http_server.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/utils/time_utils.h>
 #include <dsn/utility/output_utils.h>
-#include <dsn/http/http_server.h>
 
+#include "block_service/block_service_manager.h"
+#include "common/backup_utils.h"
 #include "meta_backup_service.h"
 #include "meta_service.h"
 #include "server_state.h"
-#include "block_service/block_service_manager.h"
-#include "common/backup_utils.h"
 
 namespace dsn {
 namespace replication {
@@ -77,7 +78,6 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
     dist::block_service::create_file_request create_file_req;
     create_file_req.ignore_metadata = true;
     create_file_req.file_name = cold_backup::get_app_metadata_file(_backup_service->backup_root(),
-                                                                   _policy.policy_name,
                                                                    _policy.app_names.at(app_id),
                                                                    app_id,
                                                                    _cur_backup.backup_id);
@@ -94,9 +94,9 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
                       })
         ->wait();
     if (err != dsn::ERR_OK) {
-        derror("%s: create file %s failed, restart this backup later",
-               _backup_sig.c_str(),
-               create_file_req.file_name.c_str());
+        derror_f("{}: create file {} failed, restart this backup later",
+                 _backup_sig,
+                 create_file_req.file_name);
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this, app_id]() {
@@ -104,7 +104,7 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
                              start_backup_app_meta_unlocked(app_id);
                          },
                          0,
-                         _backup_service->backup_option().block_retry_delay_ms);
+                         std::chrono::seconds(1));
         return;
     }
     dassert(remote_file != nullptr,
@@ -124,15 +124,16 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
                         resp.written_size);
                 {
                     zauto_lock l(_lock);
-                    ddebug("%s: successfully backup app metadata to %s",
-                           _policy.policy_name.c_str(),
-                           remote_file->file_name().c_str());
+                    ddebug_f("{}: successfully backup app metadata to %s",
+                             _backup_sig,
+                             remote_file->file_name());
                     start_backup_app_partitions_unlocked(app_id);
                 }
             } else {
-                dwarn("write %s failed, reason(%s), try it later",
-                      remote_file->file_name().c_str(),
-                      resp.err.to_string());
+                dwarn_f("{}: write {} failed, reason {}, try it later",
+                        _backup_sig,
+                        remote_file->file_name(),
+                        resp.err.to_string());
                 tasking::enqueue(LPC_DEFAULT_CALLBACK,
                                  &_tracker,
                                  [this, app_id]() {
@@ -140,7 +141,7 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
                                      start_backup_app_meta_unlocked(app_id);
                                  },
                                  0,
-                                 _backup_service->backup_option().block_retry_delay_ms);
+                                 std::chrono::seconds(1));
             }
         },
         &_tracker);
@@ -162,7 +163,7 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
                                                            dsn::task_ptr write_callback)
 {
     if (_progress.is_app_skipped[app_id]) {
-        dwarn("app is unavaliable, skip write finish flag for this app(app_id = %d)", app_id);
+        dwarn_f("{}:, app is unavailable, skip write finish flag for app {}", _backup_sig, app_id);
         if (write_callback != nullptr) {
             write_callback->enqueue();
         }
@@ -183,7 +184,6 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
     create_file_req.ignore_metadata = true;
     create_file_req.file_name =
         cold_backup::get_app_backup_status_file(_backup_service->backup_root(),
-                                                _policy.policy_name,
                                                 _policy.app_names.at(app_id),
                                                 app_id,
                                                 _cur_backup.backup_id);
@@ -198,9 +198,9 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
         ->wait();
 
     if (err != ERR_OK) {
-        derror("%s: create file %s failed, restart this backup later",
-               _backup_sig.c_str(),
-               create_file_req.file_name.c_str());
+        derror_f("{}: create file {} failed, restart this backup later",
+                 _backup_sig,
+                 create_file_req.file_name);
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this, app_id, write_callback]() {
@@ -208,7 +208,7 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
                              write_backup_app_finish_flag_unlocked(app_id, write_callback);
                          },
                          0,
-                         _backup_service->backup_option().block_retry_delay_ms);
+                         std::chrono::seconds(1));
         return;
     }
 
@@ -216,10 +216,10 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
             "%s: create file(%s) succeed, but can't get handle",
             _backup_sig.c_str(),
             create_file_req.file_name.c_str());
-    if (!remote_file->get_md5sum().empty() && remote_file->get_size() > 0) {
+    if (remote_file->get_size() > 0) {
         // we only focus whether app_backup_status file is exist, so ignore app_backup_status file's
         // context
-        ddebug("app(%d) already write finish-flag on block service", app_id);
+        ddebug_f("{}: app {} already write finish-flag on block service", _backup_sig, app_id);
         if (write_callback != nullptr) {
             write_callback->enqueue();
         }
@@ -234,15 +234,17 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
         [this, app_id, write_callback, remote_file](
             const dist::block_service::write_response &resp) {
             if (resp.err == ERR_OK) {
-                ddebug("app(%d) finish backup and write finish-flag on block service succeed",
-                       app_id);
+                ddebug_f("{}: app {} finish backup and write finish-flag on block service succeed",
+                         _backup_sig,
+                         app_id);
                 if (write_callback != nullptr) {
                     write_callback->enqueue();
                 }
             } else {
-                dwarn("write %s failed, reason(%s), try it later",
-                      remote_file->file_name().c_str(),
-                      resp.err.to_string());
+                dwarn_f("{}: write {} failed, reason {}, try it later",
+                        _backup_sig,
+                        remote_file->file_name(),
+                        resp.err.to_string());
                 tasking::enqueue(LPC_DEFAULT_CALLBACK,
                                  &_tracker,
                                  [this, app_id, write_callback]() {
@@ -250,19 +252,20 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
                                      write_backup_app_finish_flag_unlocked(app_id, write_callback);
                                  },
                                  0,
-                                 _backup_service->backup_option().block_retry_delay_ms);
+                                 std::chrono::seconds(1));
             }
         });
 }
 
 void policy_context::finish_backup_app_unlocked(int32_t app_id)
 {
-    ddebug("%s: finish backup for app(%d), progress(%d)",
-           _backup_sig.c_str(),
-           app_id,
-           _progress.unfinished_apps);
+    ddebug_f("{}: finish backup for app {}, progress {}",
+             _backup_sig,
+             app_id,
+             _progress.unfinished_apps);
+    _backup_service->remove_backup_app(app_id);
     if (--_progress.unfinished_apps == 0) {
-        ddebug("%s: finish current backup for all apps", _backup_sig.c_str());
+        ddebug_f("{}: finish current backup for all apps", _backup_sig);
         _cur_backup.end_time_ms = dsn_now_ms();
 
         task_ptr write_backup_info_callback =
@@ -277,8 +280,7 @@ void policy_context::finish_backup_app_unlocked(int32_t app_id)
                                 _cur_backup.backup_id);
                         _cur_backup.start_time_ms = 0;
                         _cur_backup.end_time_ms = 0;
-                        ddebug("%s: finish an old backup, try to start a new one",
-                               _backup_sig.c_str());
+                        ddebug_f("{}: finish an old backup, try to start a new one", _backup_sig);
                         issue_new_backup_unlocked();
                     });
                 sync_backup_to_remote_storage_unlocked(_cur_backup, start_a_new_backup, false);
@@ -295,10 +297,8 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
 
     dist::block_service::create_file_request create_file_req;
     create_file_req.ignore_metadata = true;
-    create_file_req.file_name = utils::filesystem::path_combine(
-        cold_backup::get_backup_path(
-            _backup_service->backup_root(), _policy.policy_name, b_info.backup_id),
-        cold_backup_constant::BACKUP_INFO);
+    create_file_req.file_name =
+        cold_backup::get_backup_info_file(_backup_service->backup_root(), b_info.backup_id);
     // here we can use synchronous way coz create_file with ignored metadata is very fast
     _block_service
         ->create_file(create_file_req,
@@ -310,9 +310,9 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
         ->wait();
 
     if (err != ERR_OK) {
-        derror("%s: create file %s failed, restart this backup later",
-               _backup_sig.c_str(),
-               create_file_req.file_name.c_str());
+        derror_f("{}: create file {} failed, restart this backup later",
+                 _backup_sig,
+                 create_file_req.file_name);
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this, b_info, write_callback]() {
@@ -320,7 +320,7 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
                              write_backup_info_unlocked(b_info, write_callback);
                          },
                          0,
-                         _backup_service->backup_option().block_retry_delay_ms);
+                         std::chrono::seconds(1));
         return;
     }
 
@@ -331,75 +331,75 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
 
     blob buf = dsn::json::json_forwarder<backup_info>::encode(b_info);
 
-    remote_file->write(dist::block_service::write_request{buf},
-                       LPC_DEFAULT_CALLBACK,
-                       [this, b_info, write_callback, remote_file](
-                           const dist::block_service::write_response &resp) {
-                           if (resp.err == ERR_OK) {
-                               ddebug("policy(%s) write backup_info to cold backup media succeed",
-                                      _policy.policy_name.c_str());
-                               if (write_callback != nullptr) {
-                                   write_callback->enqueue();
-                               }
-                           } else {
-                               dwarn("write %s failed, reason(%s), try it later",
-                                     remote_file->file_name().c_str(),
-                                     resp.err.to_string());
-                               tasking::enqueue(
-                                   LPC_DEFAULT_CALLBACK,
-                                   &_tracker,
-                                   [this, b_info, write_callback]() {
-                                       zauto_lock l(_lock);
-                                       write_backup_info_unlocked(b_info, write_callback);
-                                   },
-                                   0,
-                                   _backup_service->backup_option().block_retry_delay_ms);
-                           }
-                       });
+    remote_file->write(
+        dist::block_service::write_request{buf},
+        LPC_DEFAULT_CALLBACK,
+        [this, b_info, write_callback, remote_file](
+            const dist::block_service::write_response &resp) {
+            if (resp.err == ERR_OK) {
+                ddebug_f("{}: write {} succeed.", _backup_sig, remote_file->file_name());
+                if (write_callback != nullptr) {
+                    write_callback->enqueue();
+                }
+            } else {
+                dwarn_f("{}: write {} failed, reason {}, try it later.",
+                        _backup_sig,
+                        remote_file->file_name(),
+                        resp.err.to_string());
+                tasking::enqueue(LPC_DEFAULT_CALLBACK,
+                                 &_tracker,
+                                 [this, b_info, write_callback]() {
+                                     zauto_lock l(_lock);
+                                     write_backup_info_unlocked(b_info, write_callback);
+                                 },
+                                 0,
+                                 std::chrono::seconds(1));
+            }
+        });
 }
 
 bool policy_context::update_partition_progress_unlocked(gpid pid,
                                                         int32_t progress,
                                                         const rpc_address &source)
 {
-    int32_t &recorded_progress = _progress.partition_progress[pid];
-    if (recorded_progress == cold_backup_constant::PROGRESS_FINISHED) {
-        dwarn("%s: recorded progress(%d) is finished for pid(%d.%d), ignore the progress "
-              "from(%s)",
-              _backup_sig.c_str(),
-              recorded_progress,
-              pid.get_app_id(),
-              pid.get_partition_index(),
-              source.to_string(),
-              progress);
+    int32_t &local_progress = _progress.partition_progress[pid];
+    if (local_progress == cold_backup_constant::PROGRESS_FINISHED) {
+        dwarn_f("{}: local recorded progress {} is finished for pid {}.{}, ignore the progress "
+                "from {}",
+                _backup_sig,
+                local_progress,
+                pid.get_app_id(),
+                pid.get_partition_index(),
+                source.to_string(),
+                progress);
         return true;
     }
 
-    if (progress < _progress.partition_progress[pid]) {
-        dwarn("%s: local progress(%d) is larger than progress(%d) from rs(%s) for pid(%d.%d), "
-              "perhaps primary changed",
-              _backup_sig.c_str(),
-              _progress.partition_progress[pid],
-              progress,
-              source.to_string(),
-              pid.get_app_id(),
-              pid.get_partition_index());
+    if (progress < local_progress) {
+        dwarn_f("{}: local progress {} is larger than progress {} from replica server {} for "
+                "pid {}.{}, perhaps primary changed",
+                _backup_sig,
+                local_progress,
+                progress,
+                source.to_string(),
+                pid.get_app_id(),
+                pid.get_partition_index());
     }
 
-    recorded_progress = progress;
-    dinfo("%s: gpid(%d.%d)'s progress to (%d) from(%s)",
-          _backup_sig.c_str(),
-          pid.get_app_id(),
-          pid.get_partition_index(),
-          progress,
-          source.to_string());
-    if (recorded_progress == cold_backup_constant::PROGRESS_FINISHED) {
-        ddebug("%s: finish backup for gpid(%d.%d) from %s, app_progress(%d)",
-               _backup_sig.c_str(),
-               pid.get_app_id(),
-               pid.get_partition_index(),
-               source.to_string(),
-               _progress.unfinished_partitions_per_app[pid.get_app_id()]);
+    dinfo_f("{}: update gpid {}.{}'s progress to {} from {}",
+            _backup_sig,
+            pid.get_app_id(),
+            pid.get_partition_index(),
+            progress,
+            source.to_string());
+    local_progress = progress;
+    if (local_progress == cold_backup_constant::PROGRESS_FINISHED) {
+        ddebug_f("{}: finish backup for gpid {}.{} from %s, app_progress{}",
+                 _backup_sig,
+                 pid.get_app_id(),
+                 pid.get_partition_index(),
+                 source.to_string(),
+                 _progress.unfinished_partitions_per_app[pid.get_app_id()]);
 
         // let's update the progress-chain: partition => app => current_backup_instance
         if (--_progress.unfinished_partitions_per_app[pid.get_app_id()] == 0) {
@@ -411,7 +411,7 @@ bool policy_context::update_partition_progress_unlocked(gpid pid,
             write_backup_app_finish_flag_unlocked(pid.get_app_id(), task_after_write_finish_flag);
         }
     }
-    return recorded_progress == cold_backup_constant::PROGRESS_FINISHED;
+    return local_progress == cold_backup_constant::PROGRESS_FINISHED;
 }
 
 void policy_context::record_partition_checkpoint_size_unlock(const gpid &pid, int64_t size)
@@ -430,9 +430,9 @@ void policy_context::start_backup_partition_unlocked(gpid pid)
 
         if (app == nullptr || app->status == app_status::AS_DROPPED) {
             // skip backup app this time
-            dwarn("%s: app(%lld) is not available any more, just ignore this app",
-                  _backup_sig.c_str(),
-                  pid.get_app_id());
+            dwarn_f("{}: app {} is not available, just ignore this app.",
+                    _backup_sig,
+                    pid.get_app_id());
             _progress.is_app_skipped[pid.get_app_id()] = true;
             update_partition_progress_unlocked(
                 pid, cold_backup_constant::PROGRESS_FINISHED, dsn::rpc_address());
@@ -444,10 +444,10 @@ void policy_context::start_backup_partition_unlocked(gpid pid)
     // then start to backup partition
     {
         if (partition_primary.is_invalid()) {
-            dwarn("%s: gpid(%d.%d) don't have a primary right now, retry it later",
-                  _backup_sig.c_str(),
-                  pid.get_app_id(),
-                  pid.get_partition_index());
+            dwarn_f("{}: gpid({}.{}) don't have a primary right now, retry it later",
+                    _backup_sig,
+                    pid.get_app_id(),
+                    pid.get_partition_index());
             tasking::enqueue(LPC_DEFAULT_CALLBACK,
                              &_tracker,
                              [this, pid]() {
@@ -455,31 +455,30 @@ void policy_context::start_backup_partition_unlocked(gpid pid)
                                  start_backup_partition_unlocked(pid);
                              },
                              0,
-                             _backup_service->backup_option().reconfiguration_retry_delay_ms);
-        } else {
-            backup_request req;
-            req.pid = pid;
-            req.policy = *(static_cast<const policy_info *>(&_policy));
-            req.backup_id = _cur_backup.backup_id;
-            req.app_name = _policy.app_names.at(pid.get_app_id());
-            dsn::message_ex *request =
-                dsn::message_ex::create_request(RPC_COLD_BACKUP, 0, pid.thread_hash());
-            dsn::marshall(request, req);
-            dsn::rpc_response_task_ptr rpc_callback = rpc::create_rpc_response_task(
-                request,
-                &_tracker,
-                [this, pid, partition_primary](error_code err, backup_response &&response) {
-                    on_backup_reply(err, std::move(response), pid, partition_primary);
-                });
-            _progress.backup_requests[pid] = rpc_callback;
-            ddebug("%s: send backup command to replica server, partition(%d.%d), target_addr = %s",
-                   _backup_sig.c_str(),
-                   pid.get_app_id(),
-                   pid.get_partition_index(),
-                   partition_primary.to_string());
-            _backup_service->get_meta_service()->send_request(
-                request, partition_primary, rpc_callback);
+                             std::chrono::seconds(1));
+            return;
         }
+        backup_request req;
+        req.pid = pid;
+        req.policy = *(static_cast<const policy_info *>(&_policy));
+        req.backup_id = _cur_backup.backup_id;
+        req.app_name = _policy.app_names.at(pid.get_app_id());
+        dsn::message_ex *request =
+            dsn::message_ex::create_request(RPC_COLD_BACKUP, 0, pid.thread_hash());
+        dsn::marshall(request, req);
+        dsn::rpc_response_task_ptr rpc_callback = rpc::create_rpc_response_task(
+            request,
+            &_tracker,
+            [this, pid, partition_primary](error_code err, backup_response &&response) {
+                on_backup_reply(err, std::move(response), pid, partition_primary);
+            });
+        _progress.backup_requests[pid] = rpc_callback;
+        ddebug_f("{}: send backup command to replica server, partition({}.{}), target_addr = {}",
+                 _backup_sig,
+                 pid.get_app_id(),
+                 pid.get_partition_index(),
+                 partition_primary.to_string());
+        _backup_service->get_meta_service()->send_request(request, partition_primary, rpc_callback);
     }
 }
 
@@ -489,16 +488,6 @@ void policy_context::on_backup_reply(error_code err,
                                      const rpc_address &primary)
 {
     if (err == dsn::ERR_OK && response.err == dsn::ERR_OK) {
-        zauto_lock l(_lock);
-
-        _progress.backup_requests[pid] = nullptr;
-        dassert(response.policy_name == _policy.policy_name,
-                "policy name(%s vs %s) don't match, pid(%d.%d), replica_server(%s)",
-                _policy.policy_name.c_str(),
-                response.policy_name.c_str(),
-                pid.get_app_id(),
-                pid.get_partition_index(),
-                primary.to_string());
         dassert(response.pid == pid,
                 "%s: backup pid[(%d.%d) vs (%d.%d)] don't match, replica_server(%s)",
                 _policy.policy_name.c_str(),
@@ -516,28 +505,29 @@ void policy_context::on_backup_reply(error_code err,
                 pid.get_partition_index());
 
         if (response.backup_id < _cur_backup.backup_id) {
-            dwarn("%s: got a backup response with lower backup id(%lld), "
-                  "pid(%d.%d), rs(%s), maybe staled message",
-                  _backup_sig.c_str(),
-                  response.backup_id,
-                  pid.get_app_id(),
-                  pid.get_partition_index(),
-                  primary.to_string());
+            dwarn_f("{}: got a backup response with lower backup id {}, "
+                    "pid({}.{}) from server {}, maybe staled message",
+                    _backup_sig,
+                    response.backup_id,
+                    pid.get_app_id(),
+                    pid.get_partition_index(),
+                    primary.to_string());
         } else {
+            zauto_lock l(_lock);
             record_partition_checkpoint_size_unlock(pid, response.checkpoint_total_size);
-            // NOTICE: if a partition is finished, we don't try to resend the command again
             if (update_partition_progress_unlocked(pid, response.progress, primary)) {
+                // partition backup finished
                 return;
             }
         }
     } else {
-        dwarn("%s: backup got error for gpid(%d.%d) from(%s), rpc(%s), logic(%s)",
-              _backup_sig.c_str(),
-              pid.get_app_id(),
-              pid.get_partition_index(),
-              primary.to_string(),
-              err.to_string(),
-              response.err.to_string());
+        dwarn_f("{}: backup got error for gpid({}.{}) from {}, rpc error {}, response error {}",
+                _backup_sig,
+                pid.get_app_id(),
+                pid.get_partition_index(),
+                primary.to_string(),
+                err.to_string(),
+                response.err.to_string());
     }
 
     // start another turn of backup no matter we encounter error or not finished
@@ -548,54 +538,69 @@ void policy_context::on_backup_reply(error_code err,
                          start_backup_partition_unlocked(pid);
                      },
                      0,
-                     _backup_service->backup_option().request_backup_period_ms);
+                     std::chrono::seconds(1));
 }
 
 void policy_context::initialize_backup_progress_unlocked()
 {
     _progress.reset();
+    _cur_backup.app_ids.clear();
+    _cur_backup.app_names.clear();
 
     zauto_read_lock l;
     _backup_service->get_state()->lock_read(l);
 
-    // NOTICE: the unfinished_apps is initialized with the app-set's size
-    // even if some apps are not available.
-    _progress.unfinished_apps = _cur_backup.app_ids.size();
-    for (const int32_t &app_id : _cur_backup.app_ids) {
+    for (const int32_t &app_id : _policy.app_ids) {
         const std::shared_ptr<app_state> &app = _backup_service->get_state()->get_app(app_id);
         _progress.is_app_skipped[app_id] = true;
         if (app == nullptr) {
-            dwarn("%s: app id(%d) is invalid", _policy.policy_name.c_str(), app_id);
+            dwarn_f("{}: app {} is invalid", _policy.policy_name, app_id);
         } else if (app->status != app_status::AS_AVAILABLE) {
-            dwarn("%s: %s is not available, status(%s)",
-                  _policy.policy_name.c_str(),
-                  app->get_logname(),
-                  enum_to_string(app->status));
+            dwarn_f("{}: app {} is not available, status {})",
+                    _policy.policy_name,
+                    app_id,
+                    enum_to_string(app->status));
         } else {
-            // NOTICE: only available apps have entry in
-            // unfinished_partitions_per_app & partition_progress & app_chkpt_size
+            // NOTICE: only available apps would be included in these local variables
             _progress.unfinished_partitions_per_app[app_id] = app->partition_count;
             std::map<int, int64_t> partition_chkpt_size;
             for (const partition_configuration &pc : app->partitions) {
                 _progress.partition_progress[pc.pid] = 0;
-                partition_chkpt_size[pc.pid.get_app_id()] = 0;
+                partition_chkpt_size[pc.pid.get_partition_index()] = 0;
             }
             _progress.app_chkpt_size[app_id] = std::move(partition_chkpt_size);
             _progress.is_app_skipped[app_id] = false;
+            _cur_backup.app_ids.emplace(app_id);
+            _cur_backup.app_names.emplace(std::make_pair(app_id, app->app_name));
         }
     }
+    _progress.unfinished_apps = _cur_backup.app_ids.size();
 }
 
 void policy_context::prepare_current_backup_on_new_unlocked()
 {
-    // initialize the current backup structure
-    _cur_backup.backup_id = _cur_backup.start_time_ms = static_cast<int64_t>(dsn_now_ms());
-    _cur_backup.app_ids = _policy.app_ids;
-    _cur_backup.app_names = _policy.app_names;
-
     initialize_backup_progress_unlocked();
-    _backup_sig =
-        _policy.policy_name + "@" + boost::lexical_cast<std::string>(_cur_backup.backup_id);
+    if (_cur_backup.app_ids.empty()) {
+        dwarn_f("{}: all apps are not available, retry later", _policy.policy_name);
+        tasking::enqueue(LPC_DEFAULT_CALLBACK,
+                         &_tracker,
+                         [this]() {
+                             zauto_lock l(_lock);
+                             prepare_current_backup_on_new_unlocked();
+                         },
+                         0,
+                         std::chrono::seconds(10));
+        return;
+    }
+    // initialize the current backup id and _backup_sig
+    _cur_backup.backup_id = _cur_backup.start_time_ms = static_cast<int64_t>(dsn_now_ms());
+    _backup_sig = _policy.policy_name + "@" + std::to_string(_cur_backup.backup_id);
+
+    task_ptr continue_to_backup = tasking::create_task(LPC_DEFAULT_CALLBACK, &_tracker, [this]() {
+        zauto_lock l(_lock);
+        continue_current_backup_unlocked();
+    });
+    sync_backup_to_remote_storage_unlocked(_cur_backup, continue_to_backup, true);
 }
 
 void policy_context::sync_backup_to_remote_storage_unlocked(const backup_info &b_info,
@@ -608,20 +613,20 @@ void policy_context::sync_backup_to_remote_storage_unlocked(const backup_info &b
 
     auto callback = [this, b_info, sync_callback, create_new_node](dsn::error_code err) {
         if (dsn::ERR_OK == err || (create_new_node && ERR_NODE_ALREADY_EXIST == err)) {
-            ddebug("%s: synced backup_info(%" PRId64 ") to remote storage successfully,"
-                   " start real backup work, new_node_create(%s)",
-                   _policy.policy_name.c_str(),
-                   b_info.backup_id,
-                   create_new_node ? "true" : "false");
+            ddebug_f("{}: synced backup_info {} to remote storage successfully,"
+                     " start real backup work, new_node_create {}",
+                     _backup_sig,
+                     b_info.backup_id,
+                     create_new_node ? "true" : "false");
             if (sync_callback != nullptr) {
                 sync_callback->enqueue();
             } else {
-                dwarn("%s: empty callback", _policy.policy_name.c_str());
+                dwarn_f("{}: empty callback", _policy.policy_name);
             }
         } else if (ERR_TIMEOUT == err) {
-            derror("%s: sync backup info(" PRId64 ") to remote storage got timeout, retry it later",
-                   _policy.policy_name.c_str(),
-                   b_info.backup_id);
+            derror_f("{}: sync backup info {} to remote storage got timeout, retry it later",
+                     _backup_sig,
+                     b_info.backup_id);
             tasking::enqueue(LPC_DEFAULT_CALLBACK,
                              &_tracker,
                              [this, b_info, sync_callback, create_new_node]() {
@@ -630,7 +635,7 @@ void policy_context::sync_backup_to_remote_storage_unlocked(const backup_info &b
                                      std::move(b_info), std::move(sync_callback), create_new_node);
                              },
                              0,
-                             _backup_service->backup_option().meta_retry_delay_ms);
+                             std::chrono::seconds(1));
         } else {
             dassert(false,
                     "%s: we can't handle this right now, error(%s)",
@@ -651,17 +656,24 @@ void policy_context::sync_backup_to_remote_storage_unlocked(const backup_info &b
 void policy_context::continue_current_backup_unlocked()
 {
     for (const int32_t &app : _cur_backup.app_ids) {
-        if (_progress.unfinished_partitions_per_app.find(app) !=
-            _progress.unfinished_partitions_per_app.end()) {
-            start_backup_app_meta_unlocked(app);
-        } else {
-            dsn::task_ptr task_after_write_finish_flag =
-                tasking::create_task(LPC_DEFAULT_CALLBACK, &_tracker, [this, app]() {
-                    zauto_lock l(_lock);
-                    finish_backup_app_unlocked(app);
-                });
-            write_backup_app_finish_flag_unlocked(app, task_after_write_finish_flag);
-        }
+        continue_backup_app_unlocked(app);
+    }
+}
+
+void policy_context::continue_backup_app_unlocked(int32_t app_id)
+{
+    if (!_backup_service->add_backup_app(app_id)) {
+        tasking::enqueue(LPC_DEFAULT_CALLBACK,
+                         &_tracker,
+                         [this, app_id]() {
+                             zauto_lock l(_lock);
+                             continue_backup_app_unlocked(app_id);
+                         },
+                         0,
+                         std::chrono::seconds(1));
+        ddebug_f("{}: app {} is being backed up now, will retry later", _backup_sig, app_id);
+    } else {
+        start_backup_app_meta_unlocked(app_id);
     }
 }
 
@@ -673,58 +685,23 @@ bool policy_context::should_start_backup_unlocked()
         recent_backup_start_time_ms = _backup_history.rbegin()->second.start_time_ms;
     }
 
-    // the true start time of recent backup have drifted away with the origin start time of
-    // policy,
-    // so we should take the drift into consideration; if user change the start time of the
-    // policy,
-    // we just think the change of start time as drift
-    int32_t hour = 0, min = 0, sec = 0;
     if (recent_backup_start_time_ms == 0) {
-        //  the first time to backup, just consider the start time
-        ::dsn::utils::time_ms_to_date_time(now, hour, min, sec);
+        // The first time to backup, just consider the start time
+        int32_t hour = 0, min = 0, sec = 0;
+        dsn::utils::time_ms_to_date_time(now, hour, min, sec);
         return _policy.start_time.should_start_backup(hour, min);
-    } else {
-        uint64_t next_backup_time_ms =
-            recent_backup_start_time_ms + _policy.backup_interval_seconds * 1000;
-        if (_policy.start_time.hour != 24) {
-            // user have specify the time point to start backup, so we should take the the
-            // time-drift into consideration
-
-            // compute the time-drift
-            ::dsn::utils::time_ms_to_date_time(recent_backup_start_time_ms, hour, min, sec);
-            int64_t time_dirft_ms = _policy.start_time.compute_time_drift_ms(hour, min);
-
-            if (time_dirft_ms >= 0) {
-                // hour:min(the true start time) >= policy.start_time :
-                //      1, user move up the start time of policy, such as 20:00 to 2:00, we just
-                //      think this case as time drift
-                //      2, the true start time of backup is delayed, compared the origin start time
-                //      of policy, we should process this case
-                //      3, the true start time of backup is the same with the origin start time of
-                //      policy
-                next_backup_time_ms -= time_dirft_ms;
-            } else {
-                // hour:min(the true start time) < policy.start_time:
-                //      1, user delay the start time of policy, such as 2:00 to 23:00
-                //
-                // these case has already been handled, we do nothing
-            }
-        }
-        if (next_backup_time_ms <= now) {
-            ::dsn::utils::time_ms_to_date_time(now, hour, min, sec);
-            return _policy.start_time.should_start_backup(hour, min);
-        } else {
-            return false;
-        }
     }
+
+    uint64_t next_backup_time_ms =
+        recent_backup_start_time_ms + _policy.backup_interval_seconds * 1000;
+    return now >= next_backup_time_ms;
 }
 
 void policy_context::issue_new_backup_unlocked()
 {
     // before issue new backup, we check whether the policy is dropped
     if (_policy.is_disable) {
-        ddebug("%s: policy is disable, just ignore backup, try it later",
-               _policy.policy_name.c_str());
+        ddebug_f("policy {} is disable, just ignore backup, try it later", _policy.policy_name);
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this]() {
@@ -732,7 +709,7 @@ void policy_context::issue_new_backup_unlocked()
                              issue_new_backup_unlocked();
                          },
                          0,
-                         _backup_service->backup_option().issue_backup_interval_ms);
+                         std::chrono::seconds(1));
         return;
     }
 
@@ -744,35 +721,14 @@ void policy_context::issue_new_backup_unlocked()
                              issue_new_backup_unlocked();
                          },
                          0,
-                         _backup_service->backup_option().issue_backup_interval_ms);
-        ddebug("%s: start issue new backup %" PRId64 "ms later",
-               _policy.policy_name.c_str(),
-               _backup_service->backup_option().issue_backup_interval_ms.count());
+                         std::chrono::seconds(1));
+        ddebug_f(
+            "{}: it's not the right time to start backup now, retry to issue new backup later.",
+            _policy.policy_name);
         return;
     }
 
     prepare_current_backup_on_new_unlocked();
-    // if all apps are dropped, we don't issue a new backup
-    if (_progress.unfinished_partitions_per_app.empty()) {
-        // TODO: just ignore this backup and wait next backup
-        dwarn("%s: all apps have been dropped, ignore this backup and retry it later",
-              _backup_sig.c_str());
-        tasking::enqueue(LPC_DEFAULT_CALLBACK,
-                         &_tracker,
-                         [this]() {
-                             zauto_lock l(_lock);
-                             issue_new_backup_unlocked();
-                         },
-                         0,
-                         _backup_service->backup_option().issue_backup_interval_ms);
-    } else {
-        task_ptr continue_to_backup =
-            tasking::create_task(LPC_DEFAULT_CALLBACK, &_tracker, [this]() {
-                zauto_lock l(_lock);
-                continue_current_backup_unlocked();
-            });
-        sync_backup_to_remote_storage_unlocked(_cur_backup, continue_to_backup, true);
-    }
 }
 
 void policy_context::start()
@@ -816,8 +772,7 @@ void policy_context::add_backup_history(const backup_info &info)
                 info.backup_id);
         _cur_backup = info;
         initialize_backup_progress_unlocked();
-        _backup_sig =
-            _policy.policy_name + "@" + boost::lexical_cast<std::string>(_cur_backup.backup_id);
+        _backup_sig = _policy.policy_name + "@" + std::to_string(_cur_backup.backup_id);
     } else {
         ddebug("%s: add backup history, id(%lld), start_time(%lld), endtime(%lld)",
                _policy.policy_name.c_str(),
@@ -903,8 +858,8 @@ void policy_context::gc_backup_info_unlocked(const backup_info &info_to_gc)
     dsn::task_ptr sync_callback =
         ::dsn::tasking::create_task(LPC_DEFAULT_CALLBACK, &_tracker, [this, info_to_gc]() {
             dist::block_service::remove_path_request req;
-            req.path = cold_backup::get_backup_path(
-                _backup_service->backup_root(), _policy.policy_name, info_to_gc.backup_id);
+            req.path =
+                cold_backup::get_backup_path(_backup_service->backup_root(), info_to_gc.backup_id);
             req.recursive = true;
             _block_service->remove_path(
                 req,
@@ -977,22 +932,21 @@ void policy_context::sync_remove_backup_info(const backup_info &info, dsn::task_
         _backup_service->get_backup_path(_policy.policy_name, info.backup_id);
     auto callback = [this, info, sync_callback](dsn::error_code err) {
         if (err == dsn::ERR_OK || err == dsn::ERR_OBJECT_NOT_FOUND) {
-            ddebug("%s: sync remove backup_info on remote storage successfully, backup_id(%" PRId64
-                   ")",
-                   _policy.policy_name.c_str(),
-                   info.backup_id);
+            ddebug_f("{}: sync remove backup_info on remote storage successfully, backup_id {}",
+                     _policy.policy_name,
+                     info.backup_id);
             if (sync_callback != nullptr) {
                 sync_callback->enqueue();
             }
         } else if (err == ERR_TIMEOUT) {
-            derror("%s: sync remove backup info on remote storage got timeout, retry it later",
-                   _policy.policy_name.c_str());
+            derror_f("{}: sync remove backup info on remote storage got timeout, retry it later",
+                     _policy.policy_name);
             tasking::enqueue(
                 LPC_DEFAULT_CALLBACK,
                 &_tracker,
                 [this, info, sync_callback]() { sync_remove_backup_info(info, sync_callback); },
                 0,
-                _backup_service->backup_option().meta_retry_delay_ms);
+                std::chrono::seconds(1));
         } else {
             dassert(false,
                     "%s: we can't handle this right now, error(%s)",
@@ -1015,36 +969,27 @@ backup_service::backup_service(meta_service *meta_svc,
       _backup_root(backup_root)
 {
     _state = _meta_svc->get_server_state();
-
-    _opt.meta_retry_delay_ms = 10000_ms;
-    _opt.block_retry_delay_ms = 60000_ms;
-    _opt.app_dropped_retry_delay_ms = 600000_ms;
-    _opt.reconfiguration_retry_delay_ms = 15000_ms;
-    _opt.request_backup_period_ms = 10000_ms;
-    _opt.issue_backup_interval_ms = 300000_ms;
-
     _in_initialize.store(true);
 }
 
 void backup_service::start_create_policy_meta_root(dsn::task_ptr callback)
 {
-    dinfo("create policy meta root(%s) on remote_storage", _policy_meta_root.c_str());
+    dinfo_f("create policy meta root {} on remote_storage", _policy_meta_root);
     _meta_svc->get_remote_storage()->create_node(
         _policy_meta_root, LPC_DEFAULT_CALLBACK, [this, callback](dsn::error_code err) {
             if (err == dsn::ERR_OK || err == ERR_NODE_ALREADY_EXIST) {
-                ddebug("create policy meta root(%s) succeed, with err(%s)",
-                       _policy_meta_root.c_str(),
-                       err.to_string());
+                ddebug_f("create policy meta root {} succeed, with err {}",
+                         _policy_meta_root,
+                         err.to_string());
                 callback->enqueue();
             } else if (err == dsn::ERR_TIMEOUT) {
-                derror("create policy meta root(%s) timeout, try it later",
-                       _policy_meta_root.c_str());
+                derror_f("create policy meta root {} timeout, try it later", _policy_meta_root);
                 dsn::tasking::enqueue(
                     LPC_DEFAULT_CALLBACK,
                     &_tracker,
                     std::bind(&backup_service::start_create_policy_meta_root, this, callback),
                     0,
-                    _opt.meta_retry_delay_ms);
+                    std::chrono::seconds(1));
             } else {
                 dassert(false, "we can't handle this error(%s) right now", err.to_string());
             }
@@ -1059,7 +1004,7 @@ void backup_service::start_sync_policies()
     dsn::error_code err = sync_policies_from_remote_storage();
     if (err == dsn::ERR_OK) {
         for (auto &policy_kv : _policy_states) {
-            ddebug("policy(%s) start to backup", policy_kv.first.c_str());
+            ddebug_f("policy {} start to backup", policy_kv.first);
             policy_kv.second->start();
         }
         if (_policy_states.empty()) {
@@ -1072,7 +1017,7 @@ void backup_service::start_sync_policies()
                               &_tracker,
                               std::bind(&backup_service::start_sync_policies, this),
                               0,
-                              _opt.meta_retry_delay_ms);
+                              std::chrono::seconds(1));
     } else {
         dassert(false,
                 "sync policies from remote storage encounter error(%s), we can't handle "
@@ -1206,7 +1151,18 @@ void backup_service::start()
     start_create_policy_meta_root(after_create_policy_meta_root);
 }
 
-// TODO(zhaoliwei) refactor function add_backup_policy
+bool backup_service::add_backup_app(int32_t app_id)
+{
+    zauto_lock l(_lock);
+    return _active_backup_apps.insert(app_id).second;
+}
+
+void backup_service::remove_backup_app(int32_t app_id)
+{
+    zauto_lock l(_lock);
+    _active_backup_apps.erase(app_id);
+}
+
 void backup_service::add_backup_policy(dsn::message_ex *msg)
 {
     configuration_add_backup_policy_request request;
@@ -1233,67 +1189,58 @@ void backup_service::add_backup_policy(dsn::message_ex *msg)
         // check app status
         zauto_read_lock l;
         _state->lock_read(l);
-
         for (auto &app_id : request.app_ids) {
             const std::shared_ptr<app_state> &app = _state->get_app(app_id);
             if (app == nullptr) {
-                derror("app(%d) doesn't exist, can't be added to policy %s",
-                       app_id,
-                       request.policy_name.c_str());
-                response.hint_message += "invalid app(" + std::to_string(app_id) + ")\n";
-            } else {
-                app_ids.insert(app_id);
-                app_names.insert(std::make_pair(app_id, app->app_name));
-            }
-        }
-    }
-
-    bool should_create_new_policy = true;
-    std::shared_ptr<policy_context> policy_context_ptr = nullptr;
-
-    if (app_ids.size() > 0) {
-        {
-            // if request is valid, we just modify _pilicy_states fastly, then release the lock
-            zauto_lock l(_lock);
-            if (!is_valid_policy_name_unlocked(request.policy_name)) {
+                derror_f("app {} doesn't exist, we will not add policy {}.",
+                         app_id,
+                         request.policy_name);
                 response.err = ERR_INVALID_PARAMETERS;
-                should_create_new_policy = false;
-            } else {
-                policy_context_ptr = _factory(this);
+                response.hint_message = "invalid app " + std::to_string(app_id);
+                _meta_svc->reply_data(msg, response);
+                msg->release_ref();
+                return;
             }
+            app_ids.insert(app_id);
+            app_names.insert(std::make_pair(app_id, app->app_name));
         }
-
-        if (_meta_svc->get_block_service_manager().get_or_create_block_filesystem(
-                request.backup_provider_type) == nullptr) {
-            derror("invalid backup_provider_type(%s)", request.backup_provider_type.c_str());
-            response.err = ERR_INVALID_PARAMETERS;
-            should_create_new_policy = false;
-        }
-
-        if (should_create_new_policy) {
-            policy p;
-            ddebug("add backup polciy, policy_name = %s", request.policy_name.c_str());
-            p.policy_name = request.policy_name;
-            p.backup_provider_type = request.backup_provider_type;
-            p.backup_interval_seconds = request.backup_interval_seconds;
-            p.backup_history_count_to_keep = request.backup_history_count_to_keep;
-            p.start_time.parse_from(request.start_time);
-            p.app_ids = app_ids;
-            p.app_names = app_names;
-            policy_context_ptr->set_policy(std::move(p));
-        }
-    } else {
-        should_create_new_policy = false;
     }
 
-    if (should_create_new_policy) {
-        dassert(policy_context_ptr != nullptr, "invalid policy_context");
-        do_add_policy(msg, policy_context_ptr, response.hint_message);
-    } else {
+    {
+        // check policy name
+        zauto_lock l(_lock);
+        if (!is_valid_policy_name_unlocked(request.policy_name)) {
+            response.err = ERR_INVALID_PARAMETERS;
+            response.hint_message = "invalid policy_name: " + request.policy_name;
+            _meta_svc->reply_data(msg, response);
+            msg->release_ref();
+            return;
+        }
+    }
+
+    // check backup provider
+    if (_meta_svc->get_block_service_manager().get_or_create_block_filesystem(
+            request.backup_provider_type) == nullptr) {
         response.err = ERR_INVALID_PARAMETERS;
+        response.hint_message = "invalid backup_provider_type: " + request.backup_provider_type;
         _meta_svc->reply_data(msg, response);
         msg->release_ref();
+        return;
     }
+
+    ddebug_f("add backup polciy, policy_name = {}", request.policy_name);
+    std::shared_ptr<policy_context> policy_context_ptr = _factory(this);
+    dassert(policy_context_ptr != nullptr, "invalid policy_context");
+    policy p;
+    p.policy_name = request.policy_name;
+    p.backup_provider_type = request.backup_provider_type;
+    p.backup_interval_seconds = request.backup_interval_seconds;
+    p.backup_history_count_to_keep = request.backup_history_count_to_keep;
+    p.start_time.parse_from(request.start_time);
+    p.app_ids = app_ids;
+    p.app_names = app_names;
+    policy_context_ptr->set_policy(std::move(p));
+    do_add_policy(msg, policy_context_ptr, response.hint_message);
 }
 
 void backup_service::do_add_policy(dsn::message_ex *req,
@@ -1312,7 +1259,7 @@ void backup_service::do_add_policy(dsn::message_ex *req,
                 configuration_add_backup_policy_response resp;
                 resp.hint_message = hint_msg;
                 resp.err = ERR_OK;
-                ddebug("add backup policy succeed, policy_name = %s", policy_name.c_str());
+                ddebug_f("add backup policy succeed, policy_name = {}", policy_name);
 
                 _meta_svc->reply_data(req, resp);
                 req->release_ref();
@@ -1322,14 +1269,12 @@ void backup_service::do_add_policy(dsn::message_ex *req,
                 }
                 p->start();
             } else if (err == ERR_TIMEOUT) {
-                derror("create backup policy on remote storage timeout, retry after %" PRId64
-                       "(ms)",
-                       _opt.meta_retry_delay_ms.count());
+                derror("create backup policy on remote storage timeout, retry it later");
                 tasking::enqueue(LPC_DEFAULT_CALLBACK,
                                  &_tracker,
                                  std::bind(&backup_service::do_add_policy, this, req, p, hint_msg),
                                  0,
-                                 _opt.meta_retry_delay_ms);
+                                 std::chrono::seconds(1));
                 return;
             } else {
                 dassert(false,
@@ -1352,14 +1297,11 @@ void backup_service::do_update_policy_to_remote_storage(
             if (err == ERR_OK) {
                 configuration_modify_backup_policy_response resp;
                 resp.err = ERR_OK;
-                ddebug("update backup policy to remote storage succeed, policy_name = %s",
-                       p.policy_name.c_str());
+                ddebug_f("update backup policy {} to remote storage succeed.", p.policy_name);
                 p_context_ptr->set_policy(p);
             } else if (err == ERR_TIMEOUT) {
-                derror("update backup policy to remote storage failed, policy_name = %s, retry "
-                       "after %" PRId64 "(ms)",
-                       p.policy_name.c_str(),
-                       _opt.meta_retry_delay_ms.count());
+                derror_f("update backup policy {} to remote storage failed, try it later",
+                         p.policy_name);
                 tasking::enqueue(LPC_DEFAULT_CALLBACK,
                                  &_tracker,
                                  std::bind(&backup_service::do_update_policy_to_remote_storage,
@@ -1368,7 +1310,7 @@ void backup_service::do_update_policy_to_remote_storage(
                                            p,
                                            p_context_ptr),
                                  0,
-                                 _opt.meta_retry_delay_ms);
+                                 std::chrono::seconds(1));
             } else {
                 dassert(false,
                         "we can't handle this when create backup policy, err(%s)",

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -423,7 +423,7 @@ void policy_context::start_backup_partition_unlocked(gpid pid)
         _backup_service->get_state()->lock_read(l);
         const app_state *app = _backup_service->get_state()->get_app(pid.get_app_id()).get();
 
-        if (app == nullptr || app->status == app_status::AS_DROPPED) {
+        if (app == nullptr || app->status != app_status::AS_AVAILABLE) {
             // skip backup app this time
             dwarn_f("{}: app {} is not available, just ignore this app.",
                     _backup_sig,

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -94,7 +94,7 @@ struct backup_start_time
     // If time is invalid, return false.
     bool parse_from(const std::string &time)
     {
-        if (::sscanf(time.c_str(), "%d:%d", &hour, &minute) != 2) {
+        if (sscanf(time.c_str(), "%d:%d", &hour, &minute) != 2) {
             return false;
         }
         if (hour < 0 || hour >= 24 || minute < 0 || minute >= 60) {
@@ -156,7 +156,6 @@ struct backup_progress
 {
     int32_t unfinished_apps;
     std::map<gpid, int32_t> partition_progress;
-    std::map<gpid, dsn::task_ptr> backup_requests;
     std::map<app_id, int32_t> unfinished_partitions_per_app;
     // <app_id, <partition_id, checkpoint size>>
     std::map<app_id, std::map<int, int64_t>> app_chkpt_size;
@@ -169,7 +168,6 @@ struct backup_progress
     {
         unfinished_apps = 0;
         partition_progress.clear();
-        backup_requests.clear();
         unfinished_partitions_per_app.clear();
         app_chkpt_size.clear();
         is_app_skipped.clear();

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -6,6 +6,7 @@
 
 #include <dsn/c/api_layer1.h>
 #include <dsn/cpp/serialization_helper/dsn.layer2_types.h>
+#include <dsn/dist/replication/replica_envs.h>
 #include <dsn/dist/replication/replication_types.h>
 #include <dsn/dist/replication/duplication_common.h>
 #include <dsn/utility/config_api.h>
@@ -699,6 +700,75 @@ void meta_http_service::query_bulk_load_handler(const http_request &req, http_re
     resp.status_code = http_status_code::ok;
 }
 
+void meta_http_service::start_compaction_handler(const http_request &req, http_response &resp)
+{
+    if (!redirect_if_not_primary(req, resp)) {
+        return;
+    }
+
+    // validate parameters
+    manual_compaction_info info;
+    bool ret = json::json_forwarder<manual_compaction_info>::decode(req.body, info);
+
+    if (!ret) {
+        resp.body = "invalid request structure";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+    if (info.app_name.empty()) {
+        resp.body = "app_name should not be empty";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+    if (info.type.empty() || (info.type != "once" && info.type != "periodic")) {
+        resp.body = "type should ony be 'once' or 'periodic'";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+    if (info.target_level < -1) {
+        resp.body = "target_level should be >= -1";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+    if (info.bottommost_level_compaction.empty() || (info.bottommost_level_compaction != "skip" &&
+                                                     info.bottommost_level_compaction != "force")) {
+        resp.body = "bottommost_level_compaction should ony be 'skip' or 'force'";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+    if (info.max_concurrent_running_count < 0) {
+        resp.body = "max_running_count should be >= 0";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+    if (info.type == "periodic" && info.trigger_time.empty()) {
+        resp.body = "trigger_time should not be empty when type is periodic";
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+
+    // create configuration_update_app_env_request
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    if (info.type == "once") {
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_ONCE_TARGET_LEVEL);
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_ONCE_BOTTOMMOST_LEVEL_COMPACTION);
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME);
+    } else {
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_PERIODIC_TARGET_LEVEL);
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_PERIODIC_BOTTOMMOST_LEVEL_COMPACTION);
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME);
+    }
+    values.emplace_back(std::to_string(info.target_level));
+    values.emplace_back(info.bottommost_level_compaction);
+    values.emplace_back(info.type == "once" ? std::to_string(dsn_now_s()) : info.trigger_time);
+    if (info.max_concurrent_running_count > 0) {
+        keys.emplace_back(replica_envs::MANUAL_COMPACT_MAX_CONCURRENT_RUNNING_COUNT);
+        values.emplace_back(std::to_string(info.max_concurrent_running_count));
+    }
+    update_app_env(info.app_name, keys, values, resp);
+}
+
 bool meta_http_service::redirect_if_not_primary(const http_request &req, http_response &resp)
 {
 #ifdef DSN_MOCK_TEST
@@ -720,6 +790,32 @@ bool meta_http_service::redirect_if_not_primary(const http_request &req, http_re
                         resp.location.end()); // remove final '\0'
     resp.status_code = http_status_code::temporary_redirect;
     return false;
+}
+
+void meta_http_service::update_app_env(const std::string &app_name,
+                                       const std::vector<std::string> &keys,
+                                       const std::vector<std::string> &values,
+                                       http_response &resp)
+{
+    configuration_update_app_env_request request;
+    request.app_name = app_name;
+    request.op = app_env_operation::APP_ENV_OP_SET;
+    request.__set_keys(keys);
+    request.__set_values(values);
+
+    auto rpc_req = dsn::make_unique<configuration_update_app_env_request>(request);
+    update_app_env_rpc rpc(std::move(rpc_req), LPC_META_STATE_NORMAL);
+    _service->_state->set_app_envs(rpc);
+
+    auto rpc_resp = rpc.response();
+    // output as json format
+    dsn::utils::table_printer tp;
+    tp.add_row_name_and_data("error", rpc_resp.err.to_string());
+    tp.add_row_name_and_data("hint_message", rpc_resp.hint_message);
+    std::ostringstream out;
+    tp.output(out, dsn::utils::table_printer::output_format::kJsonCompact);
+    resp.body = out.str();
+    resp.status_code = http_status_code::ok;
 }
 
 } // namespace replication

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -55,11 +55,12 @@ void server_state::sync_app_from_backup_media(
         return;
     }
 
-    std::string app_metadata = cold_backup::get_app_metadata_file(request.cluster_name,
-                                                                  request.policy_name,
-                                                                  request.app_name,
-                                                                  request.app_id,
-                                                                  request.time_stamp);
+    std::string cluster_root = request.cluster_name;
+    if (!request.policy_name.empty()) {
+        cluster_root += ("/" + request.policy_name);
+    }
+    std::string app_metadata = cold_backup::get_app_metadata_file(
+        cluster_root, request.app_name, request.app_id, request.time_stamp);
 
     error_code err = ERR_OK;
     block_file_ptr file_handle = nullptr;

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -491,7 +491,7 @@ void meta_service_test_app::policy_context_test()
         int64_t oneday_sec = 1 * 24 * 60 * 60;
         mp._policy.start_time.hour = hour;
         mp._policy.start_time.minute = 0;
-        mp._policy.backup_interval_seconds = oneday_sec; // oneday
+        mp._policy.backup_interval_seconds = oneday_sec;
         mp._backup_history.clear();
 
         backup_info info;
@@ -512,21 +512,21 @@ void meta_service_test_app::policy_context_test()
 
         {
             // first backup & cur_time.hour != start_time.hour
-            mp._policy.start_time.hour = hour + 100; // invalid time
+            mp._policy.start_time.hour = hour + 100;
             ASSERT_FALSE(mp.should_start_backup_unlocked());
-            mp._policy.start_time.hour = (hour + 1) % 24; // valid, but not reach
+            mp._policy.start_time.hour = (hour + 1) % 24;
             ASSERT_FALSE(mp.should_start_backup_unlocked());
-            mp._policy.start_time.hour = hour - 1; // time passed(also, include -1)
+            mp._policy.start_time.hour = hour - 1;
             ASSERT_FALSE(mp.should_start_backup_unlocked());
         }
 
         {
             // first backup & cur_time.min != start_time.minute
-            mp._policy.start_time.minute = min + 100; // invalid time
+            mp._policy.start_time.minute = min + 100;
             ASSERT_FALSE(mp.should_start_backup_unlocked());
-            mp._policy.start_time.minute = (min + 1) % 60; // valid, but not reach
+            mp._policy.start_time.minute = (min + 1) % 60;
             ASSERT_FALSE(mp.should_start_backup_unlocked());
-            mp._policy.start_time.minute = min - 1; // time passed(also, include -1)
+            mp._policy.start_time.minute = min - 1;
             ASSERT_FALSE(mp.should_start_backup_unlocked());
         }
 
@@ -590,7 +590,7 @@ void meta_service_test_app::backup_service_test()
         req.app_ids = {1, 2, 3};
         req.backup_interval_seconds = 24 * 60 * 60;
 
-        // case1: backup policy does not contain valid app_id
+        // case1: all app in the backup policy is invalid
         // result: backup policy will not be added, and return ERR_INVALID_PARAMETERS
         {
             configuration_add_backup_policy_response resp;
@@ -627,7 +627,7 @@ void meta_service_test_app::backup_service_test()
             req.backup_interval_seconds = old_backup_interval_seconds;
         }
 
-        // case3: backup policy's all app_id is valid
+        // case3: all app in the backup policy is valid
         // result: add backup policy succeed
         {
             configuration_add_backup_policy_response resp;
@@ -647,7 +647,7 @@ void meta_service_test_app::backup_service_test()
             ASSERT_EQ(1, ptr->counter_start());
         }
 
-        // case4: backup policy contains an invalid app_id
+        // case4: backup policy contains an invalid app
         // result: backup policy will not be added, and return ERR_INVALID_PARAMETERS
         {
             server_state *state = meta_svc->get_server_state();
@@ -666,7 +666,6 @@ void meta_service_test_app::backup_service_test()
     }
 
     // test sync_policies_from_remote_storage()
-    // only one backup policy on remote storage
     {
         backup_svc->_policy_states.clear();
         ASSERT_TRUE(backup_svc->_policy_states.empty());

--- a/src/meta/test/main.cpp
+++ b/src/meta/test/main.cpp
@@ -1,12 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include <cmath>
+#include <dsn/service_api_cpp.h>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <iostream>
 
-#include <gtest/gtest.h>
-#include <dsn/service_api_cpp.h>
-
 #include "meta/meta_data.h"
-
 #include "meta_service_test_app.h"
 
 int gtest_flags = 0;
@@ -82,12 +97,10 @@ dsn::error_code meta_service_test_app::start(const std::vector<std::string> &arg
 
 GTEST_API_ int main(int argc, char **argv)
 {
+    testing::InitGoogleTest(&argc, argv);
     dsn::service_app::register_factory<dsn::replication::meta_service_test_app>("test_meta");
     dsn::service::meta_service_app::register_all();
-    if (argc < 2)
-        dassert(dsn_run_config("config-test.ini", false), "");
-    else
-        dassert(dsn_run_config(argv[1], false), "");
+    dsn_run_config("config-test.ini", false);
     while (gtest_flags == 0) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }

--- a/src/meta/test/meta_http_service_test.cpp
+++ b/src/meta/test/meta_http_service_test.cpp
@@ -81,9 +81,6 @@ public:
             _ms->_cluster_root + "/backup",
             [](backup_service *bs) { return std::make_shared<policy_context>(bs); });
         _ms->_backup_handler->start();
-        _ms->_backup_handler->backup_option().app_dropped_retry_delay_ms = 500_ms;
-        _ms->_backup_handler->backup_option().request_backup_period_ms = 20_ms;
-        _ms->_backup_handler->backup_option().issue_backup_interval_ms = 1000_ms;
         const std::string policy_root = "/test";
         dsn::error_code ec;
         _ms->_storage

--- a/src/meta/test/meta_http_service_test.cpp
+++ b/src/meta/test/meta_http_service_test.cpp
@@ -2,6 +2,7 @@
 // This source code is licensed under the Apache License Version 2.0, which
 // can be found in the LICENSE file in the root directory of this source tree.
 
+#include <iostream>
 #include <gtest/gtest.h>
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/http/http_server.h>
@@ -211,6 +212,15 @@ public:
         return resp.body;
     }
 
+    http_response test_start_compaction(std::string req_body_json)
+    {
+        http_request req;
+        http_response resp;
+        req.body = blob::create_from_bytes(std::move(req_body_json));
+        _mhs->start_compaction_handler(req, resp);
+        return resp;
+    }
+
     void mock_bulk_load_context(const bulk_load_status::type &status)
     {
         auto app = find_app(APP_NAME);
@@ -247,24 +257,24 @@ TEST_F(meta_bulk_load_http_test, start_bulk_load_request)
         http_status_code expected_code;
         std::string expected_response_json;
     } tests[] = {
-        {"{\"app\":\"test_bulk_load\",\"cluster_name\":\"onebox\", "
-         "\"file_provider_type\":\"local_service\", \"remote_root_path\":\"bulk_load_root\"}",
+        {R"({"app":"test_bulk_load","cluster_name":"onebox","file_provider_type":"local_service","remote_root_path":"bulk_load_root"})",
          http_status_code::bad_request,
          "invalid request structure"},
-        {"{\"app_name\":\"test_bulk_load\",\"cluster_name\":\"onebox\", "
-         "\"file_provider_type\":\"\", \"remote_root_path\":\"bulk_load_root\"}",
+        {R"({"app_name":"test_bulk_load","cluster_name":"onebox","file_provider_type":"","remote_root_path":"bulk_load_root"})",
          http_status_code::bad_request,
          "file_provider_type should not be empty"},
-        {"{\"app_name\":\"test_bulk_load\",\"cluster_name\":\"onebox\", "
-         "\"file_provider_type\":\"local_service\", \"remote_root_path\":\"bulk_load_root\"}",
+        {R"({"app_name":"test_bulk_load","cluster_name":"onebox","file_provider_type":"local_service","remote_root_path":"bulk_load_root"})",
          http_status_code::ok,
-         "{\"error\":\"ERR_OK\",\"hint_msg\":\"\"}\n"},
+         R"({"error":"ERR_OK","hint_msg":""})"},
     };
-
     for (const auto &test : tests) {
         http_response resp = test_start_bulk_load(test.request_json);
         ASSERT_EQ(resp.status_code, test.expected_code);
-        ASSERT_EQ(resp.body, test.expected_response_json);
+        std::string expected_json = test.expected_response_json;
+        if (test.expected_code == http_status_code::ok) {
+            expected_json += "\n";
+        }
+        ASSERT_EQ(resp.body, expected_json);
     }
     fail::teardown();
 }
@@ -281,20 +291,56 @@ TEST_F(meta_bulk_load_http_test, query_bulk_load_request)
     {
         std::string app_name;
         std::string expected_json;
-    } tests[] = {{APP_NAME,
-                  "{\"error\":\"ERR_OK\",\"app_status\":\"replication::bulk_load_status::"
-                  "BLS_DOWNLOADING\"}\n"},
-                 {NOT_BULK_LOAD,
-                  "{\"error\":\"ERR_INVALID_STATE\",\"app_status\":\"replication::"
-                  "bulk_load_status::BLS_INVALID\"}\n"},
-                 {NOT_FOUND,
-                  "{\"error\":\"ERR_APP_NOT_EXIST\",\"app_status\":\"replication::bulk_"
-                  "load_status::BLS_INVALID\"}\n"}};
+    } tests[] = {
+        {APP_NAME,
+         R"({"error":"ERR_OK","app_status":"replication::bulk_load_status::BLS_DOWNLOADING"})"},
+        {NOT_BULK_LOAD,
+         R"({"error":"ERR_INVALID_STATE","app_status":"replication::bulk_load_status::BLS_INVALID"})"},
+        {NOT_FOUND,
+         R"({"error":"ERR_APP_NOT_EXIST","app_status":"replication::bulk_load_status::BLS_INVALID"})"}};
     for (const auto &test : tests) {
-        ASSERT_EQ(test_query_bulk_load(test.app_name), test.expected_json);
+        ASSERT_EQ(test_query_bulk_load(test.app_name), test.expected_json + "\n");
     }
 
     drop_app(NOT_BULK_LOAD);
+}
+
+TEST_F(meta_bulk_load_http_test, start_compaction_test)
+{
+    struct start_compaction_test
+    {
+        std::string request_json;
+        http_status_code expected_code;
+        std::string expected_response_json;
+    } tests[] = {
+        {R"({"app_name":"test_bulk_load","type":"once","target_level":-1,"bottommost_level_compaction":"skip","max_concurrent_running_count":"0"})",
+         http_status_code::bad_request,
+         "invalid request structure"},
+        {R"({"app_name":"test_bulk_load","type":"wrong","target_level":-1,"bottommost_level_compaction":"skip","max_concurrent_running_count":0,"trigger_time":""})",
+         http_status_code::bad_request,
+         "type should ony be 'once' or 'periodic'"},
+        {R"({"app_name":"test_bulk_load","type":"once","target_level":-3,"bottommost_level_compaction":"skip","max_concurrent_running_count":0,"trigger_time":""})",
+         http_status_code::bad_request,
+         "target_level should be >= -1"},
+        {R"({"app_name":"test_bulk_load","type":"once","target_level":-1,"bottommost_level_compaction":"wrong","max_concurrent_running_count":0,"trigger_time":""})",
+         http_status_code::bad_request,
+         "bottommost_level_compaction should ony be 'skip' or 'force'"},
+        {R"({"app_name":"test_bulk_load","type":"once","target_level":-1,"bottommost_level_compaction":"skip","max_concurrent_running_count":-2,"trigger_time":""})",
+         http_status_code::bad_request,
+         "max_running_count should be >= 0"},
+        {R"({"app_name":"test_bulk_load","type":"once","target_level":-1,"bottommost_level_compaction":"skip","max_concurrent_running_count":0,"trigger_time":""})",
+         http_status_code::ok,
+         R"({"error":"ERR_OK","hint_message":""})"}};
+
+    for (const auto &test : tests) {
+        http_response resp = test_start_compaction(test.request_json);
+        ASSERT_EQ(resp.status_code, test.expected_code);
+        std::string expected_json = test.expected_response_json;
+        if (test.expected_code == http_status_code::ok) {
+            expected_json += "\n";
+        }
+        ASSERT_EQ(resp.body, expected_json);
+    }
 }
 
 } // namespace replication

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -176,7 +176,7 @@ void cold_backup_context::check_backup_on_remote()
     // check whether current checkpoint file is exist on remote, and verify whether the checkpoint
     // directory is exist
     std::string current_chkpt_file = cold_backup::get_current_chkpt_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = current_chkpt_file;
     req.ignore_metadata = false;
@@ -311,7 +311,7 @@ void cold_backup_context::remote_chkpt_dir_exist(const std::string &chkpt_dirnam
 {
     dist::block_service::ls_request req;
     req.dir_name = cold_backup::get_replica_backup_path(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
 
     add_ref();
 
@@ -407,7 +407,7 @@ void cold_backup_context::upload_checkpoint_to_remote()
 
     // check whether cold_backup_metadata is exist and verify cold_backup_metadata if exist
     std::string metadata = cold_backup::get_remote_chkpt_meta_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = metadata;
     req.ignore_metadata = false;
@@ -631,7 +631,7 @@ void cold_backup_context::prepare_upload()
 void cold_backup_context::upload_file(const std::string &local_filename)
 {
     std::string remote_chkpt_dir = cold_backup::get_remote_chkpt_dir(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = ::dsn::utils::filesystem::path_combine(remote_chkpt_dir, local_filename);
     req.ignore_metadata = false;
@@ -784,7 +784,7 @@ void cold_backup_context::write_backup_metadata()
         return;
     }
     std::string metadata = cold_backup::get_remote_chkpt_meta_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = metadata;
     req.ignore_metadata = true;
@@ -867,7 +867,7 @@ void cold_backup_context::write_current_chkpt_file(const std::string &value)
     }
 
     std::string current_chkpt_file = cold_backup::get_current_chkpt_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = current_chkpt_file;
     req.ignore_metadata = true;

--- a/src/replica/backup/replica_backup_manager.cpp
+++ b/src/replica/backup/replica_backup_manager.cpp
@@ -69,10 +69,7 @@ void replica_backup_manager::on_clear_cold_backup(const backup_clear_request &re
                 backup_context->name);
             tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
                              &_replica->_tracker,
-                             [this, request]() {
-                                 backup_response response;
-                                 on_clear_cold_backup(request);
-                             },
+                             [this, request]() { on_clear_cold_backup(request); },
                              get_gpid().thread_hash(),
                              std::chrono::seconds(100));
             return;

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -474,5 +474,11 @@ void replica::on_detect_hotkey(const detect_hotkey_request &req, detect_hotkey_r
     _app->on_detect_hotkey(req, resp);
 }
 
+uint32_t replica::query_data_version() const
+{
+    dassert_replica(_app != nullptr, "");
+    return _app->query_data_version();
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -398,6 +398,8 @@ private:
 
     void on_detect_hotkey(const detect_hotkey_request &req, /*out*/ detect_hotkey_response &resp);
 
+    uint32_t query_data_version() const;
+
 private:
     friend class ::dsn::replication::test::test_checker;
     friend class ::dsn::replication::mutation_queue;

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -20,11 +20,18 @@ public:
                                    std::placeholders::_1,
                                    std::placeholders::_2),
                          "ip:port/replica/duplication?appid=<appid>");
+        register_handler("data_version",
+                         std::bind(&replica_http_service::query_app_data_version_handler,
+                                   this,
+                                   std::placeholders::_1,
+                                   std::placeholders::_2),
+                         "ip:port/replica/data_version?app_id=<app_id>");
     }
 
     std::string path() const override { return "replica"; }
 
     void query_duplication_handler(const http_request &req, http_response &resp);
+    void query_app_data_version_handler(const http_request &req, http_response &resp);
 
 private:
     replica_stub *_stub;

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -214,21 +214,23 @@ void replica::clear_restore_useless_files(const std::string &local_chkpt_dir,
 dsn::error_code replica::find_valid_checkpoint(const configuration_restore_request &req,
                                                std::string &remote_chkpt_dir)
 {
-    const std::string &backup_root = req.cluster_name;
-    const std::string &policy_name = req.policy_name;
-    const int64_t &backup_id = req.time_stamp;
-    ddebug("%s: retore from policy_name(%s), backup_id(%lld)",
-           name(),
-           req.policy_name.c_str(),
-           req.time_stamp);
+    ddebug_f("{}: start to find valid checkpoint of app {}, backup_id {}",
+             name(),
+             req.app_id,
+             req.time_stamp);
 
     // we should base on old gpid to combine the path on cold backup media
     dsn::gpid old_gpid;
     old_gpid.set_app_id(req.app_id);
     old_gpid.set_partition_index(_config.pid.get_partition_index());
+    std::string backup_root = req.cluster_name;
+    if (!req.policy_name.empty()) {
+        backup_root += ("/" + req.policy_name);
+    }
+    int64_t backup_id = req.time_stamp;
 
-    std::string manifest_file = cold_backup::get_current_chkpt_file(
-        backup_root, policy_name, req.app_name, old_gpid, backup_id);
+    std::string manifest_file =
+        cold_backup::get_current_chkpt_file(backup_root, req.app_name, old_gpid, backup_id);
     block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(req.backup_provider_name);
     if (fs == nullptr) {
@@ -247,9 +249,9 @@ dsn::error_code replica::find_valid_checkpoint(const configuration_restore_reque
         ->wait();
 
     if (create_response.err != dsn::ERR_OK) {
-        derror("%s: create file of block_service failed, reason(%s)",
-               name(),
-               create_response.err.to_string());
+        derror_f("{}: create file of block_service failed, reason {}",
+                 name(),
+                 create_response.err.to_string());
         return create_response.err;
     }
 
@@ -263,18 +265,17 @@ dsn::error_code replica::find_valid_checkpoint(const configuration_restore_reque
         ->wait();
 
     if (r.err != dsn::ERR_OK) {
-        derror("%s: read file %s failed, reason(%s)",
-               name(),
-               create_response.file_handle->file_name().c_str(),
-               r.err.to_string());
+        derror_f("{}: read file {} failed, reason {}",
+                 name(),
+                 create_response.file_handle->file_name(),
+                 r.err.to_string());
         return r.err;
     }
 
     std::string valid_chkpt_entry(r.buffer.data(), r.buffer.length());
-    ddebug("%s: get a valid chkpt(%s)", name(), valid_chkpt_entry.c_str());
+    ddebug_f("{}: get a valid chkpt {}", name(), valid_chkpt_entry);
     remote_chkpt_dir = ::dsn::utils::filesystem::path_combine(
-        cold_backup::get_replica_backup_path(
-            backup_root, policy_name, req.app_name, old_gpid, backup_id),
+        cold_backup::get_replica_backup_path(backup_root, req.app_name, old_gpid, backup_id),
         valid_chkpt_entry);
     return dsn::ERR_OK;
 }

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2807,5 +2807,26 @@ void replica_stub::on_detect_hotkey(detect_hotkey_rpc rpc)
         response.err_hint = fmt::format("not find the replica {} \n", request.pid);
     }
 }
+
+error_code replica_stub::query_app_data_version(int32_t app_id, /*out*/ uint32_t &data_version)
+{
+    replica_ptr rep = nullptr;
+    zauto_read_lock l(_replicas_lock);
+    for (const auto &kv : _replicas) {
+        if (kv.first.get_app_id() == app_id) {
+            rep = kv.second;
+            break;
+        }
+    }
+    if (rep == nullptr) {
+        dwarn_f("app({}) is not found", app_id);
+        return ERR_OBJECT_NOT_FOUND;
+    }
+
+    data_version = rep->query_data_version();
+    ddebug_f("app({}) data_version={}", app_id, data_version);
+    return ERR_OK;
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2788,7 +2788,6 @@ void replica_stub::on_group_bulk_load(group_bulk_load_rpc rpc)
     }
 }
 
-// TODO: (Tangyanzhao) implement it later
 void replica_stub::on_detect_hotkey(detect_hotkey_rpc rpc)
 {
     const auto &request = rpc.request();

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -284,6 +284,8 @@ private:
         return 0;
     }
 
+    error_code query_app_data_version(int32_t app_id, /*out*/ uint32_t &data_version);
+
 #ifdef DSN_ENABLE_GPERF
     // Try to release tcmalloc memory back to operating system
     void gc_tcmalloc_memory();

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.h
@@ -90,6 +90,8 @@ public:
 
     virtual void query_app_envs(/*out*/ std::map<std::string, std::string> &envs) {}
 
+    virtual uint32_t query_data_version() const override { return 0; }
+
 private:
     void recover();
     void recover(const std::string &name, int64_t version);

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
@@ -90,6 +90,8 @@ public:
 
     virtual void query_app_envs(/*out*/ std::map<std::string, std::string> &envs) {}
 
+    virtual uint32_t query_data_version() const override { return 0; }
+
 private:
     void recover();
     void recover(const std::string &name, int64_t version);

--- a/src/replica/test/cold_backup_context_test.cpp
+++ b/src/replica/test/cold_backup_context_test.cpp
@@ -125,7 +125,7 @@ void replication_service_test_app::remote_chkpt_dir_exist_test()
         current_chkpt_file->set_context(dir_name);
 
         std::string parent_dir = cold_backup::get_replica_backup_path(
-            backup_root, mock_policy_info.policy_name, mock_app_name, mock_gpid, mock_backup_id);
+            backup_root, mock_app_name, mock_gpid, mock_backup_id);
 
         std::vector<ls_entry> entries;
         entries.emplace_back(ls_entry{std::string(dir_name), true});

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -79,6 +79,8 @@ public:
     void set_ingestion_status(ingestion_status::type status) { _ingestion_status = status; }
     ingestion_status::type get_ingestion_status() override { return _ingestion_status; }
 
+    uint32_t query_data_version() const { return 1; }
+
 private:
     std::map<std::string, std::string> _envs;
     decree _decree = 5;

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -7,6 +7,7 @@
 #include <dsn/utility/fail_point.h>
 #include "replica_test_base.h"
 #include <dsn/utility/defer.h>
+#include "replica/replica_http_service.h"
 
 namespace dsn {
 namespace replication {
@@ -21,6 +22,7 @@ public:
 public:
     void SetUp() override
     {
+        FLAGS_enable_http_server = false;
         stub->install_perf_counters();
         mock_app_info();
         _mock_replica = stub->generate_replica(_app_info, pid, partition_status::PS_PRIMARY, 1);
@@ -79,6 +81,38 @@ TEST_F(replica_test, backup_request_qps)
     // implementation of perf-counter which type is COUNTER_TYPE_RATE.
     usleep(1e5);
     ASSERT_GT(get_table_level_backup_request_qps(), 0);
+}
+
+TEST_F(replica_test, query_data_version_test)
+{
+    replica_http_service http_svc(stub.get());
+    struct query_data_version_test
+    {
+        std::string app_id;
+        http_status_code expected_code;
+        std::string expected_response_json;
+    } tests[] = {{"", http_status_code::bad_request, "app_id should not be empty"},
+                 {"wrong", http_status_code::bad_request, "invalid app_id=wrong"},
+                 {"2",
+                  http_status_code::ok,
+                  R"({"error":"ERR_OK","data_version":"1"})"},
+                 {"4",
+                  http_status_code::ok,
+                  R"({"error":"ERR_OBJECT_NOT_FOUND","data_version":"0"})"}};
+    for (const auto &test : tests) {
+        http_request req;
+        http_response resp;
+        if (!test.app_id.empty()) {
+            req.query_args["app_id"] = test.app_id;
+        }
+        http_svc.query_app_data_version_handler(req, resp);
+        ASSERT_EQ(resp.status_code, test.expected_code);
+        std::string expected_json = test.expected_response_json;
+        if (test.expected_code == http_status_code::ok) {
+            expected_json += "\n";
+        }
+        ASSERT_EQ(resp.body, expected_json);
+    }
 }
 
 } // namespace replication

--- a/src/replication.thrift
+++ b/src/replication.thrift
@@ -1144,7 +1144,8 @@ enum hotkey_type
 enum detect_action
 {
     START,
-    STOP
+    STOP,
+    QUERY
 }
 
 enum disk_migration_status {
@@ -1167,6 +1168,7 @@ struct detect_hotkey_response {
     // - ERR_SERVICE_ALREADY_EXIST: hotkey detection is running now
     1: dsn.error_code err;
     2: optional string err_hint;
+    3: optional string hotkey_result;
 }
 
 /*

--- a/src/runtime/security/access_controller.cpp
+++ b/src/runtime/security/access_controller.cpp
@@ -26,6 +26,8 @@
 namespace dsn {
 namespace security {
 DSN_DEFINE_bool("security", enable_acl, false, "whether enable access controller or not");
+DSN_TAG_VARIABLE(enable_acl, FT_MUTABLE);
+
 DSN_DEFINE_string("security", super_users, "", "super user for access controller");
 
 access_controller::access_controller() { utils::split_args(FLAGS_super_users, _super_users, ','); }

--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -51,7 +51,7 @@ void client_negotiation::handle_response(error_code err, const negotiation_respo
 {
     if (err != ERR_OK) {
         // ERR_HANDLER_NOT_FOUND means server is old version, which doesn't support authentication
-        if (ERR_HANDLER_NOT_FOUND == err && !FLAGS_mandatory_auth) {
+        if (ERR_HANDLER_NOT_FOUND == err) {
             ddebug_f("{}: treat negotiation succeed because server is old version, which doesn't "
                      "support authentication",
                      _name);
@@ -62,8 +62,8 @@ void client_negotiation::handle_response(error_code err, const negotiation_respo
         return;
     }
 
-    // make the negotiation succeed if server doesn't enable auth and the auth is not mandantory
-    if (negotiation_status::type::SASL_AUTH_DISABLE == response.status && !FLAGS_mandatory_auth) {
+    // make the negotiation succeed if server doesn't enable auth
+    if (negotiation_status::type::SASL_AUTH_DISABLE == response.status) {
         ddebug_f("{}: treat negotiation succeed as server doesn't enable it", _name);
         succ_negotiation();
         return;

--- a/src/runtime/security/negotiation.cpp
+++ b/src/runtime/security/negotiation.cpp
@@ -32,6 +32,7 @@ const std::set<std::string> supported_mechanisms{"GSSAPI"};
 
 DSN_DEFINE_bool("security", enable_auth, false, "whether open auth or not");
 DSN_DEFINE_bool("security", mandatory_auth, false, "wheter to do authertication mandatorily");
+DSN_TAG_VARIABLE(mandatory_auth, FT_MUTABLE);
 
 negotiation::~negotiation() {}
 

--- a/src/runtime/security/negotiation_manager.cpp
+++ b/src/runtime/security/negotiation_manager.cpp
@@ -24,6 +24,7 @@
 #include <dsn/tool-api/zlocks.h>
 #include <dsn/dist/failure_detector/fd.code.definition.h>
 #include <dsn/dist/fmt_logging.h>
+#include <dsn/http/http_server.h>
 
 namespace dsn {
 namespace security {
@@ -37,7 +38,8 @@ inline bool is_negotiation_message(dsn::task_code code)
 
 inline bool in_white_list(task_code code)
 {
-    return is_negotiation_message(code) || fd::is_failure_detector_message(code);
+    return is_negotiation_message(code) || fd::is_failure_detector_message(code) ||
+           is_http_message(code);
 }
 
 negotiation_map negotiation_manager::_negotiations;

--- a/src/runtime/security/negotiation_manager.cpp
+++ b/src/runtime/security/negotiation_manager.cpp
@@ -110,8 +110,7 @@ bool negotiation_manager::on_rpc_recv_msg(message_ex *msg)
 bool negotiation_manager::on_rpc_send_msg(message_ex *msg)
 {
     // if try_pend_message return true, it means the msg is pended to the resend message queue
-    return !FLAGS_mandatory_auth || in_white_list(msg->rpc_code()) ||
-           !msg->io_session->try_pend_message(msg);
+    return in_white_list(msg->rpc_code()) || !msg->io_session->try_pend_message(msg);
 }
 
 std::shared_ptr<negotiation> negotiation_manager::get_negotiation(negotiation_rpc rpc)

--- a/src/runtime/test/client_negotiation_test.cpp
+++ b/src/runtime/test/client_negotiation_test.cpp
@@ -95,26 +95,16 @@ TEST_F(client_negotiation_test, handle_response)
     {
         error_code resp_err;
         negotiation_status::type resp_status;
-        bool mandatory_auth;
         negotiation_status::type neg_status;
-    } tests[] = {{ERR_TIMEOUT,
-                  negotiation_status::type::SASL_SELECT_MECHANISMS,
-                  false,
-                  negotiation_status::type::SASL_AUTH_FAIL},
-                 {ERR_OK,
-                  negotiation_status::type::SASL_AUTH_DISABLE,
-                  true,
-                  negotiation_status::type::SASL_AUTH_FAIL},
-                 {ERR_OK,
-                  negotiation_status::type::SASL_AUTH_DISABLE,
-                  false,
-                  negotiation_status::type::SASL_SUCC}};
+    } tests[] = {
+        {ERR_TIMEOUT,
+         negotiation_status::type::SASL_SELECT_MECHANISMS,
+         negotiation_status::type::SASL_AUTH_FAIL},
+        {ERR_OK, negotiation_status::type::SASL_AUTH_DISABLE, negotiation_status::type::SASL_SUCC}};
 
-    DSN_DECLARE_bool(mandatory_auth);
     for (const auto &test : tests) {
         negotiation_response resp;
         resp.status = test.resp_status;
-        FLAGS_mandatory_auth = test.mandatory_auth;
         handle_response(test.resp_err, resp);
 
         ASSERT_EQ(get_negotiation_status(), test.neg_status);

--- a/src/runtime/test/negotiation_manager_test.cpp
+++ b/src/runtime/test/negotiation_manager_test.cpp
@@ -116,20 +116,17 @@ TEST_F(negotiation_manager_test, on_rpc_send_msg)
     {
         task_code rpc_code;
         bool negotiation_succeed;
-        bool mandatory_auth;
         bool return_value;
-    } tests[] = {{RPC_NEGOTIATION, false, true, true},
-                 {RPC_NEGOTIATION_ACK, false, true, true},
-                 {fd::RPC_FD_FAILURE_DETECTOR_PING, false, true, true},
-                 {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, false, true, true},
-                 {RPC_HTTP_SERVICE, false, true, true},
-                 {RPC_HTTP_SERVICE_ACK, false, true, true},
-                 {service::RPC_NFS_COPY, true, true, true},
-                 {service::RPC_NFS_COPY, false, false, true},
-                 {service::RPC_NFS_COPY, false, true, false}};
+    } tests[] = {{RPC_NEGOTIATION, false, true},
+                 {RPC_NEGOTIATION_ACK, false, true},
+                 {fd::RPC_FD_FAILURE_DETECTOR_PING, false, true},
+                 {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, false, true},
+                 {RPC_HTTP_SERVICE, false, true},
+                 {RPC_HTTP_SERVICE_ACK, false, true},
+                 {service::RPC_NFS_COPY, true, true},
+                 {service::RPC_NFS_COPY, false, false}};
 
     for (const auto &test : tests) {
-        FLAGS_mandatory_auth = test.mandatory_auth;
         message_ptr msg = dsn::message_ex::create_request(test.rpc_code, 0, 0);
         auto sim_session = create_fake_session();
         msg->io_session = sim_session;

--- a/src/runtime/test/negotiation_manager_test.cpp
+++ b/src/runtime/test/negotiation_manager_test.cpp
@@ -23,6 +23,7 @@
 #include <dsn/utility/flags.h>
 #include <dsn/dist/failure_detector/fd.code.definition.h>
 #include <http/http_server_impl.h>
+#include "nfs/nfs_code_definition.h"
 
 namespace dsn {
 namespace security {
@@ -90,9 +91,11 @@ TEST_F(negotiation_manager_test, on_rpc_recv_msg)
                  {RPC_NEGOTIATION_ACK, false, true, true},
                  {fd::RPC_FD_FAILURE_DETECTOR_PING, false, true, true},
                  {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, false, true, true},
-                 {RPC_HTTP_SERVICE, true, true, true},
-                 {RPC_HTTP_SERVICE, false, false, true},
-                 {RPC_HTTP_SERVICE, false, true, false}};
+                 {RPC_HTTP_SERVICE, false, true, true},
+                 {RPC_HTTP_SERVICE_ACK, false, true, true},
+                 {service::RPC_NFS_COPY, true, true, true},
+                 {service::RPC_NFS_COPY, false, false, true},
+                 {service::RPC_NFS_COPY, false, true, false}};
 
     for (const auto &test : tests) {
         FLAGS_mandatory_auth = test.mandatory_auth;
@@ -119,9 +122,11 @@ TEST_F(negotiation_manager_test, on_rpc_send_msg)
                  {RPC_NEGOTIATION_ACK, false, true, true},
                  {fd::RPC_FD_FAILURE_DETECTOR_PING, false, true, true},
                  {fd::RPC_FD_FAILURE_DETECTOR_PING_ACK, false, true, true},
-                 {RPC_HTTP_SERVICE, true, true, true},
-                 {RPC_HTTP_SERVICE, false, false, true},
-                 {RPC_HTTP_SERVICE, false, true, false}};
+                 {RPC_HTTP_SERVICE, false, true, true},
+                 {RPC_HTTP_SERVICE_ACK, false, true, true},
+                 {service::RPC_NFS_COPY, true, true, true},
+                 {service::RPC_NFS_COPY, false, false, true},
+                 {service::RPC_NFS_COPY, false, true, false}};
 
     for (const auto &test : tests) {
         FLAGS_mandatory_auth = test.mandatory_auth;

--- a/src/utils/test/flag_test.cpp
+++ b/src/utils/test/flag_test.cpp
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+#include <dsn/utility/flags.h>
+
+namespace dsn {
+namespace utils {
+
+DSN_DEFINE_int32("flag_test", test_int32, 5, "");
+DSN_TAG_VARIABLE(test_int32, FT_MUTABLE);
+
+DSN_DEFINE_uint32("flag_test", test_uint32, 5, "");
+DSN_TAG_VARIABLE(test_uint32, FT_MUTABLE);
+
+DSN_DEFINE_int64("flag_test", test_int64, 5, "");
+DSN_TAG_VARIABLE(test_int64, FT_MUTABLE);
+
+DSN_DEFINE_uint64("flag_test", test_uint64, 5, "");
+DSN_TAG_VARIABLE(test_uint64, FT_MUTABLE);
+
+DSN_DEFINE_double("flag_test", test_double, 5.0, "");
+DSN_TAG_VARIABLE(test_double, FT_MUTABLE);
+
+DSN_DEFINE_bool("flag_test", test_bool, true, "");
+DSN_TAG_VARIABLE(test_bool, FT_MUTABLE);
+
+DSN_DEFINE_string("flag_test", test_string_immutable, "immutable_string", "");
+
+TEST(flag_test, update_config)
+{
+    auto res = update_flag("test_int32", "3");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_test_int32, 3);
+
+    res = update_flag("test_uint32", "3");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_test_uint32, 3);
+
+    res = update_flag("test_int64", "3");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_test_int64, 3);
+
+    res = update_flag("test_uint64", "3");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_test_uint64, 3);
+
+    res = update_flag("test_double", "3.0");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_test_double, 3.0);
+
+    res = update_flag("test_bool", "false");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_FALSE(FLAGS_test_bool);
+
+    // string modifications are not supported
+    res = update_flag("test_string_immutable", "update_string");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(strcmp(FLAGS_test_string_immutable, "immutable_string"), 0);
+
+    // test flag is not exist
+    res = update_flag("test_not_exist", "test_string");
+    ASSERT_EQ(res.code(), ERR_OBJECT_NOT_FOUND);
+
+    // test to update invalid value
+    res = update_flag("test_int32", "3ab");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_test_int32, 3);
+}
+
+DSN_DEFINE_int32("flag_test", has_tag, 5, "");
+DSN_TAG_VARIABLE(has_tag, FT_MUTABLE);
+
+DSN_DEFINE_int32("flag_test", no_tag, 5, "");
+
+TEST(flag_test, tag_flag)
+{
+    // has tag
+    auto res = has_tag("has_tag", flag_tag::FT_MUTABLE);
+    ASSERT_TRUE(res);
+
+    // doesn't has tag
+    res = has_tag("no_tag", flag_tag::FT_MUTABLE);
+    ASSERT_FALSE(res);
+
+    // flag is not exist
+    res = has_tag("no_flag", flag_tag::FT_MUTABLE);
+    ASSERT_FALSE(res);
+}
+} // namespace utils
+} // namespace dsn

--- a/src/utils/test/main.cpp
+++ b/src/utils/test/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <dsn/c/api_utilities.h>
 #include <dsn/tool-api/logging_provider.h>
+#include <dsn/utility/flags.h>
 
 extern void command_manager_module_init();
 
@@ -11,6 +12,8 @@ GTEST_API_ int main(int argc, char **argv)
     command_manager_module_init();
     // init logging
     dsn_log_init("dsn::tools::simple_logger", "./", nullptr);
+
+    dsn::flags_initialize();
 
     return RUN_ALL_TESTS();
 }

--- a/src/utils/test/string_conv_test.cpp
+++ b/src/utils/test/string_conv_test.cpp
@@ -189,6 +189,52 @@ TEST(string_conv, buf2uint64)
     ASSERT_FALSE(dsn::buf2uint64(dsn::string_view(str.data(), 5), result));
 }
 
+TEST(string_conv, buf2uint32)
+{
+    uint32_t result = 1;
+
+    ASSERT_TRUE(dsn::buf2uint32(std::to_string(0), result));
+    ASSERT_EQ(result, 0);
+
+    ASSERT_TRUE(dsn::buf2uint32("-0", result));
+    ASSERT_EQ(result, 0);
+
+    ASSERT_FALSE(dsn::buf2uint32("-1", result));
+
+    ASSERT_TRUE(dsn::buf2uint32("0xdeadbeef", result));
+    ASSERT_EQ(result, 0xdeadbeef);
+
+    ASSERT_TRUE(dsn::buf2uint32("0xDEADBEEF", result));
+    ASSERT_EQ(result, 0xdeadbeef);
+
+    ASSERT_TRUE(dsn::buf2uint32(std::to_string(42), result));
+    ASSERT_EQ(result, 42);
+
+    ASSERT_TRUE(dsn::buf2uint32(std::to_string(std::numeric_limits<int16_t>::max()), result));
+    ASSERT_EQ(result, std::numeric_limits<int16_t>::max());
+
+    ASSERT_TRUE(dsn::buf2uint32(std::to_string(std::numeric_limits<uint16_t>::max()), result));
+    ASSERT_EQ(result, std::numeric_limits<uint16_t>::max());
+
+    ASSERT_TRUE(dsn::buf2uint32(std::to_string(std::numeric_limits<uint32_t>::max()), result));
+    ASSERT_EQ(result, std::numeric_limits<uint32_t>::max());
+
+    ASSERT_TRUE(dsn::buf2uint32(std::to_string(std::numeric_limits<uint32_t>::min()), result));
+    ASSERT_EQ(result, std::numeric_limits<uint32_t>::min());
+
+    ASSERT_FALSE(dsn::buf2uint32(std::to_string(std::numeric_limits<uint64_t>::max()), result));
+
+    // "\045" is "%", so the string length=5, otherwise(2th argument > 5) it will be reported
+    // "global-buffer-overflow" error under AddressSanitizer check
+    std::string str("123\0456", 5);
+    ASSERT_TRUE(dsn::buf2uint32(dsn::string_view(str.data(), 2), result));
+    ASSERT_EQ(result, 12);
+    ASSERT_TRUE(dsn::buf2uint32(dsn::string_view(str.data(), 3), result));
+    ASSERT_EQ(result, 123);
+    ASSERT_FALSE(dsn::buf2uint32(dsn::string_view(str.data(), 4), result));
+    ASSERT_FALSE(dsn::buf2uint32(dsn::string_view(str.data(), 5), result));
+}
+
 TEST(string_conv, int64_partial)
 {
     int64_t result = 0;


### PR DESCRIPTION
This patch remove policy_name from remote files' paths, and also includes some code refactoring and fixes, most of them is related to meta backup service:
1. Remove `policy_name` from remote files' paths, users could also specify the `policy_name` when restore old apps which is backed up before this patch.
2. Fix `should_start_backup_unlocked()` in policy_context, now we start first backup only when cur_time == start_time,  then periodically start backup at intervals.
3. Refuse to add policy when any app in this policy is dropped, if the policy has been added, only available apps will be included in `_cur_backup` and other local variables when `initialize_backup_progress_unlocked` called.
4. We will not start to backup app when it is being backed up now.
5. Some other code refactoring and fixes.

I have done the following backup/restore tests:
1. add a backup policy whose backup interval is 900s.
2. restore an app without specify policy_name.
3. resrore an old app with specify the policy_name.