### PR TITLE
fix: fix core while running simple_kv unit test

### DIFF
--- a/src/aio/sim_aio_provider.cpp
+++ b/src/aio/sim_aio_provider.cpp
@@ -35,11 +35,8 @@ sim_aio_provider::sim_aio_provider(disk_engine *disk) : native_linux_aio_provide
 
 void sim_aio_provider::submit_aio_task(aio_task *aio)
 {
-    error_code err;
     uint32_t bytes;
-
-    err = aio_internal(aio, &bytes);
-    complete_io(aio, err, bytes);
+    aio_internal(aio, &bytes);
 }
 
 } // namespace aio


### PR DESCRIPTION
#777 removes parameter `async` for `native_linux_aio_provider::aio_internal`, `async=false` parameter is only used running simple kv tests. That pr left a problem that function `complete_io` would be called twice, which leading coredump running simple kv unit tests. This patch fixs it.