### PR TITLE
feat(new backup): part 1: add backup_engine to implement backup

### DIFF
--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -158,9 +158,6 @@ void backup_engine::on_backup_reply(dsn::error_code err,
 {
 }
 
-// TODO: backup_service and policy_context should need two locks, its own _lock and server_state's
-// _lock this maybe lead to deadlock, should refactor this
-
 void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
 {
     error_code err = backup_app_meta(_policy.app_names.at(app_id), app_id, _cur_backup.backup_id);

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -40,9 +40,9 @@ backup_engine::~backup_engine() { _tracker.cancel_outstanding_tasks(); }
 void backup_engine::set_block_service(const std::string &provider)
 {
     _provider_type = provider;
-    _block_service.reset(_backup_service->get_meta_service()
-                             ->get_block_service_manager()
-                             .get_or_create_block_filesystem(provider));
+    _block_service = _backup_service->get_meta_service()
+                         ->get_block_service_manager()
+                         .get_or_create_block_filesystem(provider);
     dassert(_block_service, "can't initialize block filesystem by provider (%s)", provider);
 }
 
@@ -72,7 +72,7 @@ error_code backup_engine::write_backup_file(const std::string &file_name,
 
     remote_file
         ->write(dist::block_service::write_request{write_buffer},
-                LPC_DEFAULT_CALLBACK,
+                TASK_CODE_EXEC_INLINED,
                 [&err](const dist::block_service::write_response &resp) { err = resp.err; })
         ->wait();
     return err;

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -242,8 +242,8 @@ public:
 protected:
     friend class policy_context_test;
 
-    std::shared_ptr<backup_service> _backup_service;
-    std::shared_ptr<dist::block_service::block_filesystem> _block_service;
+    backup_service *_backup_service;
+    dist::block_service::block_filesystem *_block_service;
     std::string _provider_type;
     dsn::task_tracker _tracker;
 };

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -227,7 +227,7 @@ protected:
         _policy.app_names[3] = "app3";
         _policy.app_names[4] = "app4";
         _policy.app_names[6] = "app6";
-        _mp._backup_service = _service->_backup_handler.get();
+        _mp._backup_service = _service->_backup_handler;
         _mp.set_policy(policy(_policy));
 
         _service->_storage

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -227,7 +227,7 @@ protected:
         _policy.app_names[3] = "app3";
         _policy.app_names[4] = "app4";
         _policy.app_names[6] = "app6";
-        _mp._backup_service = _service->_backup_handler;
+        _mp._backup_service = _service->_backup_handler.get();
         _mp.set_policy(policy(_policy));
 
         _service->_storage


### PR DESCRIPTION
This patch added a new class `backup_engine`, and abstracted some functions from `policy_context` into `backup_engine`. I will implement new backup functions using `bakcup_engine` in the next pull request.