### PR TITLE
feat: add read limiter for hdfs

### DIFF
--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -43,7 +43,7 @@ DSN_DEFINE_uint64("replication",
                   "hdfs read batch size, the default value is 64MB");
 DSN_TAG_VARIABLE(hdfs_read_batch_size_bytes, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", hdfs_read_limit_rate, 100, "hdfs read limit(MB/s)");
+DSN_DEFINE_uint32("replication", hdfs_read_limit_rate, 200, "hdfs read limit(MB/s)");
 DSN_TAG_VARIABLE(hdfs_read_limit_rate, FT_MUTABLE);
 
 DSN_DEFINE_uint64("replication",

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -28,6 +28,7 @@
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/flags.h>
 #include <dsn/utility/safe_strerror_posix.h>
+#include <dsn/utility/TokenBucket.h>
 #include <dsn/utility/utils.h>
 
 namespace dsn {
@@ -42,13 +43,16 @@ DSN_DEFINE_uint64("replication",
                   "hdfs read batch size, the default value is 64MB");
 DSN_TAG_VARIABLE(hdfs_read_batch_size_bytes, FT_MUTABLE);
 
+DSN_DEFINE_uint32("replication", hdfs_read_limit_rate, 100, "hdfs read limit(MB/s)");
+DSN_TAG_VARIABLE(hdfs_read_limit_rate, FT_MUTABLE);
+
 DSN_DEFINE_uint64("replication",
                   hdfs_write_batch_size_bytes,
                   64 << 20,
                   "hdfs write batch size, the default value is 64MB");
 DSN_TAG_VARIABLE(hdfs_write_batch_size_bytes, FT_MUTABLE);
 
-hdfs_service::hdfs_service() {}
+hdfs_service::hdfs_service() { _read_token_bucket.reset(new folly::DynamicTokenBucket()); }
 
 hdfs_service::~hdfs_service()
 {
@@ -386,7 +390,10 @@ error_code hdfs_file_object::read_data_in_batches(uint64_t start_pos,
     uint64_t read_size = 0;
     bool read_success = true;
     while (cur_pos < start_pos + data_length) {
+        auto rate = FLAGS_hdfs_read_limit_rate << 20;
         read_size = std::min(start_pos + data_length - cur_pos, FLAGS_hdfs_read_batch_size_bytes);
+        _service->_read_token_bucket->consumeWithBorrowAndWait(read_size, rate, 2 * rate);
+
         tSize num_read_bytes = hdfsPread(_service->get_fs(),
                                          read_file,
                                          static_cast<tOffset>(cur_pos),

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -43,8 +43,8 @@ DSN_DEFINE_uint64("replication",
                   "hdfs read batch size, the default value is 64MB");
 DSN_TAG_VARIABLE(hdfs_read_batch_size_bytes, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", hdfs_read_limit_rate, 200, "hdfs read limit(MB/s)");
-DSN_TAG_VARIABLE(hdfs_read_limit_rate, FT_MUTABLE);
+DSN_DEFINE_uint32("replication", hdfs_read_limit_rate_megabytes, 200, "hdfs read limit(MB/s)");
+DSN_TAG_VARIABLE(hdfs_read_limit_rate_megabytes, FT_MUTABLE);
 
 DSN_DEFINE_uint64("replication",
                   hdfs_write_batch_size_bytes,
@@ -390,7 +390,7 @@ error_code hdfs_file_object::read_data_in_batches(uint64_t start_pos,
     uint64_t read_size = 0;
     bool read_success = true;
     while (cur_pos < start_pos + data_length) {
-        const uint64_t rate = FLAGS_hdfs_read_limit_rate << 20;
+        const uint64_t rate = FLAGS_hdfs_read_limit_rate_megabytes << 20;
         read_size = std::min(start_pos + data_length - cur_pos, FLAGS_hdfs_read_batch_size_bytes);
         // burst size should not be less than consume size
         _service->_read_token_bucket->consumeWithBorrowAndWait(

--- a/src/block_service/hdfs/hdfs_service.h
+++ b/src/block_service/hdfs/hdfs_service.h
@@ -61,6 +61,7 @@ private:
     std::string _hdfs_path;
 
     std::unique_ptr<folly::DynamicTokenBucket> _read_token_bucket;
+    // TODO: add write limiter
 
     friend class hdfs_file_object;
 };

--- a/src/block_service/hdfs/hdfs_service.h
+++ b/src/block_service/hdfs/hdfs_service.h
@@ -20,6 +20,13 @@
 #include <dsn/dist/block_service.h>
 #include <hdfs/hdfs.h>
 
+namespace folly {
+template <typename Clock>
+class BasicDynamicTokenBucket;
+
+using DynamicTokenBucket = BasicDynamicTokenBucket<std::chrono::steady_clock>;
+}
+
 namespace dsn {
 namespace dist {
 namespace block_service {
@@ -52,6 +59,10 @@ private:
     hdfsFS _fs;
     std::string _hdfs_name_node;
     std::string _hdfs_path;
+
+    std::unique_ptr<folly::DynamicTokenBucket> _read_token_bucket;
+
+    friend class hdfs_file_object;
 };
 
 class hdfs_file_object : public block_file


### PR DESCRIPTION
### What this pr solves
This pull request adds folly read limiter for hdfs, different from fds implementation, this pr uses `BasicDynamicTokenBucket` provided by folly to make it thread-safe to update limiter size dynamically.

### Test
- Unit test
- Manual test
I depoly one server supporting limiter(100M), the rest servers don't support limiter executing bulk load from hdfs, the result like the graph shows:
![image](https://user-images.githubusercontent.com/17868458/103748504-335fa500-503f-11eb-9aae-6b04e87e0265.png)
I also update limiter size dynamically: 100M -> 200M -> 50M
![image](https://user-images.githubusercontent.com/17868458/103752084-34470580-5044-11eb-9399-fba71c3eaa49.png)

### Config changed
```diff
+ [replication]
+ hdfs_read_limit_rate_megabytes = 200
```