### PR TITLE
refactor: don't resend message if it is rejected by server

### DIFF
--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -82,7 +82,7 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
                                  std::chrono::milliseconds(gap));
                 return;
             } else {
-                ddebug("service access failed (%s), no more time for further "
+                derror("service access failed (%s), no more time for further "
                        "tries, set error = ERR_TIMEOUT, trace_id = %016" PRIx64,
                        err.to_string(),
                        req->header->trace_id);

--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -82,10 +82,10 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
                                  std::chrono::milliseconds(gap));
                 return;
             } else {
-                derror("service access failed (%s), no more time for further "
-                       "tries, set error = ERR_TIMEOUT, trace_id = %016" PRIx64,
-                       err.to_string(),
-                       req->header->trace_id);
+                dinfo("service access failed (%s), no more time for further "
+                      "tries, set error = ERR_TIMEOUT, trace_id = %016" PRIx64,
+                      err.to_string(),
+                      req->header->trace_id);
                 err = ERR_TIMEOUT;
             }
         }

--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -49,8 +49,9 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
 
     rpc_response_handler old_callback;
     t->fetch_current_handler(old_callback);
-    auto new_callback = [this, deadline_ms, oc = std::move(old_callback)](
-                            dsn::error_code err, dsn::message_ex *req, dsn::message_ex *resp) {
+    auto new_callback = [ this, deadline_ms, oc = std::move(old_callback) ](
+        dsn::error_code err, dsn::message_ex * req, dsn::message_ex * resp)
+    {
         if (req->header->gpid.value() != 0 && err != ERR_OK && err != ERR_HANDLER_NOT_FOUND &&
             err != ERR_APP_NOT_EXIST && err != ERR_OPERATION_DISABLED && err != ERR_BUSY) {
             on_access_failure(req->header->gpid.get_partition_index(), err);

--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -53,7 +53,7 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
         dsn::error_code err, dsn::message_ex * req, dsn::message_ex * resp)
     {
         if (req->header->gpid.value() != 0 && err != ERR_OK && err != ERR_HANDLER_NOT_FOUND &&
-            err != ERR_APP_NOT_EXIST && err != ERR_OPERATION_DISABLED) {
+            err != ERR_APP_NOT_EXIST && err != ERR_OPERATION_DISABLED && err != ERR_BUSY) {
             on_access_failure(req->header->gpid.get_partition_index(), err);
             // still got time, retry
             uint64_t nms = dsn_now_ms();
@@ -82,10 +82,10 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
                                  std::chrono::milliseconds(gap));
                 return;
             } else {
-                dinfo("service access failed (%s), no more time for further "
-                      "tries, set error = ERR_TIMEOUT, trace_id = %016" PRIx64,
-                      err.to_string(),
-                      req->header->trace_id);
+                ddebug("service access failed (%s), no more time for further "
+                       "tries, set error = ERR_TIMEOUT, trace_id = %016" PRIx64,
+                       err.to_string(),
+                       req->header->trace_id);
                 err = ERR_TIMEOUT;
             }
         }

--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -49,9 +49,8 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
 
     rpc_response_handler old_callback;
     t->fetch_current_handler(old_callback);
-    auto new_callback = [ this, deadline_ms, oc = std::move(old_callback) ](
-        dsn::error_code err, dsn::message_ex * req, dsn::message_ex * resp)
-    {
+    auto new_callback = [this, deadline_ms, oc = std::move(old_callback)](
+                            dsn::error_code err, dsn::message_ex *req, dsn::message_ex *resp) {
         if (req->header->gpid.value() != 0 && err != ERR_OK && err != ERR_HANDLER_NOT_FOUND &&
             err != ERR_APP_NOT_EXIST && err != ERR_OPERATION_DISABLED && err != ERR_BUSY) {
             on_access_failure(req->header->gpid.get_partition_index(), err);

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -54,7 +54,8 @@ DSN_DEFINE_string("replication", cluster_name, "", "name of this cluster");
     return it->second;
 }
 
-/*extern*/ const char *get_current_cluster_name() {
+/*extern*/ const char *get_current_cluster_name()
+{
     dassert(strlen(FLAGS_cluster_name) != 0, "cluster_name is not set");
     return FLAGS_cluster_name;
 }

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -35,8 +35,6 @@
 namespace dsn {
 namespace replication {
 DSN_DEFINE_string("replication", cluster_name, "", "name of this cluster");
-DSN_DEFINE_validator(cluster_name,
-                     [](const char *cluster_name) -> bool { return strlen(cluster_name) != 0; });
 
 /*extern*/ const char *duplication_status_to_string(duplication_status::type status)
 {
@@ -56,8 +54,10 @@ DSN_DEFINE_validator(cluster_name,
     return it->second;
 }
 
-
-/*extern*/ const char *get_current_cluster_name() { return FLAGS_cluster_name; }
+/*extern*/ const char *get_current_cluster_name() {
+    dassert(strlen(FLAGS_cluster_name) != 0, "cluster_name is not set");
+    return FLAGS_cluster_name;
+}
 
 namespace internal {
 

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -30,9 +30,13 @@
 #include <dsn/utility/singleton.h>
 #include <dsn/utils/time_utils.h>
 #include <nlohmann/json.hpp>
+#include <dsn/utility/flags.h>
 
 namespace dsn {
 namespace replication {
+DSN_DEFINE_string("replication", cluster_name, "", "name of this cluster");
+DSN_DEFINE_validator(cluster_name,
+                     [](const char *cluster_name) -> bool { return strlen(cluster_name) != 0; });
 
 /*extern*/ const char *duplication_status_to_string(duplication_status::type status)
 {
@@ -52,13 +56,8 @@ namespace replication {
     return it->second;
 }
 
-/*extern*/ const char *get_current_cluster_name()
-{
-    static const char *cluster_name =
-        dsn_config_get_value_string("replication", "cluster_name", "", "name of this cluster");
-    dassert(strlen(cluster_name) != 0, "cluster_name is not set");
-    return cluster_name;
-}
+
+/*extern*/ const char *get_current_cluster_name() { return FLAGS_cluster_name; }
 
 namespace internal {
 


### PR DESCRIPTION
1. Don't resend message if it is rejected by server.  because it means that the server is overload if it reject this message. So if we resend the message, it will makes the situation even worse.
2. use cflags to define cluster_name. But we can't use flag validator, because cpp client will not set cluster name. so the validator will always fail for it