### PR TITLE
feat(split): add app_env split_validate_partition_hash

### DIFF
--- a/include/dsn/dist/replication/replica_envs.h
+++ b/include/dsn/dist/replication/replica_envs.h
@@ -57,6 +57,7 @@ public:
     static const std::string REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS;
     static const std::string READ_QPS_THROTTLING;
     static const std::string READ_SIZE_THROTTLING;
+    static const std::string SPLIT_VALIDATE_PARTITION_HASH;
 };
 
 } // namespace replication

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -628,6 +628,8 @@ const std::string replica_envs::REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS(
     "replica_access_controller.allowed_users");
 const std::string replica_envs::READ_QPS_THROTTLING("replica.read_throttling");
 const std::string replica_envs::READ_SIZE_THROTTLING("replica.read_throttling_by_size");
+const std::string
+    replica_envs::SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -123,6 +123,16 @@ bool check_throttling(const std::string &env_value, std::string &hint_message)
     return true;
 }
 
+bool check_split_validation(const std::string &env_value, std::string &hint_message)
+{
+    bool result = false;
+    if (!dsn::buf2bool(env_value, result)) {
+        hint_message = fmt::format("invalid string {}, should be \"true\" or \"false\"", env_value);
+        return false;
+    }
+    return true;
+}
+
 bool app_env_validator::validate_app_env(const std::string &env_name,
                                          const std::string &env_value,
                                          std::string &hint_message)
@@ -172,7 +182,9 @@ void app_env_validator::register_all_validators()
         {replica_envs::READ_QPS_THROTTLING,
          std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::READ_SIZE_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)}};
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
+        {replica_envs::SPLIT_VALIDATE_PARTITION_HASH,
+         std::bind(&check_split_validation, std::placeholders::_1, std::placeholders::_2)}};
 }
 
 } // namespace replication

--- a/src/meta/test/meta_split_service_test.cpp
+++ b/src/meta/test/meta_split_service_test.cpp
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 #include <dsn/service_api_c.h>
+#include <dsn/dist/replication/replica_envs.h>
 
 #include "meta_service_test_app.h"
 #include "meta_test_base.h"
@@ -262,6 +263,9 @@ TEST_F(meta_split_service_test, start_split_test)
         ASSERT_EQ(start_partition_split(test.app_name, test.new_partition_count),
                   test.expected_err);
         ASSERT_EQ(app->partition_count, test.expected_partition_count);
+        if (test.expected_err == ERR_OK) {
+            ASSERT_EQ(app->envs[replica_envs::SPLIT_VALIDATE_PARTITION_HASH], "true");
+        }
     }
 }
 


### PR DESCRIPTION
During partition split, original partition will split into two parts. To avoid reading from wrong partition or writing into wrong partition, each read and write request should be checked if it is sent to the right partition. This pull request adds an app_env called `SPLIT_VALIDATE_PARTITION_HASH`, when partition split started, it will be set as true. How this app_env works will be implmented in further pull request.