### PR TITLE
fix(asan):  heap-use-after-free caused by replica_test_base::create_test_mutation

### DIFF
--- a/src/replica/test/log_block_test.cpp
+++ b/src/replica/test/log_block_test.cpp
@@ -132,7 +132,6 @@ TEST_F(log_appender_test, read_log_block)
         ASSERT_GT(appender.all_blocks().size(), block_idx);
         ASSERT_GE(reader.get_remaining_size(), sizeof(log_block_header));
         reader.read(tmp_bb, sizeof(log_block_header));
-        
 
         const auto &expected_block = appender.all_blocks()[block_idx];
         size_t blk_len = expected_block.size() - sizeof(log_block_header);

--- a/src/replica/test/log_block_test.cpp
+++ b/src/replica/test/log_block_test.cpp
@@ -132,6 +132,7 @@ TEST_F(log_appender_test, read_log_block)
         ASSERT_GT(appender.all_blocks().size(), block_idx);
         ASSERT_GE(reader.get_remaining_size(), sizeof(log_block_header));
         reader.read(tmp_bb, sizeof(log_block_header));
+        
 
         const auto &expected_block = appender.all_blocks()[block_idx];
         size_t blk_len = expected_block.size() - sizeof(log_block_header);

--- a/src/replica/test/replica_test_base.h
+++ b/src/replica/test/replica_test_base.h
@@ -68,7 +68,9 @@ struct replica_test_base : replica_stub_test_base
         mu->data.updates.emplace_back(mutation_update());
         mu->data.updates.back().code =
             RPC_COLD_BACKUP; // whatever code it is, but never be WRITE_EMPTY
-        mu->data.updates.back().data.assign(data.data(), 0, data.length());
+        std::shared_ptr<char> ptr(dsn::utils::make_shared_array<char>(data.length()));
+        memcpy(ptr.get(), data.data(), data.length());
+        mu->data.updates.back().data.assign(ptr, 0, data.length());
         mu->client_requests.push_back(nullptr);
 
         // replica_duplicator always loads from hard disk,

--- a/src/replica/test/replica_test_base.h
+++ b/src/replica/test/replica_test_base.h
@@ -68,9 +68,7 @@ struct replica_test_base : replica_stub_test_base
         mu->data.updates.emplace_back(mutation_update());
         mu->data.updates.back().code =
             RPC_COLD_BACKUP; // whatever code it is, but never be WRITE_EMPTY
-        std::shared_ptr<char> ptr(dsn::utils::make_shared_array<char>(data.length()));
-        memcpy(ptr.get(), data.data(), data.length());
-        mu->data.updates.back().data.assign(ptr, 0, data.length());
+        mu->data.updates.back().data = blob::create_from_bytes(std::string(data));
         mu->client_requests.push_back(nullptr);
 
         // replica_duplicator always loads from hard disk,


### PR DESCRIPTION
In function `create_test_mutation`, it uses `const std::string &data`as it's second param. And gets the pointer of data, reserving it. But the caller of `create_test_mutation` may release variable `data`. So the `mu` will reserves a wild pointer in this case. and the use of the reserved pointers will produce `heap-use-after-free` error.
