### PR TITLE
fix(cmake): define `ENABLE_GCOV` when build with `--enable_gcov`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(ENABLE_GCOV)
     message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
 
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
+    add_definitions(-DENABLE_GCOV=1)
 endif()
 
 # Users don't have to configure CMAKE_INSTALL_PREFIX unless they want to customize


### PR DESCRIPTION
Some of the test code is written like this:
```
...

// exit without any destruction
#ifndef ENABLE_GCOV
    dsn_exit(0);
#endif
    return 0;
```

When we need to test destructors, `ENABLE_GCOV` should be defined, otherwise `dsn_exit()` would be called finally.