### PR TITLE
fix: multiple asan errors

### DIFF
--- a/include/dsn/utility/TokenBucket.h
+++ b/include/dsn/utility/TokenBucket.h
@@ -234,7 +234,11 @@ public:
         assert(burstSize > 0);
 
         if (burstSize < toConsume) {
-            return boost::none;
+            // boost::none
+            // if we use boost::none here, some compilers will generate warning
+            // that's actually a false positive of "-Wmaybe-uninitialized".
+            // https://www.boost.org/doc/libs/1_65_1/libs/optional/doc/html/boost_optional/tutorial/gotchas/false_positive_with__wmaybe_uninitialized.html
+            return boost::make_optional(false, double());
         }
 
         while (toConsume > 0) {

--- a/include/dsn/utils/time_utils.h
+++ b/include/dsn/utils/time_utils.h
@@ -39,7 +39,10 @@ static struct tm *get_localtime(uint64_t ts_ms, struct tm *tm_buf)
 }
 
 // get time string, which format is yyyy-MM-dd hh:mm:ss.SSS
+// NOTE: using char* as output is usually unsafe. Please use std::string as the output argument
+// as long as it's possible.
 extern void time_ms_to_string(uint64_t ts_ms, char *str);
+extern void time_ms_to_string(uint64_t ts_ms, std::string &str);
 
 // get date string with format of 'yyyy-MM-dd' from given timestamp
 inline void time_ms_to_date(uint64_t ts_ms, char *str, int len)

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -26,6 +26,7 @@
 
 #include <dsn/tool-api/async_calls.h>
 #include <dsn/utility/filesystem.h>
+#include <dsn/utility/smart_pointers.h>
 
 #include <gtest/gtest.h>
 
@@ -145,9 +146,9 @@ TEST(core, operation_failed)
     auto fp = file::open("tmp_test_file", O_WRONLY, 0600);
     EXPECT_TRUE(fp == nullptr);
 
-    ::dsn::error_code *err = new ::dsn::error_code;
-    size_t *count = new size_t;
-    auto io_callback = [err, count](::dsn::error_code e, size_t n) {
+    auto err = dsn::make_unique<dsn::error_code>();
+    auto count = dsn::make_unique<size_t>();
+    auto io_callback = [&err, &count](::dsn::error_code e, size_t n) {
         *err = e;
         *count = n;
     };

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     What is this file about?
- *
- * Revision history:
- *     xxxx-xx-xx, author, first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #include <dsn/utility/ports.h>
 #include <dsn/utility/crc.h>
 #include <dsn/utility/transient_memory.h>

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -45,9 +45,7 @@ using namespace tools;
 DSN_REGISTER_COMPONENT_PROVIDER(screen_logger, "dsn::tools::screen_logger");
 DSN_REGISTER_COMPONENT_PROVIDER(simple_logger, "dsn::tools::simple_logger");
 
-std::function<std::string()> log_prefixed_message_func = []() -> std::string {
-    return ": ";
-};
+std::function<std::string()> log_prefixed_message_func = []() -> std::string { return ": "; };
 
 void set_log_prefixed_message_func(std::function<std::string()> func)
 {

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -45,17 +45,8 @@ using namespace tools;
 DSN_REGISTER_COMPONENT_PROVIDER(screen_logger, "dsn::tools::screen_logger");
 DSN_REGISTER_COMPONENT_PROVIDER(simple_logger, "dsn::tools::simple_logger");
 
-std::function<std::string()> log_prefixed_message_func = []() {
-    static thread_local std::string prefixed_message;
-
-    static thread_local std::once_flag flag;
-    std::call_once(flag, [&]() {
-        prefixed_message.resize(23);
-        int tid = dsn::utils::get_current_tid();
-        sprintf(const_cast<char *>(prefixed_message.c_str()), "unknown.io-thrd.%05d: ", tid);
-    });
-
-    return prefixed_message;
+std::function<std::string()> log_prefixed_message_func = []() -> std::string {
+    return ": ";
 };
 
 void set_log_prefixed_message_func(std::function<std::string()> func)

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -29,6 +29,7 @@
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/flags.h>
 #include <dsn/utils/time_utils.h>
+#include <fmt/format.h>
 
 namespace dsn {
 namespace tools {
@@ -58,17 +59,17 @@ static void print_header(FILE *fp, dsn_log_level_t log_level)
     static char s_level_char[] = "IDWEF";
 
     uint64_t ts = dsn_now_ns();
-    char str[24];
-    dsn::utils::time_ms_to_string(ts / 1000000, str);
+    std::string time_str;
+    dsn::utils::time_ms_to_string(ts / 1000000, time_str);
 
     int tid = dsn::utils::get_current_tid();
-    fprintf(fp,
-            "%c%s (%" PRIu64 " %04x) %s",
-            s_level_char[log_level],
-            str,
-            ts,
-            tid,
-            log_prefixed_message_func().c_str());
+    fmt::print(fp,
+               "{}{} ({} {}) {}",
+               s_level_char[log_level],
+               time_str,
+               ts,
+               tid,
+               log_prefixed_message_func());
 }
 
 screen_logger::screen_logger(bool short_header) : logging_provider("./")

--- a/src/utils/test/priority_queue.cpp
+++ b/src/utils/test/priority_queue.cpp
@@ -114,6 +114,7 @@ TEST(core, blocking_priority_queue)
     ASSERT_EQ(0, ct);
     ASSERT_EQ(0, d->priority);
     ASSERT_EQ(10, d->queue_index);
+    delete d;
 
     bool flag = false;
 

--- a/src/utils/time_utils.cpp
+++ b/src/utils/time_utils.cpp
@@ -34,5 +34,16 @@ namespace utils {
     fmt::format_to(str, "{:%Y-%m-%d %H:%M:%S}.{}", *ret, static_cast<uint32_t>(ts_ms % 1000));
 }
 
+/*extern*/ void time_ms_to_string(uint64_t ts_ms, std::string &str)
+{
+    str.clear();
+    struct tm tmp;
+    auto ret = get_localtime(ts_ms, &tmp);
+    fmt::format_to(std::back_inserter(str),
+                   "{:%Y-%m-%d %H:%M:%S}.{}",
+                   *ret,
+                   static_cast<uint32_t>(ts_ms % 1000));
+}
+
 } // namespace utils
 } // namespace dsn


### PR DESCRIPTION
```
std::function<std::string()> log_prefixed_message_func = []() {
    static thread_local std::string prefixed_message;

    static thread_local std::once_flag flag;
    std::call_once(flag, [&]() {
        prefixed_message.resize(23);
        int tid = dsn::utils::get_current_tid();
        sprintf(const_cast<char *>(prefixed_message.c_str()), "unknown.io-thrd.%05d: ", tid);
    });

    return prefixed_message;
```

This function prepends "unknown.io-thrd.<thread id>: " to every line of our log when the rdsn runtime is not set up.
But this prefix has no useful meaning, as tid is also logged via `static void print_header(FILE *fp, dsn_log_level_t log_level)
`.  So I here simplify this function to output ": " instead.

This function has a mem-leak that the thread-local "prefixed_message" will be freed even when `log_prefixed_message_func` is in use. Simplifying this function also resolves this problem.

