### PR TITLE
refactor(backup): remove duplicate codes that related to cancel and clear backups

### DIFF
--- a/src/replica/backup/replica_backup_manager.h
+++ b/src/replica/backup/replica_backup_manager.h
@@ -1,6 +1,19 @@
-// Copyright (c) 2017-present, Xiaomi, Inc.  All rights reserved.
-// This source code is licensed under the Apache License Version 2.0, which
-// can be found in the LICENSE file in the root directory of this source tree.
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #pragma once
 

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -365,9 +365,8 @@ private:
     void wait_async_checkpoint_for_backup(cold_backup_context_ptr backup_context);
     void local_create_backup_checkpoint(cold_backup_context_ptr backup_context);
     void send_backup_request_to_secondary(const backup_request &request);
-    // set all cold_backup_state cancel/pause
-    void set_backup_context_cancel();
-    void clear_cold_backup_state();
+    void cancel_cold_backup(const std::string &policy_name);
+    void cancel_all_cold_backups();
 
     /////////////////////////////////////////////////////////////////
     // replica restore from backup

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include <boost/lexical_cast.hpp>
 
 #include <dsn/utility/filesystem.h>
@@ -64,32 +81,7 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
         cold_backup_status backup_status = backup_context->status();
 
         if (backup_context->request.backup_id < backup_id || backup_status == ColdBackupCanceled) {
-            if (backup_status == ColdBackupCheckpointing) {
-                ddebug("%s: delay clearing obsoleted cold backup context, cause backup_status == "
-                       "ColdBackupCheckpointing",
-                       new_context->name);
-                tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
-                                 &_tracker,
-                                 [this, request]() {
-                                     backup_response response;
-                                     on_cold_backup(request, response);
-                                 },
-                                 get_gpid().thread_hash(),
-                                 std::chrono::seconds(100));
-            } else {
-                // TODO(wutao1): deleting cold backup context should be
-                //               extracted as a function like try_delete_cold_backup_context;
-                // clear obsoleted backup context firstly
-                ddebug("%s: clear obsoleted cold backup context, old_backup_id = %" PRId64
-                       ", old_backup_status = %s",
-                       new_context->name,
-                       backup_context->request.backup_id,
-                       cold_backup_status_to_string(backup_status));
-                backup_context->cancel();
-                _cold_backup_contexts.erase(policy_name);
-                // go to another round
-                on_cold_backup(request, response);
-            }
+            cancel_cold_backup(policy_name);
             return;
         }
 
@@ -230,79 +222,40 @@ backup_get_tmp_dir_name(const std::string &policy_name, int64_t backup_id, int64
     return std::string(buffer);
 }
 
-// returns:
-//   0 : not related
-//   1 : related (belong to this policy but not belong to this backup_context)
-//   2 : valid (belong to this policy and belong to this backup_context)
-static int is_related_or_valid_checkpoint(const std::string &chkpt_dirname,
-                                          const cold_backup_context_ptr &backup_context)
+static bool is_valid_checkpoint(const std::string &chkpt_dirname,
+                                const cold_backup_context_ptr &backup_context)
 {
     std::vector<std::string> strs;
-    ::dsn::utils::split_args(chkpt_dirname.c_str(), strs, '.');
-    if (strs.size() == 4 && strs[0] == std::string("backup_tmp") &&
+    dsn::utils::split_args(chkpt_dirname.c_str(), strs, '.');
+    if (strs.size() == 5 && strs[0] == std::string("backup") &&
         strs[1] == backup_context->request.policy.policy_name) {
-        // backup_tmp.<policy_name>.<backup_id>.<timestamp>
-        // refer to backup_get_tmp_dir_name().
-        int64_t backup_id = boost::lexical_cast<int64_t>(strs[2]);
-        if (backup_id < backup_context->request.backup_id) {
-            // it belongs to old backup_context, we can remove it safely.
-            return 1;
-        }
-    } else if (strs.size() == 5 && strs[0] == std::string("backup_tmp") &&
-               strs[4] == std::string("tmp") &&
-               strs[1] == backup_context->request.policy.policy_name) {
-        // backup_tmp.<policy_name>.<backup_id>.<timestamp>.tmp
-        // refer to CheckpointImpl::CreateCheckpointQuick().
-        int64_t backup_id = boost::lexical_cast<int64_t>(strs[2]);
-        if (backup_id < backup_context->request.backup_id) {
-            // it belongs to old backup_context, we can remove it safely.
-            return 1;
-        }
-    } else if (strs.size() == 5 && strs[0] == std::string("backup") &&
-               strs[1] == backup_context->request.policy.policy_name) {
         // backup.<policy_name>.<backup_id>.<decree>.<timestamp>
         // refer to backup_get_dir_name().
         int64_t backup_id = boost::lexical_cast<int64_t>(strs[2]);
         // here, we only need policy_name and backup_id to verify whether chkpt_dirname belong
         // to this backup_context.
         if (backup_id == backup_context->request.backup_id) {
-            // it belongs to this backup_context.
-            return 2;
-        } else if (backup_id < backup_context->request.backup_id) {
-            // it belongs to old backup_context, we can remove it safely.
-            return 1;
+            return true;
         }
-    } else {
-        // unknown dir, ignore it
-        dwarn(
-            "%s: found a invalid checkpoint dir(%s)", backup_context->name, chkpt_dirname.c_str());
     }
-    return 0;
+    return false;
 }
 
-// filter backup checkpoint under 'dir'
-//  - find the valid backup checkpoint dir if exist
-//  - find all the backup checkpoint belong to this policy, mainly obsolete backup checkpoint
-static bool filter_checkpoint(const std::string &dir,
-                              const cold_backup_context_ptr &backup_context,
-                              /*out*/ std::vector<std::string> &related_chkpt_dirs,
-                              /*out*/ std::string &valid_chkpt_dir)
+static bool get_valid_checkpoint(const std::string &dir,
+                                 const cold_backup_context_ptr &backup_context,
+                                 /*out*/ std::string &valid_chkpt_dir)
 {
     valid_chkpt_dir.clear();
-    related_chkpt_dirs.clear();
-    // list sub dirs
+
     std::vector<std::string> sub_dirs;
     if (!utils::filesystem::get_subdirectories(dir, sub_dirs, false)) {
-        derror("%s: list sub dirs of dir %s failed", backup_context->name, dir.c_str());
+        derror_f("{}: list sub dirs of dir {} failed", backup_context->name, dir);
         return false;
     }
 
     for (std::string &d : sub_dirs) {
         std::string dirname = utils::filesystem::get_file_name(d);
-        int ret = is_related_or_valid_checkpoint(dirname, backup_context);
-        if (ret == 1) {
-            related_chkpt_dirs.emplace_back(std::move(dirname));
-        } else if (ret == 2) {
+        if (is_valid_checkpoint(dirname, backup_context)) {
             dassert(valid_chkpt_dir.empty(),
                     "%s: there are two valid backup checkpoint dir, %s VS %s",
                     backup_context->name,
@@ -389,79 +342,64 @@ void replica::generate_backup_checkpoint(cold_backup_context_ptr backup_context)
         return;
     }
 
-    std::vector<std::string> related_backup_chkpt_dirname;
     std::string valid_backup_chkpt_dirname;
-    if (!filter_checkpoint(
-            backup_dir, backup_context, related_backup_chkpt_dirname, valid_backup_chkpt_dirname)) {
-        // encounter some error, just return
+    if (!get_valid_checkpoint(backup_dir, backup_context, valid_backup_chkpt_dirname)) {
         backup_context->fail_checkpoint("list sub backup dir failed");
         return;
     }
-    if (!valid_backup_chkpt_dirname.empty()) {
-        std::vector<std::pair<std::string, int64_t>> file_infos;
-        int64_t total_size = 0;
-        std::string valid_chkpt_full_path =
-            utils::filesystem::path_combine(backup_dir, valid_backup_chkpt_dirname);
-        // parse checkpoint dirname
-        std::string policy_name;
-        int64_t backup_id = 0, decree = 0, timestamp = 0;
-        dassert(backup_parse_dir_name(
-                    valid_backup_chkpt_dirname.c_str(), policy_name, backup_id, decree, timestamp),
-                "%s: valid chekpoint dirname %s",
-                backup_context->name,
-                valid_backup_chkpt_dirname.c_str());
 
-        if (statistic_file_infos_under_dir(valid_chkpt_full_path, file_infos, total_size)) {
-            backup_context->checkpoint_decree = decree;
-            backup_context->checkpoint_timestamp = timestamp;
-            backup_context->checkpoint_dir = valid_chkpt_full_path;
-            for (std::pair<std::string, int64_t> &p : file_infos) {
-                backup_context->checkpoint_files.emplace_back(std::move(p.first));
-                backup_context->checkpoint_file_sizes.emplace_back(std::move(p.second));
-            }
-            backup_context->checkpoint_file_total_size = total_size;
-            backup_context->complete_checkpoint();
-
-            ddebug("%s: backup checkpoint aleady exist, dir = %s, file_count = %d, total_size = "
-                   "%" PRId64,
-                   backup_context->name,
-                   backup_context->checkpoint_dir.c_str(),
-                   (int)file_infos.size(),
-                   total_size);
-            // TODO: in primary, this will make the request send to secondary again
-            tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
-                             &_tracker,
-                             [this, backup_context]() {
-                                 backup_response response;
-                                 on_cold_backup(backup_context->request, response);
-                             },
-                             get_gpid().thread_hash());
-        } else {
-            backup_context->fail_checkpoint("statistic file info under checkpoint failed");
-            return;
-        }
-    } else {
-        ddebug("%s: backup checkpoint not exist, start to trigger async checkpoint",
-               backup_context->name);
+    if (valid_backup_chkpt_dirname.empty()) {
+        ddebug_replica("{}: backup checkpoint not exist, start to trigger async checkpoint",
+                       backup_context->name);
         tasking::enqueue(
             LPC_REPLICATION_COLD_BACKUP,
             &_tracker,
             [this, backup_context]() { trigger_async_checkpoint_for_backup(backup_context); },
             get_gpid().thread_hash());
+        return;
     }
 
-    // clear related but not valid checkpoint
-    for (const std::string &dirname : related_backup_chkpt_dirname) {
-        std::string full_path = utils::filesystem::path_combine(backup_dir, dirname);
-        ddebug("%s: found obsolete backup checkpoint dir(%s), remove it",
-               backup_context->name,
-               full_path.c_str());
-        if (!utils::filesystem::remove_path(full_path)) {
-            dwarn("%s: remove obsolete backup checkpoint dir(%s) failed",
-                  backup_context->name,
-                  full_path.c_str());
-        }
+    std::vector<std::pair<std::string, int64_t>> file_infos;
+    int64_t total_size = 0;
+    std::string valid_chkpt_full_path =
+        utils::filesystem::path_combine(backup_dir, valid_backup_chkpt_dirname);
+    // parse checkpoint dirname
+    std::string policy_name;
+    int64_t backup_id = 0, decree = 0, timestamp = 0;
+    dassert(backup_parse_dir_name(
+                valid_backup_chkpt_dirname.c_str(), policy_name, backup_id, decree, timestamp),
+            "%s: valid chekpoint dirname %s",
+            backup_context->name,
+            valid_backup_chkpt_dirname.c_str());
+
+    if (!statistic_file_infos_under_dir(valid_chkpt_full_path, file_infos, total_size)) {
+        backup_context->fail_checkpoint("statistic file info under checkpoint failed");
+        return;
     }
+
+    backup_context->checkpoint_decree = decree;
+    backup_context->checkpoint_timestamp = timestamp;
+    backup_context->checkpoint_dir = valid_chkpt_full_path;
+    for (std::pair<std::string, int64_t> &p : file_infos) {
+        backup_context->checkpoint_files.emplace_back(std::move(p.first));
+        backup_context->checkpoint_file_sizes.emplace_back(std::move(p.second));
+    }
+    backup_context->checkpoint_file_total_size = total_size;
+    backup_context->complete_checkpoint();
+
+    ddebug_replica("{}: backup checkpoint aleady exist, dir = {}, file_count = {}, total_size = {}",
+                   backup_context->name,
+                   backup_context->checkpoint_dir,
+                   (int)file_infos.size(),
+                   total_size);
+    // TODO: in primary, this will make the request send to secondary again
+    tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
+                     &_tracker,
+                     [this, backup_context]() {
+                         backup_response response;
+                         on_cold_backup(backup_context->request, response);
+                     },
+                     get_gpid().thread_hash());
 }
 
 // run in REPLICATION thread
@@ -685,16 +623,37 @@ void replica::local_create_backup_checkpoint(cold_backup_context_ptr backup_cont
     }
 }
 
-void replica::set_backup_context_cancel()
+void replica::cancel_cold_backup(const std::string &policy_name)
 {
-    for (auto &pair : _cold_backup_contexts) {
-        pair.second->cancel();
-        ddebug("%s: cancel backup progress, backup_request = %s",
-               name(),
-               boost::lexical_cast<std::string>(pair.second->request).c_str());
+    auto find = _cold_backup_contexts.find(policy_name);
+    if (find != _cold_backup_contexts.end()) {
+        cold_backup_context_ptr backup_context = find->second;
+        if (backup_context->is_checkpointing()) {
+            ddebug_replica("{}: delay cancel cold backup, cause backup_status == "
+                           "ColdBackupCheckpointing",
+                           backup_context->name);
+            tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
+                             &_tracker,
+                             [this, policy_name]() { cancel_cold_backup(policy_name); },
+                             get_gpid().thread_hash(),
+                             std::chrono::seconds(100));
+            return;
+        }
+
+        ddebug_replica("{}: try to cancel cold backup.", backup_context->name);
+        backup_context->cancel();
+        _cold_backup_contexts.erase(policy_name);
+    }
+
+    _backup_mgr->background_clear_backup_checkpoint(policy_name);
+}
+
+void replica::cancel_all_cold_backups()
+{
+    for (auto &it : _cold_backup_contexts) {
+        cancel_cold_backup(it.first);
     }
 }
 
-void replica::clear_cold_backup_state() { _cold_backup_contexts.clear(); }
 } // namespace replication
 } // namespace dsn

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -810,8 +810,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
                 // case 1 and case 2, just continue uploading
                 //(when case2, we stop uploading when it change to secondary)
             } else {
-                set_backup_context_cancel();
-                clear_cold_backup_state();
+                cancel_all_cold_backups();
             }
             break;
         case partition_status::PS_SECONDARY:
@@ -820,8 +819,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             // only load balance will occur primary -> secondary
             // and we just stop upload and release the cold_backup_state, and let new primary to
             // upload
-            set_backup_context_cancel();
-            clear_cold_backup_state();
+            cancel_all_cold_backups();
             break;
         case partition_status::PS_POTENTIAL_SECONDARY:
             dassert(false, "invalid execution path");
@@ -839,8 +837,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             // if secondary upgrade to primary, we must cancel & clear cold_backup_state, because
             // new-primary must check whether backup is already completed by previous-primary
 
-            set_backup_context_cancel();
-            clear_cold_backup_state();
+            cancel_all_cold_backups();
         }
         switch (config.status) {
         case partition_status::PS_PRIMARY:
@@ -917,8 +914,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
     case partition_status::PS_INACTIVE:
         if (config.status != partition_status::PS_PRIMARY || !_inactive_is_transient) {
             // except for case 1, we need stop uploading backup checkpoint
-            set_backup_context_cancel();
-            clear_cold_backup_state();
+            cancel_all_cold_backups();
         }
         switch (config.status) {
         case partition_status::PS_PRIMARY:


### PR DESCRIPTION
In order to remove duplicate codes, this patch introduce a new funtion `cancel_cold_backup(const std::string& policy_name)`, which cancels specific backup and clears related checkpoint directories, and we don't need to remove these directories in `generate_backup_checkpoint()`.
