### PR TITLE
feat: update query partition data version

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2808,24 +2808,20 @@ void replica_stub::on_detect_hotkey(detect_hotkey_rpc rpc)
     }
 }
 
-error_code replica_stub::query_app_data_version(int32_t app_id, /*out*/ uint32_t &data_version)
+void replica_stub::query_app_data_version(int32_t app_id,
+                                          std::unordered_map<int32_t, uint32_t> &version_map)
 {
-    replica_ptr rep = nullptr;
     zauto_read_lock l(_replicas_lock);
     for (const auto &kv : _replicas) {
         if (kv.first.get_app_id() == app_id) {
-            rep = kv.second;
-            break;
+            replica_ptr rep = kv.second;
+            if (rep != nullptr) {
+                uint32_t data_version = rep->query_data_version();
+                version_map[kv.first.get_partition_index()] = data_version;
+                ddebug_f("partition[{}] data_version = {}", kv.first, data_version);
+            }
         }
     }
-    if (rep == nullptr) {
-        dwarn_f("app({}) is not found", app_id);
-        return ERR_OBJECT_NOT_FOUND;
-    }
-
-    data_version = rep->query_data_version();
-    ddebug_f("app({}) data_version={}", app_id, data_version);
-    return ERR_OK;
 }
 
 void replica_stub::query_app_compact_status(

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2808,8 +2808,8 @@ void replica_stub::on_detect_hotkey(detect_hotkey_rpc rpc)
     }
 }
 
-void replica_stub::query_app_data_version(int32_t app_id,
-                                          std::unordered_map<int32_t, uint32_t> &version_map)
+void replica_stub::query_app_data_version(
+    int32_t app_id, /*pidx => data_version*/ std::unordered_map<int32_t, uint32_t> &version_map)
 {
     zauto_read_lock l(_replicas_lock);
     for (const auto &kv : _replicas) {
@@ -2818,7 +2818,6 @@ void replica_stub::query_app_data_version(int32_t app_id,
             if (rep != nullptr) {
                 uint32_t data_version = rep->query_data_version();
                 version_map[kv.first.get_partition_index()] = data_version;
-                ddebug_f("partition[{}] data_version = {}", kv.first, data_version);
             }
         }
     }

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -289,8 +289,9 @@ private:
         return 0;
     }
 
-    void query_app_data_version(int32_t app_id,
-                                /*out*/ std::unordered_map<int32_t, uint32_t> &version_map);
+    void query_app_data_version(
+        int32_t app_id,
+        /*pidx => data_version*/ std::unordered_map<int32_t, uint32_t> &version_map);
 
 #ifdef DSN_ENABLE_GPERF
     // Try to release tcmalloc memory back to operating system

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -289,7 +289,8 @@ private:
         return 0;
     }
 
-    error_code query_app_data_version(int32_t app_id, /*out*/ uint32_t &data_version);
+    void query_app_data_version(int32_t app_id,
+                                /*out*/ std::unordered_map<int32_t, uint32_t> &version_map);
 
 #ifdef DSN_ENABLE_GPERF
     // Try to release tcmalloc memory back to operating system

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -95,10 +95,8 @@ TEST_F(replica_test, query_data_version_test)
                  {"wrong", http_status_code::bad_request, "invalid app_id=wrong"},
                  {"2",
                   http_status_code::ok,
-                  R"({"error":"ERR_OK","data_version":"1"})"},
-                 {"4",
-                  http_status_code::ok,
-                  R"({"error":"ERR_OBJECT_NOT_FOUND","data_version":"0"})"}};
+                  R"({"1":{"pidx":"1","data_version":"1"}})"},
+                 {"4", http_status_code::not_found, "app_id=4 not found"}};
     for (const auto &test : tests) {
         http_request req;
         http_response resp;


### PR DESCRIPTION
PR #706 support the replica http interface to query app data_version, it will return data_version of any partition for the app, however, it is possible for partitions have different data_version. This pr fix it, return <pidx, data_version> map instead.