### PR TITLE
fix(perf_counter_wrapper): avoid using invalid perf_counters::instance() to remove counter

### DIFF
--- a/include/dsn/perf_counter/perf_counter_wrapper.h
+++ b/include/dsn/perf_counter/perf_counter_wrapper.h
@@ -63,7 +63,7 @@ public:
     perf_counter_wrapper &operator=(perf_counter_wrapper &other) = delete;
     perf_counter_wrapper &operator=(perf_counter_wrapper &&other) = delete;
 
-    ~perf_counter_wrapper() { clear(); }
+    ~perf_counter_wrapper() {}
 
     // clear the real perf-counter object.
     // call this function if you want free the counter before the wrapper's destructor is called
@@ -103,6 +103,7 @@ public:
 
     dsn::perf_counter *get() const { return _counter; }
     dsn::perf_counter *operator->() const { return _counter; }
+
 private:
     // use raw pointer to make the class object small, so it can be accessed quickly
     dsn::perf_counter *_counter;

--- a/src/perf_counter/perf_counters.cpp
+++ b/src/perf_counter/perf_counters.cpp
@@ -91,6 +91,7 @@ perf_counters::perf_counters()
 
 perf_counters::~perf_counters()
 {
+    _counters.clear();
     UNREGISTER_VALID_HANDLER(_perf_counters_cmd);
     UNREGISTER_VALID_HANDLER(_perf_counters_by_substr_cmd);
     UNREGISTER_VALID_HANDLER(_perf_counters_by_prefix_cmd);


### PR DESCRIPTION
The global variable `task_spec_profiler *s_spec_profilers` could be destroyed after the singleton `perf_counters::instance()` destroyed,
```
struct task_spec_profiler
{
    perf_counter_wrapper ptr[PERF_COUNTER_COUNT];
    bool collect_call_count;
    bool is_profile;
    std::atomic<int64_t> *call_counts;

    task_spec_profiler()
    {
        collect_call_count = false;
        is_profile = false;
        call_counts = nullptr;
        memset((void *)ptr, 0, sizeof(ptr));
    }
};
```
so there would be issues if call `perf_counters::instance()`  in `perf_counter_wrapper` destructor.

Because it seems not easy to use something else to replace the global variable `task_spec_profiler *s_spec_profilers`, and make `perf_counter_wrapper` objects destroyed before `perf_counters::instance()` destroyed based on current codes, I removed the clear counter operation from `perf_counter_wrapper` destructor, all counters would be cleared when `perf_counters::instance()` destroyed.