### PR TITLE
fix(asan): heap-use-after-free in rpc_read_stream

### DIFF
--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -48,12 +48,13 @@ public:
     void set_read_msg(message_ex *msg)
     {
         _msg = msg;
+        if (nullptr != _msg) {
+            ::dsn::blob bb;
+            bool r = ((::dsn::message_ex *)_msg)->read_next(bb);
+            dassert(r, "read msg must have one segment of buffer ready");
 
-        ::dsn::blob bb;
-        bool r = ((::dsn::message_ex *)_msg)->read_next(bb);
-        dassert(r, "read msg must have one segment of buffer ready");
-
-        init(std::move(bb));
+            init(std::move(bb));
+        }
     }
 
     ~rpc_read_stream()

--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -111,6 +111,9 @@ static message_ex *create_message_from_request_blob(const blob &body_data)
     if (dsn_hdr->context.u.is_request != 1) {
         derror("invalid message type: %d", mtype);
         delete msg;
+        /// set set rpc_read_stream::_msg to nullptr,
+        /// to avoid the dstor to call read_commit of _msg, which is deleted here.
+        stream.set_read_msg(nullptr);
         return nullptr;
     }
     dsn_hdr->context.u.serialize_format = DSF_THRIFT_BINARY; // always serialize in thrift binary


### PR DESCRIPTION
fix heap-use-after-free in rpc_read_stream.

In src/runtime/rpc/thrift_message_parser.cpp L113, the message is deleted. And when the dstor of rpc_read_stream is called, it will call _msg->read_commit. So heap-use-after-free occured.


```
==30014==ERROR: AddressSanitizer: heap-use-after-free on address 0x60f0000c32c8 at pc 0x5605c96ac468 bp 0x7ff9f4fc66a0 sp 0x7ff9f4fc6690
READ of size 1 at 0x60f0000c32c8 thread T20 (client.THREAD_P)
    #0 0x5605c96ac467 in dsn::message_ex::read_commit(unsigned long) /home/mi/workspace/rdsn/src/runtime/rpc/rpc_message.cpp:505
    #1 0x5605c96c0242 in dsn::rpc_read_stream::~rpc_read_stream() /home/mi/workspace/rdsn/include/dsn/cpp/rpc_stream.h:62
    #2 0x5605c96c0242 in create_message_from_request_blob /home/mi/workspace/rdsn/src/runtime/rpc/thrift_message_parser.cpp:93
    #3 0x5605c96c1826 in dsn::thrift_message_parser::parse_request_body_v0(dsn::message_reader*, int&) /home/mi/workspace/rdsn/src/runtime/rpc/thrift_message_parser.cpp:199
    #4 0x5605c946f8e6 in dsn::thrift_message_parser_test::test_get_message_on_receive_v0_data(dsn::message_reader&, apache::thrift::protocol::TMessageType, bool) /home/mi/workspace/rdsn/src/runtime/test/thrift_message_parser_test.cpp:63
    #5 0x5605c945f4c5 in dsn::thrift_message_parser_test_get_message_on_receive_v0_not_request_Test::TestBody() /home/mi/workspace/rdsn/src/runtime/test/thrift_message_parser_test.cpp:321
    #6 0x5605c94a70b7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x56f0b7)
    #7 0x5605c94a11d0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x5691d0)
    #8 0x5605c9484f19 in testing::Test::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54cf19)
    #9 0x5605c9485841 in testing::TestInfo::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54d841)
    #10 0x5605c9485eb9 in testing::TestCase::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54deb9)
    #11 0x5605c948cd5d in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x554d5d)
    #12 0x5605c94a8278 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x570278)
    #13 0x5605c94a200c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x56a00c)
    #14 0x5605c948b943 in testing::UnitTest::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x553943)
    #15 0x5605c9313b2a in non-virtual thunk to test_client::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x3dbb2a)
    #16 0x5605c9515bb4 in dsn::service_node::start_app() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:73
    #17 0x5605c954adf3 in dsn::service_control_task::exec() /home/mi/workspace/rdsn/src/runtime/tool_api.cpp:60
    #18 0x5605c96cd360 in dsn::task::exec_internal() /home/mi/workspace/rdsn/src/runtime/task/task.cpp:176
    #19 0x5605c972a195 in dsn::task_worker::loop() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:211
    #20 0x5605c972adbf in dsn::task_worker::run_internal() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:191
    #21 0x5605c972b3a3 in void std::__invoke_impl<void, void (dsn::task_worker::*&)(), dsn::task_worker*&>(std::__invoke_memfun_deref, void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:73
    #22 0x5605c972b3a3 in std::__invoke_result<void (dsn::task_worker::*&)(), dsn::task_worker*&>::type std::__invoke<void (dsn::task_worker::*&)(), dsn::task_worker*&>(void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:95
    #23 0x5605c972b3a3 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/7/functional:467
    #24 0x5605c972b3a3 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::operator()<, void>() /usr/include/c++/7/functional:551
    #25 0x5605c972b3a3 in void std::__invoke_impl<void, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::__invoke_other, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:60
    #26 0x5605c972b3a3 in std::__invoke_result<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>::type std::__invoke<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:95
    #27 0x5605c972b3a3 in decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/7/thread:234
    #28 0x5605c972b3a3 in std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::operator()() /usr/include/c++/7/thread:243
    #29 0x5605c972b3a3 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > > >::_M_run() /usr/include/c++/7/thread:186
    #30 0x7ffa05c9c6de  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd6de)
    #31 0x7ffa069556da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
    #32 0x7ffa056f7a3e in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x121a3e)

0x60f0000c32c8 is located 168 bytes inside of 176-byte region [0x60f0000c3220,0x60f0000c32d0)
freed by thread T20 (client.THREAD_P) here:
    #0 0x7ffa06c4e9c8 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19c8)
    #1 0x5605c96c00d4 in create_message_from_request_blob /home/mi/workspace/rdsn/src/runtime/rpc/thrift_message_parser.cpp:113
    #2 0x5605c96c1826 in dsn::thrift_message_parser::parse_request_body_v0(dsn::message_reader*, int&) /home/mi/workspace/rdsn/src/runtime/rpc/thrift_message_parser.cpp:199
    #3 0x5605c946f8e6 in dsn::thrift_message_parser_test::test_get_message_on_receive_v0_data(dsn::message_reader&, apache::thrift::protocol::TMessageType, bool) /home/mi/workspace/rdsn/src/runtime/test/thrift_message_parser_test.cpp:63
    #4 0x5605c945f4c5 in dsn::thrift_message_parser_test_get_message_on_receive_v0_not_request_Test::TestBody() /home/mi/workspace/rdsn/src/runtime/test/thrift_message_parser_test.cpp:321
    #5 0x5605c94a70b7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x56f0b7)
    #6 0x5605c94a11d0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x5691d0)
    #7 0x5605c9484f19 in testing::Test::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54cf19)
    #8 0x5605c9485841 in testing::TestInfo::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54d841)
    #9 0x5605c9485eb9 in testing::TestCase::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54deb9)
    #10 0x5605c948cd5d in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x554d5d)
    #11 0x5605c94a8278 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x570278)
    #12 0x5605c94a200c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x56a00c)
    #13 0x5605c948b943 in testing::UnitTest::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x553943)
    #14 0x5605c9313b2a in non-virtual thunk to test_client::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x3dbb2a)
    #15 0x5605c9515bb4 in dsn::service_node::start_app() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:73
    #16 0x5605c954adf3 in dsn::service_control_task::exec() /home/mi/workspace/rdsn/src/runtime/tool_api.cpp:60
    #17 0x5605c96cd360 in dsn::task::exec_internal() /home/mi/workspace/rdsn/src/runtime/task/task.cpp:176
    #18 0x5605c972a195 in dsn::task_worker::loop() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:211
    #19 0x5605c972adbf in dsn::task_worker::run_internal() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:191
    #20 0x5605c972b3a3 in void std::__invoke_impl<void, void (dsn::task_worker::*&)(), dsn::task_worker*&>(std::__invoke_memfun_deref, void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:73
    #21 0x5605c972b3a3 in std::__invoke_result<void (dsn::task_worker::*&)(), dsn::task_worker*&>::type std::__invoke<void (dsn::task_worker::*&)(), dsn::task_worker*&>(void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:95
    #22 0x5605c972b3a3 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/7/functional:467
    #23 0x5605c972b3a3 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::operator()<, void>() /usr/include/c++/7/functional:551
    #24 0x5605c972b3a3 in void std::__invoke_impl<void, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::__invoke_other, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:60
    #25 0x5605c972b3a3 in std::__invoke_result<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>::type std::__invoke<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:95
    #26 0x5605c972b3a3 in decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/7/thread:234
    #27 0x5605c972b3a3 in std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::operator()() /usr/include/c++/7/thread:243
    #28 0x5605c972b3a3 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > > >::_M_run() /usr/include/c++/7/thread:186
    #29 0x7ffa05c9c6de  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd6de)

previously allocated by thread T20 (client.THREAD_P) here:
    #0 0x7ffa06c4d448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x5605c96b2abb in dsn::message_ex::create_receive_message_with_standalone_header(dsn::blob const&) /home/mi/workspace/rdsn/src/runtime/rpc/rpc_message.cpp:150
    #2 0x5605c96bf387 in create_message_from_request_blob /home/mi/workspace/rdsn/src/runtime/rpc/thrift_message_parser.cpp:90
    #3 0x5605c96c1826 in dsn::thrift_message_parser::parse_request_body_v0(dsn::message_reader*, int&) /home/mi/workspace/rdsn/src/runtime/rpc/thrift_message_parser.cpp:199
    #4 0x5605c946f8e6 in dsn::thrift_message_parser_test::test_get_message_on_receive_v0_data(dsn::message_reader&, apache::thrift::protocol::TMessageType, bool) /home/mi/workspace/rdsn/src/runtime/test/thrift_message_parser_test.cpp:63
    #5 0x5605c945f4c5 in dsn::thrift_message_parser_test_get_message_on_receive_v0_not_request_Test::TestBody() /home/mi/workspace/rdsn/src/runtime/test/thrift_message_parser_test.cpp:321
    #6 0x5605c94a70b7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x56f0b7)
    #7 0x5605c94a11d0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x5691d0)
    #8 0x5605c9484f19 in testing::Test::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54cf19)
    #9 0x5605c9485841 in testing::TestInfo::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54d841)
    #10 0x5605c9485eb9 in testing::TestCase::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x54deb9)
    #11 0x5605c948cd5d in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x554d5d)
    #12 0x5605c94a8278 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x570278)
    #13 0x5605c94a200c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x56a00c)
    #14 0x5605c948b943 in testing::UnitTest::Run() (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x553943)
    #15 0x5605c9313b2a in non-virtual thunk to test_client::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (/home/mi/workspace/rdsn/builder/src/runtime/test/dsn_runtime_tests+0x3dbb2a)
    #16 0x5605c9515bb4 in dsn::service_node::start_app() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:73
    #17 0x5605c954adf3 in dsn::service_control_task::exec() /home/mi/workspace/rdsn/src/runtime/tool_api.cpp:60
    #18 0x5605c96cd360 in dsn::task::exec_internal() /home/mi/workspace/rdsn/src/runtime/task/task.cpp:176
    #19 0x5605c972a195 in dsn::task_worker::loop() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:211
    #20 0x5605c972adbf in dsn::task_worker::run_internal() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:191
    #21 0x5605c972b3a3 in void std::__invoke_impl<void, void (dsn::task_worker::*&)(), dsn::task_worker*&>(std::__invoke_memfun_deref, void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:73
    #22 0x5605c972b3a3 in std::__invoke_result<void (dsn::task_worker::*&)(), dsn::task_worker*&>::type std::__invoke<void (dsn::task_worker::*&)(), dsn::task_worker*&>(void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:95
    #23 0x5605c972b3a3 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/7/functional:467
    #24 0x5605c972b3a3 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::operator()<, void>() /usr/include/c++/7/functional:551
    #25 0x5605c972b3a3 in void std::__invoke_impl<void, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::__invoke_other, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:60
    #26 0x5605c972b3a3 in std::__invoke_result<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>::type std::__invoke<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:95
    #27 0x5605c972b3a3 in decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/7/thread:234
    #28 0x5605c972b3a3 in std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::operator()() /usr/include/c++/7/thread:243
    #29 0x5605c972b3a3 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > > >::_M_run() /usr/include/c++/7/thread:186
    #30 0x7ffa05c9c6de  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd6de)

Thread T20 (client.THREAD_P) created by T0 here:
    #0 0x7ffa06ba4d2f in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x37d2f)
    #1 0x7ffa05c9c994 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd994)
    #2 0x5605c96db9e3 in dsn::task_worker_pool::start() /home/mi/workspace/rdsn/src/runtime/task/task_engine.cpp:101
    #3 0x5605c96de0d0 in dsn::task_engine::start() /home/mi/workspace/rdsn/src/runtime/task/task_engine.cpp:231
    #4 0x5605c9525f2d in dsn::service_node::start() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:121
    #5 0x5605c95277a4 in dsn::service_engine::start_node(dsn::service_app_spec&) /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:232
    #6 0x5605c950ba77 in run /home/mi/workspace/rdsn/src/runtime/service_api_c.cpp:508
    #7 0x5605c9510dee in dsn_run(int, char**, bool) /home/mi/workspace/rdsn/src/runtime/service_api_c.cpp:274
    #8 0x5605c922ab06 in main /home/mi/workspace/rdsn/src/runtime/test/main.cpp:56
    #9 0x7ffa055f7b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: heap-use-after-free /home/mi/workspace/rdsn/src/runtime/rpc/rpc_message.cpp:505 in dsn::message_ex::read_commit(unsigned long)
Shadow bytes around the buggy address:
  0x0c1e80010600: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c1e80010610: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
  0x0c1e80010620: fa fa fa fa fa fa 00 00 00 00 00 00 00 00 00 00
  0x0c1e80010630: 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa
  0x0c1e80010640: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c1e80010650: fd fd fd fd fd fd fd fd fd[fd]fa fa fa fa fa fa
  0x0c1e80010660: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e80010670: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e80010680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e80010690: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e800106a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==30014==ABORTING

```