### PR TITLE
refactor:  remove the dependency of tls memory for some member functions in message_ex

### DIFF
--- a/include/dsn/tool-api/rpc_message.h
+++ b/include/dsn/tool-api/rpc_message.h
@@ -176,6 +176,7 @@ public:
     /// The returned message:
     ///   - msg->buffers[0] = message_header
     ///   - msg->buffers[1] = data
+    /// AUCTION: the reference of returned message_ex is not added in this function
     DSN_API static message_ex *create_receive_message_with_standalone_header(const blob &data);
 
     /// copy message without client information, it will not reply

--- a/include/dsn/tool-api/rpc_message.h
+++ b/include/dsn/tool-api/rpc_message.h
@@ -176,7 +176,7 @@ public:
     /// The returned message:
     ///   - msg->buffers[0] = message_header
     ///   - msg->buffers[1] = data
-    /// NOTE: the reference of returned message_ex is not added in this function
+    /// NOTE: the reference counter of returned message_ex is not added in this function
     DSN_API static message_ex *create_receive_message_with_standalone_header(const blob &data);
 
     /// copy message without client information, it will not reply

--- a/include/dsn/tool-api/rpc_message.h
+++ b/include/dsn/tool-api/rpc_message.h
@@ -176,7 +176,7 @@ public:
     /// The returned message:
     ///   - msg->buffers[0] = message_header
     ///   - msg->buffers[1] = data
-    /// AUCTION: the reference of returned message_ex is not added in this function
+    /// NOTE: the reference of returned message_ex is not added in this function
     DSN_API static message_ex *create_receive_message_with_standalone_header(const blob &data);
 
     /// copy message without client information, it will not reply

--- a/include/dsn/utility/transient_memory.h
+++ b/include/dsn/utility/transient_memory.h
@@ -80,13 +80,4 @@ void tls_trans_mem_init(size_t default_per_block_bytes);
 // "tls_trans_mem_next" should be used together with "tls_trans_mem_commit"
 void tls_trans_mem_next(void **ptr, size_t *sz, size_t min_size);
 void tls_trans_mem_commit(size_t use_size);
-
-// allocate a blob, the size is "sz"
-blob tls_trans_mem_alloc_blob(size_t sz);
-
-// allocate memory
-void *tls_trans_malloc(size_t sz);
-
-// free memory, ptr shouldn't be null
-void tls_trans_free(void *ptr);
-}
+} // namespace dsn

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -152,7 +152,7 @@ message_ex *message_ex::create_receive_message_with_standalone_header(const blob
     std::string str(header_size, '\0');
     msg->header = reinterpret_cast<message_header *>(const_cast<char *>(str.data()));
 
-    msg->buffers.emplace_back(dsn::blob::create_from_bytes(std::move(str)));
+    msg->buffers.emplace_back(blob::create_from_bytes(std::move(str)));
     msg->buffers.push_back(data);
 
     msg->header->body_length = data.length();
@@ -170,7 +170,7 @@ message_ex *message_ex::copy_message_no_reply(const message_ex &old_msg)
     std::string str(header_size, '\0');
     msg->header = reinterpret_cast<message_header *>(const_cast<char *>(str.data()));
 
-    msg->buffers.emplace_back(dsn::blob::create_from_bytes(std::move(str)));
+    msg->buffers.emplace_back(blob::create_from_bytes(std::move(str)));
     if (old_msg.buffers.size() == 1) {
         // if old_msg only has header, consider its header as data
         msg->buffers.emplace_back(old_msg.buffers[0]);

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -149,11 +149,10 @@ message_ex *message_ex::create_receive_message_with_standalone_header(const blob
 {
     message_ex *msg = new message_ex();
     size_t header_size = sizeof(message_header);
-    std::shared_ptr<char> header_holder(utils::make_shared_array<char>(header_size));
-    msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    memset(static_cast<void *>(msg->header), 0, header_size);
+    std::string str(header_size, '\0');
+    msg->header = reinterpret_cast<message_header *>(const_cast<char *>(str.data()));
 
-    msg->buffers.emplace_back(blob(std::move(header_holder), header_size));
+    msg->buffers.emplace_back(dsn::blob::create_from_bytes(std::move(str)));
     msg->buffers.push_back(data);
 
     msg->header->body_length = data.length();
@@ -168,11 +167,10 @@ message_ex *message_ex::copy_message_no_reply(const message_ex &old_msg)
 {
     message_ex *msg = new message_ex();
     size_t header_size = sizeof(message_header);
-    std::shared_ptr<char> header_holder(utils::make_shared_array<char>(header_size));
-    msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    memset(static_cast<void *>(msg->header), 0, header_size);
-    msg->buffers.emplace_back(blob(std::move(header_holder), header_size));
+    std::string str(header_size, '\0');
+    msg->header = reinterpret_cast<message_header *>(const_cast<char *>(str.data()));
 
+    msg->buffers.emplace_back(dsn::blob::create_from_bytes(std::move(str)));
     if (old_msg.buffers.size() == 1) {
         // if old_msg only has header, consider its header as data
         msg->buffers.emplace_back(old_msg.buffers[0]);

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -149,7 +149,7 @@ message_ex *message_ex::create_receive_message_with_standalone_header(const blob
 {
     message_ex *msg = new message_ex();
     size_t header_size = sizeof(message_header);
-    auto header_holder(utils::make_shared_array<char>(header_size));
+    std::shared_ptr<char> header_holder(utils::make_shared_array<char>(header_size));
     msg->header = reinterpret_cast<message_header *>(header_holder.get());
     memset(static_cast<void *>(msg->header), 0, header_size);
 
@@ -168,7 +168,7 @@ message_ex *message_ex::copy_message_no_reply(const message_ex &old_msg)
 {
     message_ex *msg = new message_ex();
     size_t header_size = sizeof(message_header);
-    auto header_holder(utils::make_shared_array<char>(header_size));
+    std::shared_ptr<char> header_holder(utils::make_shared_array<char>(header_size));
     msg->header = reinterpret_cast<message_header *>(header_holder.get());
     memset(static_cast<void *>(msg->header), 0, header_size);
     msg->buffers.emplace_back(blob(std::move(header_holder), header_size));

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -149,11 +149,10 @@ message_ex *message_ex::create_receive_message_with_standalone_header(const blob
 {
     message_ex *msg = new message_ex();
     size_t header_size = sizeof(message_header);
-    auto header_holder(utils::make_shared_array<char>(header_size));
-    msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    memset(static_cast<void *>(msg->header), 0, header_size);
+    std::string str('\0', header_size);
+    msg->header = reinterpret_cast<message_header *>(const_cast<char *>(str.data()));
 
-    msg->buffers.emplace_back(blob(std::move(header_holder), header_size));
+    msg->buffers.emplace_back(dsn::blob::create_from_bytes(std::move(str)));
     msg->buffers.push_back(data);
 
     msg->header->body_length = data.length();
@@ -168,11 +167,10 @@ message_ex *message_ex::copy_message_no_reply(const message_ex &old_msg)
 {
     message_ex *msg = new message_ex();
     size_t header_size = sizeof(message_header);
-    auto header_holder(utils::make_shared_array<char>(header_size));
-    msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    memset(static_cast<void *>(msg->header), 0, header_size);
-    msg->buffers.emplace_back(blob(std::move(header_holder), header_size));
+    std::string str('\0', header_size);
+    msg->header = reinterpret_cast<message_header *>(const_cast<char *>(str.data()));
 
+    msg->buffers.emplace_back(dsn::blob::create_from_bytes(std::move(str)));
     if (old_msg.buffers.size() == 1) {
         // if old_msg only has header, consider its header as data
         msg->buffers.emplace_back(old_msg.buffers[0]);

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -148,13 +148,12 @@ message_ex *message_ex::create_received_request(dsn::task_code code,
 message_ex *message_ex::create_receive_message_with_standalone_header(const blob &data)
 {
     message_ex *msg = new message_ex();
-    std::shared_ptr<char> header_holder(
-        static_cast<char *>(dsn::tls_trans_malloc(sizeof(message_header))),
-        [](char *c) { dsn::tls_trans_free(c); });
+    size_t header_size = sizeof(message_header);
+    auto header_holder(utils::make_shared_array<char>(header_size));
     msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    memset(static_cast<void *>(msg->header), 0, sizeof(message_header));
+    memset(static_cast<void *>(msg->header), 0, header_size);
 
-    msg->buffers.emplace_back(blob(std::move(header_holder), sizeof(message_header)));
+    msg->buffers.emplace_back(blob(std::move(header_holder), header_size));
     msg->buffers.push_back(data);
 
     msg->header->body_length = data.length();
@@ -168,12 +167,11 @@ message_ex *message_ex::create_receive_message_with_standalone_header(const blob
 message_ex *message_ex::copy_message_no_reply(const message_ex &old_msg)
 {
     message_ex *msg = new message_ex();
-    std::shared_ptr<char> header_holder(
-        static_cast<char *>(dsn::tls_trans_malloc(sizeof(message_header))),
-        [](char *c) { dsn::tls_trans_free(c); });
+    size_t header_size = sizeof(message_header);
+    auto header_holder(utils::make_shared_array<char>(header_size));
     msg->header = reinterpret_cast<message_header *>(header_holder.get());
-    memset(static_cast<void *>(msg->header), 0, sizeof(message_header));
-    msg->buffers.emplace_back(blob(std::move(header_holder), sizeof(message_header)));
+    memset(static_cast<void *>(msg->header), 0, header_size);
+    msg->buffers.emplace_back(blob(std::move(header_holder), header_size));
 
     if (old_msg.buffers.size() == 1) {
         // if old_msg only has header, consider its header as data


### PR DESCRIPTION
remove the dependency of tls memory for `message_ex::create_receive_message_with_standalone_header` and `message_ex::copy_message_no_reply`