### PR TITLE
fix: do not call unregister_rpc_handler when exiting progress

### DIFF
--- a/src/failure_detector/failure_detector.cpp
+++ b/src/failure_detector/failure_detector.cpp
@@ -108,8 +108,6 @@ error_code failure_detector::stop()
 
     _is_started = false;
 
-    close_service();
-
     {
         zauto_lock l(_lock);
         for (auto &m : _masters) {

--- a/src/nfs/nfs_node_impl.cpp
+++ b/src/nfs/nfs_node_impl.cpp
@@ -64,7 +64,6 @@ error_code nfs_node_simple::start()
 
 error_code nfs_node_simple::stop()
 {
-    _server->close_service();
     delete _server;
     _server = nullptr;
 


### PR DESCRIPTION
When exiting progress `dsn::task::get_current_node()` is `nullptr`, so we shouldn't call `dsn_rpc_unregiser_handler`. Also, when the `rpc_engine` destructed, all handlers have been cleared, this is no need to call `dsn_rpc_unregiser_handler`.
```
rpc_server_dispatcher::~rpc_server_dispatcher()
{
    for (auto &h : _vhandlers) {
        delete h;
    }
    _vhandlers.clear();
    _handlers.clear();
    dassert(_handlers.size() == 0,
            "please make sure all rpc handlers are unregistered at this point");
}
```