### PR TITLE
fix: make disk_engine destructed after service_engine destructed

### DIFF
--- a/src/aio/aio_provider.cpp
+++ b/src/aio/aio_provider.cpp
@@ -31,8 +31,6 @@ namespace dsn {
 
 aio_provider::aio_provider(disk_engine *disk) : _engine(disk) {}
 
-service_node *aio_provider::node() const { return _engine->node(); }
-
 void aio_provider::complete_io(aio_task *aio, error_code err, uint32_t bytes)
 {
     _engine->complete_io(aio, err, bytes);

--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -53,8 +53,6 @@ public:
     explicit aio_provider(disk_engine *disk);
     virtual ~aio_provider() = default;
 
-    service_node *node() const;
-
     // return DSN_INVALID_FILE_HANDLE if failed
     // TODO(wutao1): return uint64_t instead (because we only support linux now)
     virtual dsn_handle_t open(const char *file_name, int flag, int pmode) = 0;

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -26,6 +26,7 @@
 
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/tool-api/aio_task.h>
+
 #include "disk_engine.h"
 #include "sim_aio_provider.h"
 #include "runtime/service_engine.h"
@@ -143,8 +144,6 @@ aio_task *disk_file::on_write_completed(aio_task *wk, void *ctx, error_code err,
 //----------------- disk_engine ------------------------
 disk_engine::disk_engine()
 {
-    _node = service_engine::instance().get_all_nodes().begin()->second.get();
-
     aio_provider *provider = utils::factory_store<aio_provider>::create(
         FLAGS_aio_factory_name, dsn::PROVIDER_TYPE_MAIN, this);
     // use native_aio_provider in default

--- a/src/aio/disk_engine.h
+++ b/src/aio/disk_engine.h
@@ -72,8 +72,6 @@ class disk_engine : public utils::singleton<disk_engine>
 {
 public:
     void write(aio_task *aio);
-
-    service_node *node() const { return _node; }
     static aio_provider &provider() { return *instance()._provider.get(); }
 
 private:
@@ -85,7 +83,6 @@ private:
     void complete_io(aio_task *aio, error_code err, uint32_t bytes);
 
     std::unique_ptr<aio_provider> _provider;
-    service_node *_node;
 
     friend class aio_provider;
     friend class batch_write_io_task;

--- a/src/aio/file_io.cpp
+++ b/src/aio/file_io.cpp
@@ -42,10 +42,13 @@ namespace file {
 
 /*extern*/ error_code close(disk_file *file)
 {
+    error_code result = ERR_INVALID_HANDLE;
     if (file != nullptr) {
-        return disk_engine::provider().close(file->native_handle());
+        result = disk_engine::provider().close(file->native_handle());
+        delete file;
+        file = nullptr;
     }
-    return ERR_INVALID_HANDLE;
+    return result;
 }
 
 /*extern*/ error_code flush(disk_file *file)

--- a/src/aio/file_io.cpp
+++ b/src/aio/file_io.cpp
@@ -25,7 +25,6 @@
  */
 
 #include "disk_engine.h"
-
 #include <dsn/tool-api/file_io.h>
 
 namespace dsn {
@@ -43,13 +42,10 @@ namespace file {
 
 /*extern*/ error_code close(disk_file *file)
 {
-    if (nullptr != file) {
-        auto ret = disk_engine::provider().close(file->native_handle());
-        delete file;
-        return ret;
-    } else {
-        return ERR_INVALID_HANDLE;
+    if (file != nullptr) {
+        return disk_engine::provider().close(file->native_handle());
     }
+    return ERR_INVALID_HANDLE;
 }
 
 /*extern*/ error_code flush(disk_file *file)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -30,5 +30,5 @@ add_library(dsn_runtime STATIC
         tracer.cpp
         zlocks.cpp
         )
-target_link_libraries(dsn_runtime dsn_utils sasl2 gssapi_krb5 krb5)
+target_link_libraries(dsn_runtime PRIVATE dsn_utils sasl2 gssapi_krb5 krb5 dsn_aio)
 install(TARGETS dsn_runtime DESTINATION "lib")

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "aio/disk_engine.h"
 #include "service_engine.h"
 #include "utils/coredump.h"
 #include "runtime/rpc/rpc_engine.h"
@@ -292,10 +293,11 @@ extern void dsn_core_init();
 
 inline void dsn_global_init()
 {
-    // ensure perf_counters is destructed after service_engine,
+    // make perf_counters/disk_engine destructed after service_engine,
     // because service_engine relies on the former to monitor
-    // task queues length.
+    // task queues length and close files.
     dsn::perf_counters::instance();
+    dsn::disk_engine::instance();
     dsn::service_engine::instance();
 }
 


### PR DESCRIPTION
When exiting the process, we need to close files using `disk_engine`, `disk_engine` should be destructed after `service_engine` destructed.