### PR TITLE
feat: add http interface to get all configs

### DIFF
--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -109,4 +109,7 @@ extern error_s update_flag(const std::string &name, const std::string &val);
 
 // determine if the tag is exist for the specified flag
 extern bool has_tag(const std::string &name, const flag_tag &tag);
+
+// list all the flags
+extern std::string list_all_flags();
 } // namespace dsn

--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -8,12 +8,18 @@
 #include <cstdint>
 #include <functional>
 #include "errors.h"
+#include "enum_helper.h"
 #include "utils.h"
 
 enum class flag_tag
 {
     FT_MUTABLE = 0, /** flag data is mutable */
+    FV_MAX_INDEX = 0,
 };
+
+ENUM_BEGIN(flag_tag, flag_tag::FV_MAX_INDEX)
+ENUM_REG(flag_tag::FT_MUTABLE)
+ENUM_END(flag_tag)
 
 // support std::hash with enum types is implemented since gcc 6.1
 // so we should define hash for flag_tag to compatible with gcc < 6.1

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -77,6 +77,11 @@ namespace dsn {
         .with_callback(
             [](const http_request &req, http_response &resp) { update_config(req, resp); })
         .with_help("Updates the value of a config");
+
+    register_http_call("listAllConfigs")
+        .with_callback(
+            [](const http_request &req, http_response &resp) { list_all_configs(req, resp); })
+        .with_help("list all configs");
 }
 
 } // namespace dsn

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -78,7 +78,7 @@ namespace dsn {
             [](const http_request &req, http_response &resp) { update_config(req, resp); })
         .with_help("Updates the value of a config");
 
-    register_http_call("listAllConfigs")
+    register_http_call("configs")
         .with_callback(
             [](const http_request &req, http_response &resp) { list_all_configs(req, resp); })
         .with_help("list all configs");

--- a/src/http/builtin_http_calls.h
+++ b/src/http/builtin_http_calls.h
@@ -34,4 +34,6 @@ extern void get_recent_start_time_handler(const http_request &req, http_response
 
 extern void update_config(const http_request &req, http_response &resp);
 
+extern void list_all_configs(const http_request &req, http_response &resp);
+
 } // namespace dsn

--- a/src/http/config_http_service.cpp
+++ b/src/http/config_http_service.cpp
@@ -37,4 +37,15 @@ void update_config(const http_request &req, http_response &resp)
     resp.body = out.str();
     resp.status_code = http_status_code::ok;
 }
+
+void list_all_configs(const http_request &req, http_response &resp)
+{
+    if (req.query_args.size() != 0) {
+        resp.status_code = http_status_code::bad_request;
+        return;
+    }
+
+    resp.body = list_all_flags();
+    resp.status_code = http_status_code::ok;
+}
 } // namespace dsn

--- a/src/http/config_http_service.cpp
+++ b/src/http/config_http_service.cpp
@@ -40,7 +40,7 @@ void update_config(const http_request &req, http_response &resp)
 
 void list_all_configs(const http_request &req, http_response &resp)
 {
-    if (req.query_args.size() != 0) {
+    if (!req.query_args.empty()) {
         resp.status_code = http_status_code::bad_request;
         return;
     }

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -28,6 +28,16 @@ enum value_type
     FV_MAX_INDEX = 6,
 };
 
+ENUM_BEGIN(value_type, FV_MAX_INDEX)
+ENUM_REG(FV_BOOL)
+ENUM_REG(FV_INT32)
+ENUM_REG(FV_UINT32)
+ENUM_REG(FV_INT64)
+ENUM_REG(FV_UINT64)
+ENUM_REG(FV_DOUBLE)
+ENUM_REG(FV_STRING)
+ENUM_END(value_type)
+
 using validator_fn = std::function<void()>;
 
 class flag_data
@@ -96,13 +106,99 @@ public:
     void add_tag(const flag_tag &tag) { _tags.insert(tag); }
     bool has_tag(const flag_tag &tag) const { return _tags.find(tag) != _tags.end(); }
 
-    std::string description() const { return _desc; }
+    std::string to_json() const
+    {
+        utils::table_printer tp;
+        tp.add_row_name_and_data("name", _name);
+        tp.add_row_name_and_data("section", _section);
+        tp.add_row_name_and_data("type", _type);
+        tp.add_row_name_and_data("tags", tags_str());
+        tp.add_row_name_and_data("description", _desc);
+        switch (_type) {
+        case FV_BOOL:
+            tp.add_row_name_and_data("value", value<bool>());
+            break;
+        case FV_INT32:
+            tp.add_row_name_and_data("value", value<int32_t>());
+            break;
+        case FV_UINT32:
+            tp.add_row_name_and_data("value", value<uint32_t>());
+            break;
+        case FV_INT64:
+            tp.add_row_name_and_data("value", value<int64_t>());
+            break;
+        case FV_UINT64:
+            tp.add_row_name_and_data("value", value<uint64_t>());
+            break;
+        case FV_DOUBLE:
+            tp.add_row_name_and_data("value", value<double>());
+            break;
+        case FV_STRING:
+            tp.add_row_name_and_data("value", value<const char *>());
+            break;
+        }
+        /**
+        tp.add_title("name");
+        tp.add_column("section");
+        tp.add_column("type");
+        tp.add_column("tags");
+        tp.add_column("description");
+        tp.add_column("value");
+
+        tp.add_row(_name);
+        tp.append_data(_section);
+        tp.append_data(enum_to_string(_type));
+        tp.append_data(tags_str());
+        tp.append_data(_desc);
+        switch (_type) {
+            case FV_BOOL:
+                tp.append_data(value<bool>());
+                break;
+            case FV_INT32:
+                tp.append_data(value<int32_t>());
+                break;
+            case FV_UINT32:
+                tp.append_data(value<uint32_t>());
+                break;
+            case FV_INT64:
+                tp.append_data(value<int64_t>());
+                break;
+            case FV_UINT64:
+                tp.append_data(value<uint64_t>());
+                break;
+            case FV_DOUBLE:
+                tp.append_data(value<double>());
+                break;
+            case FV_STRING:
+                tp.append_data(value<const char *>());
+                break;
+            }
+            */
+
+        std::ostringstream out;
+        tp.output(out, utils::table_printer::output_format::kJsonCompact);
+        return out.str();
+    }
 
 private:
     template <typename T>
-    T &value()
+    T &value() const
     {
         return *reinterpret_cast<T *>(_val);
+    }
+
+    std::string tags_str() const
+    {
+        std::string tags_str;
+        for (const auto &tag : _tags) {
+            tags_str += enum_to_string(tag);
+            tags_str += ",";
+        }
+        if (!tags_str.empty()) {
+            tags_str.pop_back();
+        }
+
+        return tags_str;
     }
 
 private:
@@ -167,7 +263,7 @@ public:
     {
         utils::table_printer tp;
         for (const auto &flag : _flags) {
-            tp.add_row_name_and_data(flag.first, flag.second.description());
+            tp.add_row_name_and_data(flag.first, flag.second.to_json());
         }
 
         std::ostringstream out;

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 
 #include <map>
+#include <dsn/utility/output_utils.h>
 
 namespace dsn {
 
@@ -95,6 +96,8 @@ public:
     void add_tag(const flag_tag &tag) { _tags.insert(tag); }
     bool has_tag(const flag_tag &tag) const { return _tags.find(tag) != _tags.end(); }
 
+    std::string description() const { return _desc; }
+
 private:
     template <typename T>
     T &value()
@@ -160,6 +163,18 @@ public:
         return it->second.has_tag(tag);
     }
 
+    std::string list_all_flags() const
+    {
+        utils::table_printer tp;
+        for (const auto &flag : _flags) {
+            tp.add_row_name_and_data(flag.first, flag.second.description());
+        }
+
+        std::ostringstream out;
+        tp.output(out, utils::table_printer::output_format::kJsonCompact);
+        return out.str();
+    }
+
 private:
     friend class utils::singleton<flag_registry>;
     flag_registry() = default;
@@ -204,5 +219,7 @@ flag_tagger::flag_tagger(const char *name, const flag_tag &tag)
 {
     return flag_registry::instance().has_tag(name, tag);
 }
+
+/*extern*/ std::string list_all_flags() { return flag_registry::instance().list_all_flags(); }
 
 } // namespace dsn

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -137,43 +137,6 @@ public:
             tp.add_row_name_and_data("value", value<const char *>());
             break;
         }
-        /**
-        tp.add_title("name");
-        tp.add_column("section");
-        tp.add_column("type");
-        tp.add_column("tags");
-        tp.add_column("description");
-        tp.add_column("value");
-
-        tp.add_row(_name);
-        tp.append_data(_section);
-        tp.append_data(enum_to_string(_type));
-        tp.append_data(tags_str());
-        tp.append_data(_desc);
-        switch (_type) {
-            case FV_BOOL:
-                tp.append_data(value<bool>());
-                break;
-            case FV_INT32:
-                tp.append_data(value<int32_t>());
-                break;
-            case FV_UINT32:
-                tp.append_data(value<uint32_t>());
-                break;
-            case FV_INT64:
-                tp.append_data(value<int64_t>());
-                break;
-            case FV_UINT64:
-                tp.append_data(value<uint64_t>());
-                break;
-            case FV_DOUBLE:
-                tp.append_data(value<double>());
-                break;
-            case FV_STRING:
-                tp.append_data(value<const char *>());
-                break;
-            }
-            */
 
         std::ostringstream out;
         tp.output(out, utils::table_printer::output_format::kJsonCompact);

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -108,34 +108,25 @@ public:
 
     std::string to_json() const
     {
+#define TABLE_PRINTER_ADD_VALUE(type, type_enum)                                                   \
+    case type_enum:                                                                                \
+        tp.add_row_name_and_data("value", value<type>());                                          \
+        break;
+
         utils::table_printer tp;
         tp.add_row_name_and_data("name", _name);
         tp.add_row_name_and_data("section", _section);
-        tp.add_row_name_and_data("type", _type);
+        tp.add_row_name_and_data("type", enum_to_string(_type));
         tp.add_row_name_and_data("tags", tags_str());
         tp.add_row_name_and_data("description", _desc);
         switch (_type) {
-        case FV_BOOL:
-            tp.add_row_name_and_data("value", value<bool>());
-            break;
-        case FV_INT32:
-            tp.add_row_name_and_data("value", value<int32_t>());
-            break;
-        case FV_UINT32:
-            tp.add_row_name_and_data("value", value<uint32_t>());
-            break;
-        case FV_INT64:
-            tp.add_row_name_and_data("value", value<int64_t>());
-            break;
-        case FV_UINT64:
-            tp.add_row_name_and_data("value", value<uint64_t>());
-            break;
-        case FV_DOUBLE:
-            tp.add_row_name_and_data("value", value<double>());
-            break;
-        case FV_STRING:
-            tp.add_row_name_and_data("value", value<const char *>());
-            break;
+            TABLE_PRINTER_ADD_VALUE(bool, FV_BOOL);
+            TABLE_PRINTER_ADD_VALUE(int32_t, FV_INT32);
+            TABLE_PRINTER_ADD_VALUE(uint32_t, FV_UINT32);
+            TABLE_PRINTER_ADD_VALUE(int64_t, FV_INT64);
+            TABLE_PRINTER_ADD_VALUE(uint64_t, FV_UINT64);
+            TABLE_PRINTER_ADD_VALUE(double, FV_DOUBLE);
+            TABLE_PRINTER_ADD_VALUE(const char *, FV_STRING);
         }
 
         std::ostringstream out;


### PR DESCRIPTION
add a http interface to get all configs

### Manual Test

1. Start onebox
2. use http://localhost:34601/listAllConfigs to get all the configs, the result shows:
```
{"abnormal_write_trace_latency_threshold":"{\"name\":\"abnormal_write_trace_latency_threshold\",\"section\":\"replication\",\"type\":\"4\",\"tags\":\"\",\"description\":\"latency trace will be logged when exceed the write latency threshold\",\"value\":\"1000000000\"}\n","aio_factory_name":"{\"name\":\"aio_factory_name\",\"section\":\"core\",\"type\":\"6\",\"tags\":\"\",\"description\":\"asynchonous file system provider\",\"value\":\"dsn::tools::native_aio_provider\"}\n","capacity_unit_saving_ttl_days":"{\"name\":\"capacity_unit_saving_ttl_days\",\"section\":\"pegasus.collector\",\"type\":\"1\",\"tags\":\"\",\"description\":\"the ttl of the CU data, 0 if no ttl\",\"value\":\"90\"}\n","enable_acl":"{\"name\":\"enable_acl\",\"section\":\"security\",\"type\":\"0\",\"tags\":\"flag_tag::FT_MUTABLE\",\"description\":\"whether enable access controller or not\",\"value\":\"false\"}\n","enable_auth":"{\"name\":\"enable_auth\",\"section\":\"security\",\"type\":\"0\",\"tags\":\"\",\"description\":\"whether open auth or not\",\"value\":\"false\"}\n","enable_detect_hotkey":"{\"name\":\"enable_detect_hotkey\",\"section\":\"pegasus.collector\",\"type\":\"0\",\"tags\":\"\",\"description\":\"auto detect hot key in the hot paritition\",\"value\":\"false\"}\n","enable_http_server":"{\"name\":\"enable_http_server\",\"section\":\"http\",\"type\":\"0\",\"tags\":\"\",\"description\":\"whether to enable the embedded HTTP server\",\"value\":\"true\"}\n","enable_latency_tracer":"{\"name\":\"enable_latency_tracer\",\"section\":\"replication\",\"type\":\"0\",\"tags\":\"\",\"description\":\"whether enable the latency tracer\",\"value\":\"false\"}\n","falcon_host":"{\"name\":\"falcon_host\",\"section\":\"pegasus.server\",\"type\":\"6\",\"tags\":\"\",\"description\":\"falcon agent host\",\"value\":\"127.0.0.1\"}\n","falcon_path":"{\"name\":\"falcon_path\",\"section\":\"pegasus.server\",\"type\":\"6\",\"tags\":\"\",\"description\":\"falcon agent http path\",\"value\":\"/v1/push\"}\n","falcon_port":"{\"name\":\"falcon_port\",\"section\":\"pegasus.server\",\"type\":\"4\",\"tags\":\"\",\"description\":\"falcon agent port\",\"value\":\"1988\"}\n","fast_flush":"{\"name\":\"fast_flush\",\"section\":\"tools.simple_logger\",\"type\":\"0\",\"tags\":\"\",\"description\":\"whether to flush immediately\",\"value\":\"false\"}\n","fds_read_batch_size":"{\"name\":\"fds_read_batch_size\",\"section\":\"replication\",\"type\":\"2\",\"tags\":\"\",\"description\":\"read batch size of fds(MB)\",\"value\":\"100\"}\n","fds_read_limit_rate":"{\"name\":\"fds_read_limit_rate\",\"section\":\"replication\",\"type\":\"2\",\"tags\":\"\",\"description\":\"read rate limit of fds(MB/s)\",\"value\":\"100\"}\n","fds_write_limit_rate":"{\"name\":\"fds_write_limit_rate\",\"section\":\"replication\",\"type\":\"2\",\"tags\":\"\",\"description\":\"write rate limit of fds(MB/s)\",\"value\":\"100\"}\n","file_close_expire_time_ms":"{\"name\":\"file_close_expire_time_ms\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"max idle time for an opening file on nfs server\",\"value\":\"60000\"}\n","file_close_timer_interval_ms_on_server":"{\"name\":\"file_close_timer_interval_ms_on_server\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"time interval for checking whether cached file handles need to be closed\",\"value\":\"30000\"}\n","hdfs_read_batch_size_bytes":"{\"name\":\"hdfs_read_batch_size_bytes\",\"section\":\"replication\",\"type\":\"4\",\"tags\":\"\",\"description\":\"hdfs read batch size, the default value is 64MB\",\"value\":\"67108864\"}\n","hdfs_write_batch_size_bytes":"{\"name\":\"hdfs_write_batch_size_bytes\",\"section\":\"replication\",\"type\":\"4\",\"tags\":\"\",\"description\":\"hdfs write batch size, the default value is 64MB\",\"value\":\"67108864\"}\n","high_priority_speed_rate":"{\"name\":\"high_priority_speed_rate\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"the copy speed rate of high priority comparing with low priority on nfs client\",\"value\":\"2\"}\n","hot_bucket_variance_threshold":"{\"name\":\"hot_bucket_variance_threshold\",\"section\":\"pegasus.server\",\"type\":\"2\",\"tags\":\"\",\"description\":\"the variance threshold to detect hot bucket during coarse analysis of hotkey detection\",\"value\":\"3\"}\n","hot_key_variance_threshold":"{\"name\":\"hot_key_variance_threshold\",\"section\":\"pegasus.server\",\"type\":\"2\",\"tags\":\"\",\"description\":\"the variance threshold to detect hot key during fine analysis of hotkey detection\",\"value\":\"3\"}\n","hot_partition_threshold":"{\"name\":\"hot_partition_threshold\",\"section\":\"pegasus.collector\",\"type\":\"1\",\"tags\":\"\",\"description\":\"threshold of hotspot partition value, if app.stat.hotspots >= FLAGS_hotpartition_threshold, this partition is a hot partition\",\"value\":\"3\"}\n","hotkey_analyse_time_interval_s":"{\"name\":\"hotkey_analyse_time_interval_s\",\"section\":\"pegasus.server\",\"type\":\"1\",\"tags\":\"\",\"description\":\"hotkey analyse interval in seconds\",\"value\":\"10\"}\n","hotkey_buckets_num":"{\"name\":\"hotkey_buckets_num\",\"section\":\"pegasus.server\",\"type\":\"2\",\"tags\":\"\",\"description\":\"the number of data capture hash buckets\",\"value\":\"37\"}\n","krb5_config":"{\"name\":\"krb5_config\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"absolute path of krb5_config file\",\"value\":\"\"}\n","krb5_keytab":"{\"name\":\"krb5_keytab\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"absolute path of keytab file\",\"value\":\"\"}\n","krb5_principal":"{\"name\":\"krb5_principal\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"kerberos principal\",\"value\":\"\"}\n","logging_flush_on_exit":"{\"name\":\"logging_flush_on_exit\",\"section\":\"core\",\"type\":\"0\",\"tags\":\"\",\"description\":\"flush log when exit system\",\"value\":\"true\"}\n","logging_start_level":"{\"name\":\"logging_start_level\",\"section\":\"core\",\"type\":\"6\",\"tags\":\"\",\"description\":\"logs with level below this will not be logged\",\"value\":\"LOG_LEVEL_DEBUG\"}\n","mandatory_auth":"{\"name\":\"mandatory_auth\",\"section\":\"security\",\"type\":\"0\",\"tags\":\"flag_tag::FT_MUTABLE\",\"description\":\"wheter to do authertication mandatorily\",\"value\":\"false\"}\n","max_buffered_local_writes":"{\"name\":\"max_buffered_local_writes\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"max buffered file writes on nfs client\",\"value\":\"500\"}\n","max_concurrent_bulk_load_downloading_count":"{\"name\":\"max_concurrent_bulk_load_downloading_count\",\"section\":\"replication\",\"type\":\"1\",\"tags\":\"\",\"description\":\"concurrent bulk load downloading replica count\",\"value\":\"5\"}\n","max_concurrent_local_writes":"{\"name\":\"max_concurrent_local_writes\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"max local file writes on nfs client\",\"value\":\"50\"}\n","max_concurrent_remote_copy_requests":"{\"name\":\"max_concurrent_remote_copy_requests\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"max concurrent remote copy to the same server on nfs client\",\"value\":\"50\"}\n","max_concurrent_uploading_file_count":"{\"name\":\"max_concurrent_uploading_file_count\",\"section\":\"replication\",\"type\":\"4\",\"tags\":\"\",\"description\":\"concurrent uploading file count to block service\",\"value\":\"10\"}\n","max_copy_rate_megabytes":"{\"name\":\"max_copy_rate_megabytes\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"max rate of copying from remote node(MB/s)\",\"value\":\"500\"}\n","max_file_copy_request_count_per_file":"{\"name\":\"max_file_copy_request_count_per_file\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"maximum concurrent remote copy requests for the same file on nfs clientto limit each file copy speed\",\"value\":\"2\"}\n","max_hotspot_store_size":"{\"name\":\"max_hotspot_store_size\",\"section\":\"pegasus.collector\",\"type\":\"3\",\"tags\":\"\",\"description\":\"the max count of historical data stored in calculator, The FIFO queue design is used to eliminate outdated historical data\",\"value\":\"100\"}\n","max_number_of_log_files_on_disk":"{\"name\":\"max_number_of_log_files_on_disk\",\"section\":\"tools.simple_logger\",\"type\":\"4\",\"tags\":\"\",\"description\":\"max number of log files reserved on disk, older logs are auto deleted\",\"value\":\"20\"}\n","max_retry_count_per_copy_request":"{\"name\":\"max_retry_count_per_copy_request\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"maximum retry count when copy failed\",\"value\":\"2\"}\n","max_seconds_to_detect_hotkey":"{\"name\":\"max_seconds_to_detect_hotkey\",\"section\":\"pegasus.server\",\"type\":\"2\",\"tags\":\"\",\"description\":\"the max time (in seconds) allowed to capture hotkey, will stop if hotkey's not found\",\"value\":\"150\"}\n","meta_acl_rpc_allow_list":"{\"name\":\"meta_acl_rpc_allow_list\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"allowed list of rpc codes for meta_access_controller\",\"value\":\"\"}\n","nfs_copy_block_bytes":"{\"name\":\"nfs_copy_block_bytes\",\"section\":\"nfs\",\"type\":\"2\",\"tags\":\"\",\"description\":\"max block size (bytes) for each network copy\",\"value\":\"4194304\"}\n","occurrence_threshold":"{\"name\":\"occurrence_threshold\",\"section\":\"pegasus.collector\",\"type\":\"1\",\"tags\":\"\",\"description\":\"hot paritiotion occurrence times' threshold to send rpc to detect hotkey\",\"value\":\"100\"}\n","perf_counter_enable_logging":"{\"name\":\"perf_counter_enable_logging\",\"section\":\"pegasus.server\",\"type\":\"0\",\"tags\":\"\",\"description\":\"perf_counter_enable_logging\",\"value\":\"false\"}\n","perf_counter_sink":"{\"name\":\"perf_counter_sink\",\"section\":\"pegasus.server\",\"type\":\"6\",\"tags\":\"\",\"description\":\"perf_counter_sink\",\"value\":\"\"}\n","perf_counter_update_interval_seconds":"{\"name\":\"perf_counter_update_interval_seconds\",\"section\":\"pegasus.server\",\"type\":\"4\",\"tags\":\"\",\"description\":\"perf_counter_update_interval_seconds\",\"value\":\"10\"}\n","prometheus_port":"{\"name\":\"prometheus_port\",\"section\":\"pegasus.server\",\"type\":\"4\",\"tags\":\"\",\"description\":\"prometheus exposer port\",\"value\":\"9095\"}\n","rocksdb_limiter_enable_auto_tune":"{\"name\":\"rocksdb_limiter_enable_auto_tune\",\"section\":\"pegasus.server\",\"type\":\"0\",\"tags\":\"\",\"description\":\"whether to enable write rate auto tune when open rocksdb write limit\",\"value\":\"false\"}\n","rocksdb_limiter_max_write_megabytes_per_sec":"{\"name\":\"rocksdb_limiter_max_write_megabytes_per_sec\",\"section\":\"pegasus.server\",\"type\":\"3\",\"tags\":\"\",\"description\":\"max rate of rocksdb flush and compaction(MB/s), if less than or equal to 0 means close limit\",\"value\":\"500\"}\n","rocksdb_target_file_size_base":"{\"name\":\"rocksdb_target_file_size_base\",\"section\":\"pegasus.server\",\"type\":\"4\",\"tags\":\"\",\"description\":\"rocksdb options.target_file_size_base\",\"value\":\"67108864\"}\n","rocksdb_write_buffer_size":"{\"name\":\"rocksdb_write_buffer_size\",\"section\":\"pegasus.server\",\"type\":\"4\",\"tags\":\"\",\"description\":\"rocksdb options.write_buffer_size\",\"value\":\"67108864\"}\n","rpc_timeout_ms":"{\"name\":\"rpc_timeout_ms\",\"section\":\"nfs\",\"type\":\"1\",\"tags\":\"\",\"description\":\"rpc timeout in milliseconds for nfs copy, 0 means use default timeout of rpc engine\",\"value\":\"10000\"}\n","sasl_plugin_path":"{\"name\":\"sasl_plugin_path\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"path to search sasl plugins\",\"value\":\"/usr/lib/sasl2\"}\n","service_fqdn":"{\"name\":\"service_fqdn\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"the fully qualified domain name of the server\",\"value\":\"\"}\n","service_name":"{\"name\":\"service_name\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"service name\",\"value\":\"\"}\n","short_header":"{\"name\":\"short_header\",\"section\":\"tools.simple_logger\",\"type\":\"0\",\"tags\":\"\",\"description\":\"whether to use short header (excluding file/function etc.)\",\"value\":\"false\"}\n","stderr_start_level":"{\"name\":\"stderr_start_level\",\"section\":\"tools.simple_logger\",\"type\":\"6\",\"tags\":\"\",\"description\":\"copy log messages at or above this level to stderr in addition to logfiles\",\"value\":\"LOG_LEVEL_ERROR\"}\n","super_users":"{\"name\":\"super_users\",\"section\":\"security\",\"type\":\"6\",\"tags\":\"\",\"description\":\"super user for access controller\",\"value\":\"\"}\n"}
```