### PR TITLE
fix(asan): several memory leaks in join_point

### DIFF
--- a/include/dsn/utility/join_point.h
+++ b/include/dsn/utility/join_point.h
@@ -43,6 +43,7 @@ class join_point_base
 {
 public:
     join_point_base(const char *name);
+    virtual ~join_point_base();
 
     bool put_front(void *fn, const char *name, bool is_native = false);
     bool put_back(void *fn, const char *name, bool is_native = false);
@@ -50,6 +51,7 @@ public:
     bool put_after(const char *base, void *fn, const char *name, bool is_native = false);
     bool remove(const char *name);
     bool put_replace(const char *base, void *fn, const char *name);
+    void remove_all();
 
     const char *name() const { return _name.c_str(); }
 

--- a/src/utils/join_point.cpp
+++ b/src/utils/join_point.cpp
@@ -45,6 +45,10 @@ join_point_base::join_point_base(const char *name)
     _hdr.name = "";
 }
 
+join_point_base::~join_point_base() {
+    remove_all();
+}
+
 bool join_point_base::put_front(void *fn, const char *name, bool is_native)
 {
     auto e = new_entry(fn, name, is_native);
@@ -133,7 +137,17 @@ bool join_point_base::remove(const char *name)
     e0->next->prev = e0->prev;
     e0->prev->next = e0->next;
 
+    delete e0;
     return true;
+}
+
+void join_point_base::remove_all() {
+    auto p = _hdr.next;
+    while (p != &_hdr) {
+        p = p->next;
+        delete p->prev;
+    }
+    _hdr.next = _hdr.prev = &_hdr;
 }
 
 join_point_base::advice_entry *

--- a/src/utils/join_point.cpp
+++ b/src/utils/join_point.cpp
@@ -45,9 +45,7 @@ join_point_base::join_point_base(const char *name)
     _hdr.name = "";
 }
 
-join_point_base::~join_point_base() {
-    remove_all();
-}
+join_point_base::~join_point_base() { remove_all(); }
 
 bool join_point_base::put_front(void *fn, const char *name, bool is_native)
 {
@@ -141,7 +139,8 @@ bool join_point_base::remove(const char *name)
     return true;
 }
 
-void join_point_base::remove_all() {
+void join_point_base::remove_all()
+{
     auto p = _hdr.next;
     while (p != &_hdr) {
         p = p->next;

--- a/src/utils/test/join_point.cpp
+++ b/src/utils/test/join_point.cpp
@@ -157,4 +157,12 @@ TEST(core, join_point)
         jp.get_all(jp_vec);
         ASSERT_EQ(check_vec, jp_vec);
     }
+
+    {
+        // []
+        check_vec.clear();
+        jp.remove_all();
+        jp.get_all(jp_vec);
+        ASSERT_EQ(check_vec, jp_vec);
+    }
 }


### PR DESCRIPTION
fix several memory leaks in join_point:
1. entry is not deleted in join_point::remove
2. all the entries are not deleted when the join_point is destructed