### PR TITLE
fix(hdfs): do not call hdfsDisconnect() after jvm exited

### DIFF
--- a/src/block_service/hdfs/hdfs_service.h
+++ b/src/block_service/hdfs/hdfs_service.h
@@ -52,6 +52,7 @@ public:
                               dsn::task_code code,
                               const remove_path_callback &cb,
                               dsn::task_tracker *tracker) override;
+    void close();
 
     static std::string get_hdfs_entry_name(const std::string &hdfs_path);
 


### PR DESCRIPTION
When we kill a pegasus progress, `vm_direct_exit(int)` was first called, after that we should not call `hdfsDisconnect()` which would try to gc jni objects.  So I removed `hdfsDisconnect()` from the destructor, this may lead connections leaked, but I couldn't find a safe way to call it when progress terminated.