### PR TITLE
refactor: remove unused config aio_factory_name

### DIFF
--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -49,11 +49,6 @@ struct disk_engine_initializer
 // because service_engine relies on the former to close files.
 static disk_engine_initializer disk_engine_init;
 
-DSN_DEFINE_string("core",
-                  aio_factory_name,
-                  native_aio_provider,
-                  "asynchonous file system provider");
-
 //----------------- disk_file ------------------------
 aio_task *disk_write_queue::unlink_next_workload(void *plength)
 {

--- a/src/replica/storage/simple_kv/config.ini
+++ b/src/replica/storage/simple_kv/config.ini
@@ -39,8 +39,6 @@ toollets = tracer, profiler, fault_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 ;logging_start_level = LOG_LEVEL_WARNING
 ;logging_factory_name = dsn::tools::screen_logger
 ;logging_factory_name = dsn::tools::hpc_logger

--- a/src/replica/storage/simple_kv/test/case-000.ini
+++ b/src/replica/storage/simple_kv/test/case-000.ini
@@ -43,8 +43,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-001.ini
+++ b/src/replica/storage/simple_kv/test/case-001.ini
@@ -43,8 +43,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-002.ini
+++ b/src/replica/storage/simple_kv/test/case-002.ini
@@ -43,8 +43,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-003.ini
+++ b/src/replica/storage/simple_kv/test/case-003.ini
@@ -43,8 +43,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-004.ini
+++ b/src/replica/storage/simple_kv/test/case-004.ini
@@ -43,8 +43,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-005.ini
+++ b/src/replica/storage/simple_kv/test/case-005.ini
@@ -43,8 +43,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-006.ini
+++ b/src/replica/storage/simple_kv/test/case-006.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-100.ini
+++ b/src/replica/storage/simple_kv/test/case-100.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-101.ini
+++ b/src/replica/storage/simple_kv/test/case-101.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-102.ini
+++ b/src/replica/storage/simple_kv/test/case-102.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-103.ini
+++ b/src/replica/storage/simple_kv/test/case-103.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-104.ini
+++ b/src/replica/storage/simple_kv/test/case-104.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-105.ini
+++ b/src/replica/storage/simple_kv/test/case-105.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-106.ini
+++ b/src/replica/storage/simple_kv/test/case-106.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-107.ini
+++ b/src/replica/storage/simple_kv/test/case-107.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-108.ini
+++ b/src/replica/storage/simple_kv/test/case-108.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-109.ini
+++ b/src/replica/storage/simple_kv/test/case-109.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-200.ini
+++ b/src/replica/storage/simple_kv/test/case-200.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-201.ini
+++ b/src/replica/storage/simple_kv/test/case-201.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-202-0.ini
+++ b/src/replica/storage/simple_kv/test/case-202-0.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-202-1.ini
+++ b/src/replica/storage/simple_kv/test/case-202-1.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-203-0.ini
+++ b/src/replica/storage/simple_kv/test/case-203-0.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-203-1.ini
+++ b/src/replica/storage/simple_kv/test/case-203-1.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-204.ini
+++ b/src/replica/storage/simple_kv/test/case-204.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-205.ini
+++ b/src/replica/storage/simple_kv/test/case-205.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-206.ini
+++ b/src/replica/storage/simple_kv/test/case-206.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-207.ini
+++ b/src/replica/storage/simple_kv/test/case-207.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-208.ini
+++ b/src/replica/storage/simple_kv/test/case-208.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-209.ini
+++ b/src/replica/storage/simple_kv/test/case-209.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-212.ini
+++ b/src/replica/storage/simple_kv/test/case-212.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-214.ini
+++ b/src/replica/storage/simple_kv/test/case-214.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-215.ini
+++ b/src/replica/storage/simple_kv/test/case-215.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-216.ini
+++ b/src/replica/storage/simple_kv/test/case-216.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-300-0.ini
+++ b/src/replica/storage/simple_kv/test/case-300-0.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-300-1.ini
+++ b/src/replica/storage/simple_kv/test/case-300-1.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-300-2.ini
+++ b/src/replica/storage/simple_kv/test/case-300-2.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-301.ini
+++ b/src/replica/storage/simple_kv/test/case-301.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-302.ini
+++ b/src/replica/storage/simple_kv/test/case-302.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-303.ini
+++ b/src/replica/storage/simple_kv/test/case-303.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-304.ini
+++ b/src/replica/storage/simple_kv/test/case-304.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-305.ini
+++ b/src/replica/storage/simple_kv/test/case-305.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-306.ini
+++ b/src/replica/storage/simple_kv/test/case-306.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-307.ini
+++ b/src/replica/storage/simple_kv/test/case-307.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-400.ini
+++ b/src/replica/storage/simple_kv/test/case-400.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-401.ini
+++ b/src/replica/storage/simple_kv/test/case-401.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-402.ini
+++ b/src/replica/storage/simple_kv/test/case-402.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-600.ini
+++ b/src/replica/storage/simple_kv/test/case-600.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-601.ini
+++ b/src/replica/storage/simple_kv/test/case-601.ini
@@ -44,8 +44,6 @@ toollets = tracer,test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-602.ini
+++ b/src/replica/storage/simple_kv/test/case-602.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/case-603.ini
+++ b/src/replica/storage/simple_kv/test/case-603.ini
@@ -44,8 +44,6 @@ toollets = test_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 

--- a/src/replica/storage/simple_kv/test/config.ini
+++ b/src/replica/storage/simple_kv/test/config.ini
@@ -61,8 +61,6 @@ toollets = tracer, profiler, fault_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 ;logging_start_level = LOG_LEVEL_WARNING
 ;logging_factory_name = dsn::tools::screen_logger
 ;logging_factory_name = dsn::tools::hpc_logger

--- a/src/runtime/test/config-test-sim.ini
+++ b/src/runtime/test/config-test-sim.ini
@@ -37,8 +37,6 @@ tool = simulator
 toollets = tracer, profiler
 pause_on_start = false
 
-aio_factory_name = dsn::tools::sim_aio_provider
-
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger
 


### PR DESCRIPTION
In https://github.com/XiaoMi/rdsn/pull/778, we decoupled aio from dsn runtime. And make the config `aio_factory_name` unused. So in this pr, I remove the unused config `aio_factory_name` in each *.ini file

```diff
-  aio_factory_name
```