### PR TITLE
fix(asan): memory leak in command_manager

### DIFF
--- a/include/dsn/tool-api/command_manager.h
+++ b/include/dsn/tool-api/command_manager.h
@@ -30,6 +30,7 @@
 #include <dsn/utility/singleton.h>
 #include <dsn/c/api_utilities.h>
 #include <map>
+#include <dsn/utility/autoref_ptr.h>
 
 namespace dsn {
 
@@ -54,7 +55,7 @@ public:
                      /*out*/ std::string &output);
 
 private:
-    struct command_instance
+    struct command_instance : public ref_counter
     {
         std::vector<std::string> commands;
         std::string help_short;
@@ -62,8 +63,9 @@ private:
         command_handler handler;
     };
 
-    ::dsn::utils::rw_lock_nr _lock;
-    std::map<std::string, command_instance *> _handlers;
+    typedef ref_ptr<command_instance> command_instance_ptr;
+    utils::rw_lock_nr _lock;
+    std::map<std::string, command_instance_ptr> _handlers;
 };
 
 } // namespace dsn

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -73,7 +73,6 @@ void command_manager::deregister_command(dsn_handle_t handle)
         ddebug("unregister command: %s", cmd.c_str());
         _handlers.erase(cmd);
     }
-    delete c;
 }
 
 bool command_manager::run_command(const std::string &cmd,

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -70,7 +70,6 @@ void command_manager::deregister_command(dsn_handle_t handle)
     dassert(c != nullptr, "cannot deregister a null handle");
     utils::auto_write_lock l(_lock);
     for (const std::string &cmd : c->commands) {
-        ddebug("unregister command: %s", cmd.c_str());
         _handlers.erase(cmd);
     }
 }


### PR DESCRIPTION
In the dstor of command_instance, the command_instances handled by `_handlers`.