### PR TITLE
fix: fix bug when update bool app envs

### DIFF
--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -567,11 +567,12 @@ void replica::update_bool_envs(const std::map<std::string, std::string> &envs,
                                const std::string &name,
                                bool &value)
 {
-    bool new_value = value;
+    bool new_value = false;
     auto iter = envs.find(name);
     if (iter != envs.end()) {
         if (!buf2bool(iter->second, new_value)) {
             dwarn_replica("invalid value of env {}: \"{}\"", name, iter->second);
+            return;
         }
     }
     if (new_value != value) {

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -167,20 +167,18 @@ TEST_F(replica_test, update_validate_partition_hash_test)
 {
     struct update_validate_partition_hash_test
     {
-        bool old_value;
         bool set_in_map;
+        bool old_value;
         std::string new_value;
         bool expected_value;
-    } tests[]{
-        {false, false, "false", false},
-        {false, true, "false", false},
-        {false, false, "true", false},
-        {false, true, "true", true},
-        {false, true, "ture", false},
-        {true, true, "false", false},
-        {true, true, "true", true},
-        {true, true, "flase", true},
-    };
+    } tests[]{{true, false, "false", false},
+              {true, false, "true", true},
+              {true, true, "true", true},
+              {true, true, "false", false},
+              {false, false, "", false},
+              {false, true, "", false},
+              {true, true, "flase", true},
+              {true, false, "ture", false}};
     for (const auto &test : tests) {
         update_validate_partition_hash(test.old_value, test.set_in_map, test.new_value);
         ASSERT_EQ(get_validate_partition_hash(), test.expected_value);


### PR DESCRIPTION
Function `update_bool_envs` is used to update bool app envs:
- old value = false, app value = false/true -> new value =  false/true
- old value = true, app value = false/true -> new value =  false/true

But the previous implemetation didn't consider the value is not set. For example, old value = true, admin delete this app envs, replica will not update value into false, this patch fixs this bug and update unit tests.