### PR TITLE
fix(perf_counter): remove static map from counter_info

### DIFF
--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -441,7 +441,7 @@ void profiler::install(service_spec &)
             "collect_call_count",
             collect_call_count,
             "whether to collect how many time this kind of tasks invoke each of other kinds tasks");
-        s_spec_profilers[i].call_counts = new std::atomic<int64_t>[s_task_code_max + 1];
+        s_spec_profilers[i].call_counts = new std::atomic<int64_t>[ s_task_code_max + 1 ];
         std::fill(s_spec_profilers[i].call_counts,
                   s_spec_profilers[i].call_counts + s_task_code_max + 1,
                   0);

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -65,8 +65,6 @@ std::unique_ptr<task_spec_profiler[]> s_spec_profilers;
 
 int s_task_code_max = 0;
 
-std::map<std::string, perf_counter_ptr_type> counter_info::pointer_type;
-
 counter_info *counter_info_ptr[] = {
     new counter_info({"queue.time", "qt"},
                      TASK_QUEUEING_TIME_NS,
@@ -443,7 +441,7 @@ void profiler::install(service_spec &)
             "collect_call_count",
             collect_call_count,
             "whether to collect how many time this kind of tasks invoke each of other kinds tasks");
-        s_spec_profilers[i].call_counts = new std::atomic<int64_t>[ s_task_code_max + 1 ];
+        s_spec_profilers[i].call_counts = new std::atomic<int64_t>[s_task_code_max + 1];
         std::fill(s_spec_profilers[i].call_counts,
                   s_spec_profilers[i].call_counts + s_task_code_max + 1,
                   0);

--- a/src/runtime/profiler_command.cpp
+++ b/src/runtime/profiler_command.cpp
@@ -77,11 +77,14 @@ static dsn_perf_counter_percentile_type_t find_percentail_type(const std::string
 
 static perf_counter_ptr_type find_counter_type(const std::string &name)
 {
-    auto it = counter_info::pointer_type.find(std::string(name));
-    if (it == counter_info::pointer_type.end()) {
-        return PERF_COUNTER_INVALID;
+    for (int k = 0; k < PERF_COUNTER_COUNT; k++) {
+        perf_counter_ptr_type counter_type = static_cast<perf_counter_ptr_type>(k);
+        const auto &keys = counter_info_ptr[counter_type]->keys;
+        if (std::find(keys.begin(), keys.end(), name) != keys.end()) {
+            return counter_info_ptr[counter_type]->counter_ptr_type;
+        }
     }
-    return it->second;
+    return PERF_COUNTER_INVALID;
 }
 
 std::string profiler_output_handler(const std::vector<std::string> &args)
@@ -377,8 +380,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                     if (s_spec_profilers[task_id].ptr[counter_type].get() == NULL)
                         continue;
 
-                    char name[20] = {0};
-                    strcpy(name, counter_info_ptr[counter_type]->title);
+                    std::string name = counter_info_ptr[counter_type]->title;
 
                     char name_suffix[10] = {0};
                     switch (task_spec::get(task_id)->type) {
@@ -393,7 +395,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                         break;
                     }
 
-                    resp.name = std::string(name) + std::string(name_suffix);
+                    resp.name = name + std::string(name_suffix);
 
                     // get samples
                     perf_counter::samples_t samples;
@@ -491,25 +493,25 @@ std::string query_data_handler(const std::vector<std::string> &args)
 
                     timeGet = ((timeGet < 0) ? 0 : timeGet);
 
-                    if (strcmp(counter_info_ptr[counter_type]->title, "RPC.SERVER(ns)") == 0 &&
+                    if (counter_info_ptr[counter_type]->title == "RPC.SERVER(ns)" &&
                         task_spec::get(task_id)->type == TASK_TYPE_RPC_REQUEST)
                         timeList[0] = timeGet;
-                    else if (strcmp(counter_info_ptr[counter_type]->title, "QUEUE(ns)") == 0 &&
+                    else if (counter_info_ptr[counter_type]->title == "QUEUE(ns)" &&
                              task_spec::get(task_id)->type == TASK_TYPE_RPC_REQUEST)
                         timeList[1] = timeGet;
-                    else if (strcmp(counter_info_ptr[counter_type]->title, "EXEC(ns)") == 0 &&
+                    else if (counter_info_ptr[counter_type]->title == "EXEC(ns)" &&
                              task_spec::get(task_id)->type == TASK_TYPE_RPC_REQUEST)
                         timeList[2] = timeGet;
-                    else if (strcmp(counter_info_ptr[counter_type]->title, "RPC.CLIENT(ns)") == 0 &&
+                    else if (counter_info_ptr[counter_type]->title == "RPC.CLIENT(ns)" &&
                              task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE)
                         timeList[3] = timeGet;
-                    else if (strcmp(counter_info_ptr[counter_type]->title, "QUEUE(ns)") == 0 &&
+                    else if (counter_info_ptr[counter_type]->title == "QUEUE(ns)" &&
                              task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE)
                         timeList[4] = timeGet;
-                    else if (strcmp(counter_info_ptr[counter_type]->title, "EXEC(ns)") == 0 &&
+                    else if (counter_info_ptr[counter_type]->title == "EXEC(ns)" &&
                              task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE)
                         timeList[5] = timeGet;
-                    else if (strcmp(counter_info_ptr[counter_type]->title, "AIO.LATENCY(ns)") == 0)
+                    else if (counter_info_ptr[counter_type]->title == "AIO.LATENCY(ns)")
                         timeList[6] = timeGet;
                 }
             }
@@ -554,8 +556,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                     if (s_spec_profilers[task_id].ptr[counter_type].get() == NULL)
                         continue;
 
-                    char name[20] = {0};
-                    strcpy(name, counter_info_ptr[counter_type]->title);
+                    std::string name = counter_info_ptr[counter_type]->title;
 
                     char name_suffix[10] = {0};
                     switch (task_spec::get(task_id)->type) {
@@ -573,7 +574,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                     uint64_t sample =
                         s_spec_profilers[task_id].ptr[counter_type]->get_latest_sample();
 
-                    data.push_back(nv_pair{std::string(name) + std::string(name_suffix), sample});
+                    data.push_back(nv_pair{name + std::string(name_suffix), sample});
                 }
             }
             if (task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE ||

--- a/src/runtime/profiler_command.cpp
+++ b/src/runtime/profiler_command.cpp
@@ -77,11 +77,10 @@ static dsn_perf_counter_percentile_type_t find_percentail_type(const std::string
 
 static perf_counter_ptr_type find_counter_type(const std::string &name)
 {
-    for (int k = 0; k < PERF_COUNTER_COUNT; k++) {
-        perf_counter_ptr_type counter_type = static_cast<perf_counter_ptr_type>(k);
-        const auto &keys = counter_info_ptr[counter_type]->keys;
+    for (int i = 0; i < PERF_COUNTER_COUNT; i++) {
+        const auto &keys = counter_info_ptr[i]->keys;
         if (std::find(keys.begin(), keys.end(), name) != keys.end()) {
-            return counter_info_ptr[counter_type]->counter_ptr_type;
+            return counter_info_ptr[i]->counter_ptr_type;
         }
     }
     return PERF_COUNTER_INVALID;

--- a/src/runtime/profiler_command.cpp
+++ b/src/runtime/profiler_command.cpp
@@ -379,7 +379,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                     if (s_spec_profilers[task_id].ptr[counter_type].get() == NULL)
                         continue;
 
-                    std::string name = counter_info_ptr[counter_type]->title;
+                    const std::string &name = counter_info_ptr[counter_type]->title;
 
                     char name_suffix[10] = {0};
                     switch (task_spec::get(task_id)->type) {
@@ -555,7 +555,7 @@ std::string query_data_handler(const std::vector<std::string> &args)
                     if (s_spec_profilers[task_id].ptr[counter_type].get() == NULL)
                         continue;
 
-                    std::string name = counter_info_ptr[counter_type]->title;
+                    const std::string &name = counter_info_ptr[counter_type]->title;
 
                     char name_suffix[10] = {0};
                     switch (task_spec::get(task_id)->type) {

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -59,28 +59,24 @@ enum perf_counter_ptr_type
 class counter_info
 {
 public:
-    counter_info(const std::vector<const char *> &command_keys,
-                 perf_counter_ptr_type _index,
-                 dsn_perf_counter_type_t _type,
-                 const char *_title,
-                 const char *_unit)
-        : type(_type), title(_title), unit_name(_unit)
+    counter_info(const std::vector<std::string> &command_keys,
+                 perf_counter_ptr_type ptr_type,
+                 dsn_perf_counter_type_t counter_type,
+                 const std::string &title,
+                 const std::string &unit)
+        : keys(command_keys),
+          counter_ptr_type(ptr_type),
+          type(counter_type),
+          title(title),
+          unit_name(unit)
     {
-        for (auto key : command_keys) {
-            if (key != nullptr) {
-                keys.push_back(key);
-                auto it = pointer_type.find(std::string(key));
-                dassert(it == pointer_type.end(), "command '%s' already regisered", key);
-                pointer_type[std::string(key)] = _index;
-            }
-        }
     }
 
-    static std::map<std::string, perf_counter_ptr_type> pointer_type;
-    std::vector<const char *> keys;
+    std::vector<std::string> keys;
+    perf_counter_ptr_type counter_ptr_type;
     dsn_perf_counter_type_t type;
-    const char *title;
-    const char *unit_name;
+    std::string title;
+    std::string unit_name;
 };
 
 class profiler_output_data_type


### PR DESCRIPTION
In latest tests I found that pegasus server crashed when destroy a static map after called `exit()` in libc.so.6.
Coredump stack is:
```
(gdb) bt
#0  std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::tools::perf_counter_ptr_type>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::tools::perf_counter_ptr_type> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::tools::perf_counter_ptr_type> > >::_M_erase (this=this@entry=0x7f1ab9634cc0 <dsn::tools::counter_info::pointer_type[abi:cxx11]>, 
    __x=0x434548435f424452) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/bits/stl_tree.h:1612
#1  0x00007f1ab922f61c in std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::tools::perf_counter_ptr_type>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::tools::perf_counter_ptr_type> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, dsn::tools::perf_counter_ptr_type> > >::_M_erase (this=0x7f1ab9634cc0 <dsn::tools::counter_info::pointer_type[abi:cxx11]>, 
    __x=0x3236eb0) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/bits/stl_tree.h:1612
#2  0x00007f1ab4678dba in __cxa_finalize () from /lib64/libc.so.6
#3  0x00007f1ab85006f6 in __do_global_dtors_aux () from /home/work/app/pegasus/c4tst-hdfs/meta/package/bin/libdsn_meta_server.so
#4  0x00007f1aba771548 in ?? ()
#5  0x0000000000000001 in ?? ()
#6  0x00007f1a352e99f0 in ?? ()
```
To avoid this we should follow google style guide
> Objects with static storage duration are forbidden unless they are trivially destructible. [1]

I removed the static map from `counter_info`, and loop through the array `counter_info_ptr` to implement the method `find_counter_type`. Because we only had 11 elements(each element has two keys) in the array, this may not lead to much performance degradation.

[1] https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables