### PR TITLE
feat: add http interface to get a specified config

### DIFF
--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -109,4 +109,7 @@ extern error_s update_flag(const std::string &name, const std::string &val);
 
 // determine if the tag is exist for the specified flag
 extern bool has_tag(const std::string &name, const flag_tag &tag);
+
+// get the json string of a specified flag
+extern error_with<std::string> get_flag_str(const std::string &flag_name);
 } // namespace dsn

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -80,7 +80,7 @@ namespace dsn {
 
     register_http_call("config")
         .with_callback([](const http_request &req, http_response &resp) { get_config(req, resp); })
-        .with_help("get the value of a config");
+        .with_help("get the details of a config");
 
     register_http_call("configs")
         .with_callback(

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -77,6 +77,10 @@ namespace dsn {
         .with_callback(
             [](const http_request &req, http_response &resp) { update_config(req, resp); })
         .with_help("Updates the value of a config");
+
+    register_http_call("config")
+        .with_callback([](const http_request &req, http_response &resp) { get_config(req, resp); })
+        .with_help("get the value of a config");
 }
 
 } // namespace dsn

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -80,7 +80,7 @@ namespace dsn {
 
     register_http_call("config")
         .with_callback([](const http_request &req, http_response &resp) { get_config(req, resp); })
-        .with_help("get the details of a config");
+        .with_help("get the details of a specified config");
 
     register_http_call("configs")
         .with_callback(

--- a/src/http/builtin_http_calls.h
+++ b/src/http/builtin_http_calls.h
@@ -34,4 +34,5 @@ extern void get_recent_start_time_handler(const http_request &req, http_response
 
 extern void update_config(const http_request &req, http_response &resp);
 
+extern void get_config(const http_request &req, http_response &resp);
 } // namespace dsn

--- a/src/http/config_http_service.cpp
+++ b/src/http/config_http_service.cpp
@@ -49,7 +49,8 @@ void list_all_configs(const http_request &req, http_response &resp)
     resp.status_code = http_status_code::ok;
 }
 
-void get_config(const http_request &req, http_response &resp) {
+void get_config(const http_request &req, http_response &resp)
+{
     std::string config_name;
     for (const auto &p : req.query_args) {
         if ("name" == p.first) {

--- a/src/http/config_http_service.cpp
+++ b/src/http/config_http_service.cpp
@@ -37,4 +37,25 @@ void update_config(const http_request &req, http_response &resp)
     resp.body = out.str();
     resp.status_code = http_status_code::ok;
 }
+
+void get_config(const http_request &req, http_response &resp)
+{
+    std::string config_name;
+    for (const auto &p : req.query_args) {
+        if ("name" == p.first) {
+            config_name = p.second;
+        } else {
+            resp.status_code = http_status_code::bad_request;
+            return;
+        }
+    }
+
+    auto res = get_flag_str(config_name);
+    if (res.is_ok()) {
+        resp.body = res.get_value();
+    } else {
+        resp.body = res.get_error().description();
+    }
+    resp.status_code = http_status_code::ok;
+}
 } // namespace dsn

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -160,6 +160,16 @@ public:
         return it->second.has_tag(tag);
     }
 
+    error_with<std::string> get_flag_str(const std::string &name) const
+    {
+        const auto iter = _flags.find(name);
+        if (iter == _flags.end()) {
+            return error_s::make(ERR_OBJECT_NOT_FOUND, fmt::format("{} is not found", name));
+        }
+
+        return iter->second.to_json();
+    }
+
 private:
     friend class utils::singleton<flag_registry>;
     flag_registry() = default;
@@ -205,4 +215,8 @@ flag_tagger::flag_tagger(const char *name, const flag_tag &tag)
     return flag_registry::instance().has_tag(name, tag);
 }
 
+/*extern*/ error_with<std::string> get_flag_str(const std::string &flag_name)
+{
+    return flag_registry::instance().get_flag_str(flag_name);
+}
 } // namespace dsn

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -215,7 +215,8 @@ public:
         return it->second.has_tag(tag);
     }
 
-    error_with<std::string> get_flag_str(const std::string &name) const {
+    error_with<std::string> get_flag_str(const std::string &name) const
+    {
         const auto iter = _flags.find(name);
         if (iter == _flags.end()) {
             return error_s::make(ERR_OBJECT_NOT_FOUND, fmt::format("{} is not found", name));

--- a/src/utils/test/flag_test.cpp
+++ b/src/utils/test/flag_test.cpp
@@ -120,5 +120,75 @@ TEST(flag_test, tag_flag)
     res = has_tag("no_flag", flag_tag::FT_MUTABLE);
     ASSERT_FALSE(res);
 }
+
+DSN_DEFINE_int32("flag_test", get_flag_int32, 5, "test get_flag_int32");
+DSN_TAG_VARIABLE(get_flag_int32, FT_MUTABLE);
+DSN_DEFINE_uint32("flag_test", get_flag_uint32, 5, "test get_flag_uint32");
+DSN_TAG_VARIABLE(get_flag_uint32, FT_MUTABLE);
+DSN_DEFINE_int64("flag_test", get_flag_int64, 5, "test get_flag_int64");
+DSN_TAG_VARIABLE(get_flag_int64, FT_MUTABLE);
+DSN_DEFINE_uint64("flag_test", get_flag_uint64, 5, "test get_flag_uint64");
+DSN_TAG_VARIABLE(get_flag_uint64, FT_MUTABLE);
+DSN_DEFINE_double("flag_test", get_flag_double, 5.12, "test get_flag_double");
+DSN_TAG_VARIABLE(get_flag_double, FT_MUTABLE);
+DSN_DEFINE_bool("flag_test", get_flag_bool, true, "test get_flag_bool");
+DSN_TAG_VARIABLE(get_flag_bool, FT_MUTABLE);
+DSN_DEFINE_string("flag_test", get_flag_string, "flag_string", "test get_flag_string");
+DSN_TAG_VARIABLE(get_flag_string, FT_MUTABLE);
+
+TEST(flag_test, get_config)
+{
+    auto res = get_flag_str("get_flag_not_exist");
+    ASSERT_EQ(res.get_error().code(), ERR_OBJECT_NOT_FOUND);
+
+    res = get_flag_str("get_flag_int32");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(
+        res.get_value(),
+        "{\"name\":\"get_flag_int32\",\"section\":\"flag_test\",\"type\":\"FV_INT32\",\"tags\":"
+        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_int32\",\"value\":\"5\"}\n");
+
+    res = get_flag_str("get_flag_uint32");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(
+        res.get_value(),
+        "{\"name\":\"get_flag_uint32\",\"section\":\"flag_test\",\"type\":\"FV_UINT32\",\"tags\":"
+        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_uint32\",\"value\":\"5\"}\n");
+
+    res = get_flag_str("get_flag_int64");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(
+        res.get_value(),
+        "{\"name\":\"get_flag_int64\",\"section\":\"flag_test\",\"type\":\"FV_INT64\",\"tags\":"
+        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_int64\",\"value\":\"5\"}\n");
+
+    res = get_flag_str("get_flag_uint64");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(
+        res.get_value(),
+        "{\"name\":\"get_flag_uint64\",\"section\":\"flag_test\",\"type\":\"FV_UINT64\",\"tags\":"
+        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_uint64\",\"value\":\"5\"}\n");
+
+    res = get_flag_str("get_flag_double");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(
+        res.get_value(),
+        "{\"name\":\"get_flag_double\",\"section\":\"flag_test\",\"type\":\"FV_DOUBLE\",\"tags\":"
+        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_double\",\"value\":\"5.12\"}\n");
+
+    res = get_flag_str("get_flag_bool");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(
+        res.get_value(),
+        "{\"name\":\"get_flag_bool\",\"section\":\"flag_test\",\"type\":\"FV_BOOL\",\"tags\":"
+        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_bool\",\"value\":\"true\"}\n");
+
+    res = get_flag_str("get_flag_string");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(res.get_value(),
+              "{\"name\":\"get_flag_string\",\"section\":\"flag_test\",\"type\":\"FV_STRING\","
+              "\"tags\":\"flag_tag::FT_MUTABLE\",\"description\":\"test "
+              "get_flag_string\",\"value\":\"flag_string\"}\n");
+}
 } // namespace utils
 } // namespace dsn

--- a/src/utils/test/flag_test.cpp
+++ b/src/utils/test/flag_test.cpp
@@ -141,54 +141,68 @@ TEST(flag_test, get_config)
     auto res = get_flag_str("get_flag_not_exist");
     ASSERT_EQ(res.get_error().code(), ERR_OBJECT_NOT_FOUND);
 
-    res = get_flag_str("get_flag_int32");
+    std::string test_app = "get_flag_int32";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(
         res.get_value(),
-        "{\"name\":\"get_flag_int32\",\"section\":\"flag_test\",\"type\":\"FV_INT32\",\"tags\":"
-        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_int32\",\"value\":\"5\"}\n");
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_INT32","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_int32","value":")" +
+            std::to_string(FLAGS_get_flag_int32) + R"("})" + "\n");
 
-    res = get_flag_str("get_flag_uint32");
+    test_app = "get_flag_uint32";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(
         res.get_value(),
-        "{\"name\":\"get_flag_uint32\",\"section\":\"flag_test\",\"type\":\"FV_UINT32\",\"tags\":"
-        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_uint32\",\"value\":\"5\"}\n");
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_UINT32","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_uint32","value":")" +
+            std::to_string(FLAGS_get_flag_uint32) + R"("})" + "\n");
 
-    res = get_flag_str("get_flag_int64");
+    test_app = "get_flag_int64";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(
         res.get_value(),
-        "{\"name\":\"get_flag_int64\",\"section\":\"flag_test\",\"type\":\"FV_INT64\",\"tags\":"
-        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_int64\",\"value\":\"5\"}\n");
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_INT64","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_int64","value":")" +
+            std::to_string(FLAGS_get_flag_int64) + R"("})" + "\n");
 
-    res = get_flag_str("get_flag_uint64");
+    test_app = "get_flag_uint64";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(
         res.get_value(),
-        "{\"name\":\"get_flag_uint64\",\"section\":\"flag_test\",\"type\":\"FV_UINT64\",\"tags\":"
-        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_uint64\",\"value\":\"5\"}\n");
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_UINT64","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_uint64","value":")" +
+            std::to_string(FLAGS_get_flag_uint64) + R"("})" + "\n");
 
-    res = get_flag_str("get_flag_double");
+    test_app = "get_flag_double";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(
         res.get_value(),
-        "{\"name\":\"get_flag_double\",\"section\":\"flag_test\",\"type\":\"FV_DOUBLE\",\"tags\":"
-        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_double\",\"value\":\"5.12\"}\n");
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_DOUBLE","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_double","value":"5.12"})" +
+            "\n");
 
-    res = get_flag_str("get_flag_bool");
+    test_app = "get_flag_bool";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(
         res.get_value(),
-        "{\"name\":\"get_flag_bool\",\"section\":\"flag_test\",\"type\":\"FV_BOOL\",\"tags\":"
-        "\"flag_tag::FT_MUTABLE\",\"description\":\"test get_flag_bool\",\"value\":\"true\"}\n");
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_BOOL","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_bool","value":"true"})"
+            "\n");
 
-    res = get_flag_str("get_flag_string");
+    test_app = "get_flag_string";
+    res = get_flag_str(test_app);
     ASSERT_TRUE(res.is_ok());
-    ASSERT_EQ(res.get_value(),
-              "{\"name\":\"get_flag_string\",\"section\":\"flag_test\",\"type\":\"FV_STRING\","
-              "\"tags\":\"flag_tag::FT_MUTABLE\",\"description\":\"test "
-              "get_flag_string\",\"value\":\"flag_string\"}\n");
+    ASSERT_EQ(
+        res.get_value(),
+        R"({"name":")" + test_app +
+            R"(","section":"flag_test","type":"FV_STRING","tags":"flag_tag::FT_MUTABLE","description":"test get_flag_string","value":")" +
+            FLAGS_get_flag_string + R"("})" + "\n");
 }
 } // namespace utils
 } // namespace dsn


### PR DESCRIPTION
add http interface to get a specified config

***TEST***

request:
```http://localhost:34801/config?name=abnormal_write_trace_latency_threshold```

response: 
```
{"name":"abnormal_write_trace_latency_threshold","section":"replication","type":"FV_UINT64","tags":"","description":"latency trace will be logged when exceed the write latency threshold","value":"1000000000"}
```