### PR TITLE
fix(split): add flush_memtable for copy_checkpoint_to_dir

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -197,7 +197,8 @@ public:
     // must be thread safe
     //
     virtual ::dsn::error_code copy_checkpoint_to_dir(const char *checkpoint_dir,
-                                                     /*output*/ int64_t *last_decree) = 0;
+                                                     /*output*/ int64_t *last_decree,
+                                                     bool flush_memtable = false) = 0;
 
     //
     // Query methods.

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -174,7 +174,7 @@ void replica_split_manager::parent_prepare_states(const std::string &dir) // on 
     learn_state parent_states;
     int64_t checkpoint_decree;
     // generate checkpoint
-    error_code ec = _replica->_app->copy_checkpoint_to_dir(dir.c_str(), &checkpoint_decree);
+    error_code ec = _replica->_app->copy_checkpoint_to_dir(dir.c_str(), &checkpoint_decree, true);
     if (ec == ERR_OK) {
         ddebug_replica("prepare checkpoint succeed: checkpoint dir = {}, checkpoint decree = {}",
                        dir,
@@ -206,8 +206,8 @@ void replica_split_manager::parent_prepare_states(const std::string &dir) // on 
     plist->truncate(last_committed_decree());
 
     dcheck_eq(last_committed_decree(), checkpoint_decree);
-    dcheck_gt(mutation_list.size(), 0);
-    dcheck_gt(files.size(), 0);
+    dcheck_ge(mutation_list.size(), 0);
+    dcheck_ge(files.size(), 0);
     ddebug_replica("prepare state succeed: {} mutations, {} private log files, total file size = "
                    "{}, last_committed_decree = {}",
                    mutation_list.size(),

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.h
@@ -70,7 +70,8 @@ public:
     virtual ::dsn::error_code async_checkpoint(bool flush_memtable) override;
 
     virtual ::dsn::error_code copy_checkpoint_to_dir(const char *checkpoint_dir,
-                                                     int64_t *last_decree) override
+                                                     int64_t *last_decree,
+                                                     bool flush_memtable = false) override
     {
         return ERR_NOT_IMPLEMENTED;
     }

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
@@ -72,7 +72,8 @@ public:
     virtual ::dsn::error_code async_checkpoint(bool flush_memtable) override;
 
     virtual ::dsn::error_code copy_checkpoint_to_dir(const char *checkpoint_dir,
-                                                     int64_t *last_decree) override
+                                                     int64_t *last_decree,
+                                                     bool flush_memtable = false) override
     {
         return ERR_NOT_IMPLEMENTED;
     }

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -56,7 +56,8 @@ public:
         return ERR_OK;
     }
     error_code copy_checkpoint_to_dir(const char *checkpoint_dir,
-                                      /*output*/ int64_t *last_decree) override
+                                      /*output*/ int64_t *last_decree,
+                                      bool flush_memtable = false) override
     {
         if (last_decree != nullptr) {
             *last_decree = _decree;


### PR DESCRIPTION
In pegasus pr [535](https://github.com/apache/incubator-pegasus/pull/535), we use rocksdb's original API CreateCheckpoint to do checkpoint. In function `copy_checkpoint_to_dir_unsafe`, it will create a checkpoint without flush memtable, code like below:
```
// CreateCheckpoint() will not flush memtable when log_size_for_flush = max
status = chkpt->CreateCheckpoint(checkpoint_dir, std::numeric_limits<uint64_t>::max());
```
When parent partition prepare states for child to learned, it should create a checkpoint with memtable flushed.  As a result, this checkpoint will contain more data, less data will be learned during async-learn stage. 

This pull request adds `flush_memtable` option for function `copy_checkpoint_to_dir`, the pegasus implementation is in pegasus pr [684](https://github.com/apache/incubator-pegasus/pull/684).