### PR TITLE
fix(split): message header should not be empty struct

### DIFF
--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -172,7 +172,7 @@ message_ex *message_ex::copy_message_no_reply(const message_ex &old_msg)
         static_cast<char *>(dsn::tls_trans_malloc(sizeof(message_header))),
         [](char *c) { dsn::tls_trans_free(c); });
     msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    msg->header = {}; // initialize to empty struct
+    memset(static_cast<void *>(msg->header), 0, sizeof(message_header));
     msg->buffers.emplace_back(blob(std::move(header_holder), sizeof(message_header)));
 
     if (old_msg.buffers.size() == 1) {


### PR DESCRIPTION
Function `copy_message_no_reply` will be used during partition split when child copy parent's mutation, its header should not be an empty structure.