### PR TITLE
BREAKING CHANGE(backup): remove 'policy_name' from backup files' path

### DIFF
--- a/src/common/backup_utils.cpp
+++ b/src/common/backup_utils.cpp
@@ -29,123 +29,86 @@ const int32_t cold_backup_constant::PROGRESS_FINISHED = 1000;
 
 namespace cold_backup {
 
-std::string get_policy_path(const std::string &root, const std::string &policy_name)
+std::string get_backup_path(const std::string &root, int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << root << "/" << policy_name;
-    return ss.str();
+    return root + "/" + std::to_string(backup_id);
 }
 
-std::string
-get_backup_path(const std::string &root, const std::string &policy_name, int64_t backup_id)
+std::string get_backup_info_file(const std::string &root, int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_policy_path(root, policy_name) << "/" << backup_id;
-    return ss.str();
-}
-
-std::string get_app_backup_path(const std::string &root,
-                                const std::string &policy_name,
-                                const std::string &app_name,
-                                int32_t app_id,
-                                int64_t backup_id)
-{
-    std::stringstream ss;
-    ss << get_backup_path(root, policy_name, backup_id) << "/" << app_name << "_" << app_id;
-    return ss.str();
+    return get_backup_path(root, backup_id) + "/" + cold_backup_constant::BACKUP_INFO;
 }
 
 std::string get_replica_backup_path(const std::string &root,
-                                    const std::string &policy_name,
                                     const std::string &app_name,
                                     gpid pid,
                                     int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_policy_path(root, policy_name) << "/" << backup_id << "/" << app_name << "_"
-       << pid.get_app_id() << "/" << pid.get_partition_index();
-    return ss.str();
+    std::string str_app = app_name + "_" + std::to_string(pid.get_app_id());
+    return get_backup_path(root, backup_id) + "/" + str_app + "/" +
+           std::to_string(pid.get_partition_index());
 }
 
 std::string get_app_meta_backup_path(const std::string &root,
-                                     const std::string &policy_name,
                                      const std::string &app_name,
                                      int32_t app_id,
                                      int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_policy_path(root, policy_name) << "/" << backup_id << "/" << app_name << "_" << app_id
-       << "/meta";
-    return ss.str();
+    std::string str_app = app_name + "_" + std::to_string(app_id);
+    return get_backup_path(root, backup_id) + "/" + str_app + "/meta";
 }
 
 std::string get_app_metadata_file(const std::string &root,
-                                  const std::string &policy_name,
                                   const std::string &app_name,
                                   int32_t app_id,
                                   int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_app_meta_backup_path(root, policy_name, app_name, app_id, backup_id) << "/"
-       << cold_backup_constant::APP_METADATA;
-    return ss.str();
+    return get_app_meta_backup_path(root, app_name, app_id, backup_id) + "/" +
+           cold_backup_constant::APP_METADATA;
 }
 
 std::string get_app_backup_status_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        int32_t app_id,
                                        int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_app_meta_backup_path(root, policy_name, app_name, app_id, backup_id) << "/"
-       << cold_backup_constant::APP_BACKUP_STATUS;
-    return ss.str();
+    return get_app_meta_backup_path(root, app_name, app_id, backup_id) + "/" +
+           cold_backup_constant::APP_BACKUP_STATUS;
 }
 
 std::string get_current_chkpt_file(const std::string &root,
-                                   const std::string &policy_name,
                                    const std::string &app_name,
                                    gpid pid,
                                    int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_replica_backup_path(root, policy_name, app_name, pid, backup_id) << "/"
-       << cold_backup_constant::CURRENT_CHECKPOINT;
-    return ss.str();
+    return get_replica_backup_path(root, app_name, pid, backup_id) + "/" +
+           cold_backup_constant::CURRENT_CHECKPOINT;
 }
 
 std::string get_remote_chkpt_dirname()
 {
     // here using server address as suffix of remote_chkpt_dirname
-    rpc_address local_address = dsn_primary_address();
-    std::stringstream ss;
-    ss << "chkpt_" << local_address.ipv4_str() << "_" << local_address.port();
-    return ss.str();
+    std::string local_address = dsn_primary_address().ipv4_str();
+    std::string port = std::to_string(dsn_primary_address().port());
+    return "chkpt_" + local_address + "_" + port;
 }
 
 std::string get_remote_chkpt_dir(const std::string &root,
-                                 const std::string &policy_name,
                                  const std::string &app_name,
                                  gpid pid,
                                  int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_replica_backup_path(root, policy_name, app_name, pid, backup_id) << "/"
-       << get_remote_chkpt_dirname();
-    return ss.str();
+    return get_replica_backup_path(root, app_name, pid, backup_id) + "/" +
+           get_remote_chkpt_dirname();
 }
 
 std::string get_remote_chkpt_meta_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        gpid pid,
                                        int64_t backup_id)
 {
-    std::stringstream ss;
-    ss << get_remote_chkpt_dir(root, policy_name, app_name, pid, backup_id) << "/"
-       << cold_backup_constant::BACKUP_METADATA;
-    return ss.str();
+    return get_remote_chkpt_dir(root, app_name, pid, backup_id) + "/" +
+           cold_backup_constant::BACKUP_METADATA;
 }
 
 } // namespace cold_backup

--- a/src/common/backup_utils.h
+++ b/src/common/backup_utils.h
@@ -45,19 +45,19 @@ namespace cold_backup {
 
 // The directory structure on block service
 //
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_metadata
-//                                                      /meta/app_backup_status
-//                                                      /partition_1/checkpoint@ip:port/***.sst
-//                                                      /partition_1/checkpoint@ip:port/CURRENT
-//                                                      /partition_1/checkpoint@ip:port/backup_metadata
-//                                                      /partition_1/current_checkpoint
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_metadata
-//                                                      /meta/app_backup_status
-//                                                      /partition_1/checkpoint@ip:port/***.sst
-//                                                      /partition_1/checkpoint@ip:port/CURRENT
-//                                                      /partition_1/checkpoint@ip:port/backup_metadata
-//                                                      /partition_1/current_checkpoint
-//      <root>/<policy_name>/<backup_id>/backup_info
+//      <root>/<backup_id>/<appname_appid>/meta/app_metadata
+//                                        /meta/app_backup_status
+//                                        /partition_1/checkpoint@ip:port/***.sst
+//                                        /partition_1/checkpoint@ip:port/CURRENT
+//                                        /partition_1/checkpoint@ip:port/backup_metadata
+//                                        /partition_1/current_checkpoint
+//      <root>/<backup_id>/<appname_appid>/meta/app_metadata
+//                                        /meta/app_backup_status
+//                                        /partition_1/checkpoint@ip:port/***.sst
+//                                        /partition_1/checkpoint@ip:port/CURRENT
+//                                        /partition_1/checkpoint@ip:port/backup_metadata
+//                                        /partition_1/current_checkpoint
+//      <root>/<backup_id>/backup_info
 //
 
 //
@@ -72,39 +72,22 @@ namespace cold_backup {
 //      5, backup_info : recording the information of this backup
 //
 
-// compose the path for policy on block service
-// input:
-//  -- root: the prefix of path
-// return:
-//      the path: <root>/<policy_name>
-std::string get_policy_path(const std::string &root, const std::string &policy_name);
-
 // compose the path for app on block service
 // input:
 //  -- root:  the prefix of path
 // return:
-//      the path: <root>/<policy_name>/<backup_id>
-std::string
-get_backup_path(const std::string &root, const std::string &policy_name, int64_t backup_id);
+//      the path: <root>/<backup_id>
+std::string get_backup_path(const std::string &root, int64_t backup_id);
 
-// compose the path for app on block service
-// input:
-//  -- root:  the prefix of path
-// return:
-//      the path: <root>/<policy_name>/<backup_id>/<appname_appid>
-std::string get_app_backup_path(const std::string &root,
-                                const std::string &policy_name,
-                                const std::string &app_name,
-                                int32_t app_id,
-                                int64_t backup_id);
+// return: <root>/<backup_id>/backup_info
+std::string get_backup_info_file(const std::string &root, int64_t backup_id);
 
 // compose the path for replica on block service
 // input:
 //  -- root:  the prefix of the path
 // return:
-//      the path: <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>
+//      the path: <root>/<backup_id>/<appname_appid>/<partition_index>
 std::string get_replica_backup_path(const std::string &root,
-                                    const std::string &policy_name,
                                     const std::string &app_name,
                                     gpid pid,
                                     int64_t backup_id);
@@ -113,9 +96,8 @@ std::string get_replica_backup_path(const std::string &root,
 // input:
 //  -- root:  the prefix of the path
 // return:
-//      the path: <root>/<policy_name>/<backup_id>/<appname_appid>/meta
+//      the path: <root>/<backup_id>/<appname_appid>/meta
 std::string get_app_meta_backup_path(const std::string &root,
-                                     const std::string &policy_name,
                                      const std::string &app_name,
                                      int32_t app_id,
                                      int64_t backup_id);
@@ -125,9 +107,8 @@ std::string get_app_meta_backup_path(const std::string &root,
 //  -- prefix:      the prefix of AP
 // return:
 //      the AP of app meta data file:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_metadata
+//      <root>/<backup_id>/<appname_appid>/meta/app_metadata
 std::string get_app_metadata_file(const std::string &root,
-                                  const std::string &policy_name,
                                   const std::string &app_name,
                                   int32_t app_id,
                                   int64_t backup_id);
@@ -137,9 +118,8 @@ std::string get_app_metadata_file(const std::string &root,
 //  -- prefix:      the prefix of AP
 // return:
 //      the AP of flag-file, which represent whether the app have finished backup:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/meta/app_backup_status
+//      <root>/<backup_id>/<appname_appid>/meta/app_backup_status
 std::string get_app_backup_status_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        int32_t app_id,
                                        int64_t backup_id);
@@ -150,9 +130,8 @@ std::string get_app_backup_status_file(const std::string &root,
 //  -- pid:         gpid of replica
 // return:
 //      the AP of current checkpoint file:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>/current_checkpoint
+//      <root>/<backup_id>/<appname_appid>/<partition_index>/current_checkpoint
 std::string get_current_chkpt_file(const std::string &root,
-                                   const std::string &policy_name,
                                    const std::string &app_name,
                                    gpid pid,
                                    int64_t backup_id);
@@ -168,9 +147,8 @@ std::string get_remote_chkpt_dirname();
 //  -- pid:          gpid of replcia
 // return:
 //      the AP of the checkpoint dir:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>
+//      <root>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>
 std::string get_remote_chkpt_dir(const std::string &root,
-                                 const std::string &policy_name,
                                  const std::string &app_name,
                                  gpid pid,
                                  int64_t backup_id);
@@ -181,9 +159,8 @@ std::string get_remote_chkpt_dir(const std::string &root,
 //  -- pid:          gpid of replcia
 // return:
 //      the AP of the checkpoint file metadata:
-//      <root>/<policy_name>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>/backup_metadata
+//      <root>/<backup_id>/<appname_appid>/<partition_index>/checkpoint@<ip:port>/backup_metadata
 std::string get_remote_chkpt_meta_file(const std::string &root,
-                                       const std::string &policy_name,
                                        const std::string &app_name,
                                        gpid pid,
                                        int64_t backup_id);

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -293,9 +293,8 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
 
     dist::block_service::create_file_request create_file_req;
     create_file_req.ignore_metadata = true;
-    create_file_req.file_name = utils::filesystem::path_combine(
-        cold_backup::get_backup_path(_backup_service->backup_root(), b_info.backup_id),
-        cold_backup_constant::BACKUP_INFO);
+    create_file_req.file_name =
+        cold_backup::get_backup_info_file(_backup_service->backup_root(), b_info.backup_id);
     // here we can use synchronous way coz create_file with ignored metadata is very fast
     _block_service
         ->create_file(create_file_req,

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -77,7 +77,6 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
     dist::block_service::create_file_request create_file_req;
     create_file_req.ignore_metadata = true;
     create_file_req.file_name = cold_backup::get_app_metadata_file(_backup_service->backup_root(),
-                                                                   _policy.policy_name,
                                                                    _policy.app_names.at(app_id),
                                                                    app_id,
                                                                    _cur_backup.backup_id);
@@ -183,7 +182,6 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
     create_file_req.ignore_metadata = true;
     create_file_req.file_name =
         cold_backup::get_app_backup_status_file(_backup_service->backup_root(),
-                                                _policy.policy_name,
                                                 _policy.app_names.at(app_id),
                                                 app_id,
                                                 _cur_backup.backup_id);
@@ -296,8 +294,7 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
     dist::block_service::create_file_request create_file_req;
     create_file_req.ignore_metadata = true;
     create_file_req.file_name = utils::filesystem::path_combine(
-        cold_backup::get_backup_path(
-            _backup_service->backup_root(), _policy.policy_name, b_info.backup_id),
+        cold_backup::get_backup_path(_backup_service->backup_root(), b_info.backup_id),
         cold_backup_constant::BACKUP_INFO);
     // here we can use synchronous way coz create_file with ignored metadata is very fast
     _block_service
@@ -903,8 +900,8 @@ void policy_context::gc_backup_info_unlocked(const backup_info &info_to_gc)
     dsn::task_ptr sync_callback =
         ::dsn::tasking::create_task(LPC_DEFAULT_CALLBACK, &_tracker, [this, info_to_gc]() {
             dist::block_service::remove_path_request req;
-            req.path = cold_backup::get_backup_path(
-                _backup_service->backup_root(), _policy.policy_name, info_to_gc.backup_id);
+            req.path =
+                cold_backup::get_backup_path(_backup_service->backup_root(), info_to_gc.backup_id);
             req.recursive = true;
             _block_service->remove_path(
                 req,

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -55,11 +55,12 @@ void server_state::sync_app_from_backup_media(
         return;
     }
 
-    std::string app_metadata = cold_backup::get_app_metadata_file(request.cluster_name,
-                                                                  request.policy_name,
-                                                                  request.app_name,
-                                                                  request.app_id,
-                                                                  request.time_stamp);
+    std::string cluster_root = request.cluster_name;
+    if (!request.policy_name.empty()) {
+        cluster_root += ("/" + request.policy_name);
+    }
+    std::string app_metadata = cold_backup::get_app_metadata_file(
+        cluster_root, request.app_name, request.app_id, request.time_stamp);
 
     error_code err = ERR_OK;
     block_file_ptr file_handle = nullptr;

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -176,7 +176,7 @@ void cold_backup_context::check_backup_on_remote()
     // check whether current checkpoint file is exist on remote, and verify whether the checkpoint
     // directory is exist
     std::string current_chkpt_file = cold_backup::get_current_chkpt_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = current_chkpt_file;
     req.ignore_metadata = false;
@@ -311,7 +311,7 @@ void cold_backup_context::remote_chkpt_dir_exist(const std::string &chkpt_dirnam
 {
     dist::block_service::ls_request req;
     req.dir_name = cold_backup::get_replica_backup_path(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
 
     add_ref();
 
@@ -407,7 +407,7 @@ void cold_backup_context::upload_checkpoint_to_remote()
 
     // check whether cold_backup_metadata is exist and verify cold_backup_metadata if exist
     std::string metadata = cold_backup::get_remote_chkpt_meta_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = metadata;
     req.ignore_metadata = false;
@@ -631,7 +631,7 @@ void cold_backup_context::prepare_upload()
 void cold_backup_context::upload_file(const std::string &local_filename)
 {
     std::string remote_chkpt_dir = cold_backup::get_remote_chkpt_dir(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = ::dsn::utils::filesystem::path_combine(remote_chkpt_dir, local_filename);
     req.ignore_metadata = false;
@@ -784,7 +784,7 @@ void cold_backup_context::write_backup_metadata()
         return;
     }
     std::string metadata = cold_backup::get_remote_chkpt_meta_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = metadata;
     req.ignore_metadata = true;
@@ -867,7 +867,7 @@ void cold_backup_context::write_current_chkpt_file(const std::string &value)
     }
 
     std::string current_chkpt_file = cold_backup::get_current_chkpt_file(
-        backup_root, request.policy.policy_name, request.app_name, request.pid, request.backup_id);
+        backup_root, request.app_name, request.pid, request.backup_id);
     dist::block_service::create_file_request req;
     req.file_name = current_chkpt_file;
     req.ignore_metadata = true;

--- a/src/replica/backup/replica_backup_manager.cpp
+++ b/src/replica/backup/replica_backup_manager.cpp
@@ -69,10 +69,7 @@ void replica_backup_manager::on_clear_cold_backup(const backup_clear_request &re
                 backup_context->name);
             tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
                              &_replica->_tracker,
-                             [this, request]() {
-                                 backup_response response;
-                                 on_clear_cold_backup(request);
-                             },
+                             [this, request]() { on_clear_cold_backup(request); },
                              get_gpid().thread_hash(),
                              std::chrono::seconds(100));
             return;

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -218,10 +218,7 @@ void replica::clear_restore_useless_files(const std::string &local_chkpt_dir,
 dsn::error_code replica::find_valid_checkpoint(const configuration_restore_request &req,
                                                std::string &remote_chkpt_dir)
 {
-    ddebug_f("{}: start to find valid checkpoint of app {}, backup_id {}",
-             name(),
-             req.app_id,
-             req.time_stamp);
+    ddebug_f("{}: start to find valid checkpoint of backup_id {}", name(), req.time_stamp);
 
     // we should base on old gpid to combine the path on cold backup media
     dsn::gpid old_gpid;

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -218,21 +218,23 @@ void replica::clear_restore_useless_files(const std::string &local_chkpt_dir,
 dsn::error_code replica::find_valid_checkpoint(const configuration_restore_request &req,
                                                std::string &remote_chkpt_dir)
 {
-    const std::string &backup_root = req.cluster_name;
-    const std::string &policy_name = req.policy_name;
-    const int64_t &backup_id = req.time_stamp;
-    ddebug("%s: retore from policy_name(%s), backup_id(%lld)",
-           name(),
-           req.policy_name.c_str(),
-           req.time_stamp);
+    ddebug_f("{}: start to find valid checkpoint of app {}, backup_id {}",
+             name(),
+             req.app_id,
+             req.time_stamp);
 
     // we should base on old gpid to combine the path on cold backup media
     dsn::gpid old_gpid;
     old_gpid.set_app_id(req.app_id);
     old_gpid.set_partition_index(_config.pid.get_partition_index());
+    std::string backup_root = req.cluster_name;
+    if (!req.policy_name.empty()) {
+        backup_root += ("/" + req.policy_name);
+    }
+    int64_t backup_id = req.time_stamp;
 
-    std::string manifest_file = cold_backup::get_current_chkpt_file(
-        backup_root, policy_name, req.app_name, old_gpid, backup_id);
+    std::string manifest_file =
+        cold_backup::get_current_chkpt_file(backup_root, req.app_name, old_gpid, backup_id);
     block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(req.backup_provider_name);
     if (fs == nullptr) {
@@ -251,9 +253,9 @@ dsn::error_code replica::find_valid_checkpoint(const configuration_restore_reque
         ->wait();
 
     if (create_response.err != dsn::ERR_OK) {
-        derror("%s: create file of block_service failed, reason(%s)",
-               name(),
-               create_response.err.to_string());
+        derror_f("{}: create file of block_service failed, reason {}",
+                 name(),
+                 create_response.err.to_string());
         return create_response.err;
     }
 
@@ -267,18 +269,17 @@ dsn::error_code replica::find_valid_checkpoint(const configuration_restore_reque
         ->wait();
 
     if (r.err != dsn::ERR_OK) {
-        derror("%s: read file %s failed, reason(%s)",
-               name(),
-               create_response.file_handle->file_name().c_str(),
-               r.err.to_string());
+        derror_f("{}: read file {} failed, reason {}",
+                 name(),
+                 create_response.file_handle->file_name(),
+                 r.err.to_string());
         return r.err;
     }
 
     std::string valid_chkpt_entry(r.buffer.data(), r.buffer.length());
-    ddebug("%s: get a valid chkpt(%s)", name(), valid_chkpt_entry.c_str());
+    ddebug_f("{}: got a valid chkpt {}", name(), valid_chkpt_entry);
     remote_chkpt_dir = ::dsn::utils::filesystem::path_combine(
-        cold_backup::get_replica_backup_path(
-            backup_root, policy_name, req.app_name, old_gpid, backup_id),
+        cold_backup::get_replica_backup_path(backup_root, req.app_name, old_gpid, backup_id),
         valid_chkpt_entry);
     return dsn::ERR_OK;
 }
@@ -330,19 +331,25 @@ dsn::error_code replica::restore_checkpoint()
         skip_bad_partition = true;
     }
 
+    ddebug_f("{}: restore checkpoint(policy_name {}, backup_id {}) from {} to local dir {}",
+             name(),
+             restore_req.policy_name,
+             restore_req.time_stamp,
+             restore_req.backup_provider_name,
+             _dir);
+
     // then create a local restore dir if it doesn't exist
     if (!utils::filesystem::directory_exists(_dir) && !utils::filesystem::create_directory(_dir)) {
         derror("create dir %s failed", _dir.c_str());
         return ERR_FILE_OPERATION_FAILED;
     }
 
-    // we don't remove the old restore.policy_name.backup_id
     std::ostringstream os;
     os << _dir << "/restore." << restore_req.policy_name << "." << restore_req.time_stamp;
     std::string restore_dir = os.str();
     if (!utils::filesystem::directory_exists(restore_dir) &&
         !utils::filesystem::create_directory(restore_dir)) {
-        derror("create dir %s failed", restore_dir.c_str());
+        derror_f("create restore dir {} failed", restore_dir);
         return ERR_FILE_OPERATION_FAILED;
     }
 

--- a/src/replica/test/cold_backup_context_test.cpp
+++ b/src/replica/test/cold_backup_context_test.cpp
@@ -125,7 +125,7 @@ void replication_service_test_app::remote_chkpt_dir_exist_test()
         current_chkpt_file->set_context(dir_name);
 
         std::string parent_dir = cold_backup::get_replica_backup_path(
-            backup_root, mock_policy_info.policy_name, mock_app_name, mock_gpid, mock_backup_id);
+            backup_root, mock_app_name, mock_gpid, mock_backup_id);
 
         std::vector<ls_entry> entries;
         entries.emplace_back(ls_entry{std::string(dir_name), true});


### PR DESCRIPTION
This patch remove `policy_name` from backup files' path.
If we want to restore apps which is backed up in this new way, we don't need to use `-p` to specify the `policy_name`. If we want to restore old apps, we could also use `-p`.

I have tested this using onebox cluster, backup and restore some apps, all works well.