### PR TITLE
fix(security): make mandatory_auth to be a server side config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5.2)
 
 project(dsn C CXX)
 
+
 include(bin/dsn.cmake)
 
 set(DSN_BUILD_RUNTIME TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5.2)
 
 project(dsn C CXX)
 
-
 include(bin/dsn.cmake)
 
 set(DSN_BUILD_RUNTIME TRUE)

--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -27,7 +27,6 @@
 
 namespace dsn {
 namespace security {
-DSN_DECLARE_bool(mandatory_auth);
 extern const std::set<std::string> supported_mechanisms;
 
 client_negotiation::client_negotiation(rpc_session_ptr session) : negotiation(session)

--- a/src/runtime/security/negotiation_manager.cpp
+++ b/src/runtime/security/negotiation_manager.cpp
@@ -102,22 +102,24 @@ void negotiation_manager::on_rpc_disconnected(rpc_session *session)
     }
 }
 
-// `on_rpc_recv_msg` and `on_rpc_recv_msg` will be called by both server and client session
-// For server sessioin, it can receive message if mandatory_auth is false
-// Because mandatory_auth is a server-side config only, so it doesn't have the same effect for
-// client session
+// `on_rpc_send_msg` and `on_rpc_recv_msg` will be called by both server and client session.
+// For server session, it can bypass negotiation if mandatory_auth is false.
+// mandatory_auth is a server-side config only, it doesn't have the same effect for
+// client session.
 bool negotiation_manager::on_rpc_recv_msg(message_ex *msg)
 {
     if (!msg->io_session->is_client() && !FLAGS_mandatory_auth) {
+        // if this is server_session and mandatory_auth is turned off.
         return true;
     }
 
-    return in_white_list(msg->rpc_code()) || msg->io_session->is_negotiation_succeed();
+    return dsn_likely(msg->io_session->is_negotiation_succeed()) || in_white_list(msg->rpc_code());
 }
 
 bool negotiation_manager::on_rpc_send_msg(message_ex *msg)
 {
     if (!msg->io_session->is_client() && !FLAGS_mandatory_auth) {
+        // if this is server_session and mandatory_auth is turned off.
         return true;
     }
 

--- a/src/runtime/security/negotiation_manager.cpp
+++ b/src/runtime/security/negotiation_manager.cpp
@@ -102,14 +102,25 @@ void negotiation_manager::on_rpc_disconnected(rpc_session *session)
     }
 }
 
+// `on_rpc_recv_msg` and `on_rpc_recv_msg` will be called by both server and client session
+// For server sessioin, it can receive message if mandatory_auth is false
+// Because mandatory_auth is a server-side config only, so it doesn't have the same effect for
+// client session
 bool negotiation_manager::on_rpc_recv_msg(message_ex *msg)
 {
-    return !FLAGS_mandatory_auth || in_white_list(msg->rpc_code()) ||
-           msg->io_session->is_negotiation_succeed();
+    if (!msg->io_session->is_client() && !FLAGS_mandatory_auth) {
+        return true;
+    }
+
+    return in_white_list(msg->rpc_code()) || msg->io_session->is_negotiation_succeed();
 }
 
 bool negotiation_manager::on_rpc_send_msg(message_ex *msg)
 {
+    if (!msg->io_session->is_client() && !FLAGS_mandatory_auth) {
+        return true;
+    }
+
     // if try_pend_message return true, it means the msg is pended to the resend message queue
     return in_white_list(msg->rpc_code()) || !msg->io_session->try_pend_message(msg);
 }


### PR DESCRIPTION
In pr(https://github.com/XiaoMi/rdsn/pull/708), I remove mandatory_auth on client_side. But I forgot that both `on_rpc_recv_msg` and `on_rpc_recv_msg` will be called by both server and client session. So in this pull request, I fix it to make mandatory_auth to be a server side config.

I have tested all of the cases below for this pr:

server | server | server | client | client | expected result | test result
-- | -- | -- | -- | -- | -- | -- 
support security | enable_auth | mandatory_auth | support security | enable_auth
no | - | - | yes | TRUE | √ | √
no | - | - | yes | FALSE | √ | √
yes | FALSE | - | no | - | √ | √
yes | TRUE | FALSE | no | - | √ | √
yes | TRUE | TRUE | no | - | × | ×


server | server |  client | expected result | test result
-- | -- | -- | -- | --
enable_auth | mandatory_auth | enable_auth
TRUE | TRUE | TRUE | √ | √
TRUE | TRUE | FALSE | × | ×
TRUE | FALSE | TRUE | √ | √
TRUE | FALSE | FALSE | √ | √
FALSE | - | whatever | √ | √

the authencation status when we are doing rolling-update/down-grade (update/dowgrade from v2.1.1).

enable_auth | mandatory_auth | expected result | test result
-- | -- | -- | --
FALSE | - | √ | √
TRUE | FALSE | √ | √
TRUE | TRUE | × | ×


