### PR TITLE
feat(http): update query data version

### DIFF
--- a/src/replica/replica_http_service.cpp
+++ b/src/replica/replica_http_service.cpp
@@ -83,17 +83,14 @@ void replica_http_service::query_app_data_version_handler(const http_request &re
         return;
     }
 
-    dsn::utils::table_printer tp;
-    tp.add_title("pidx");
-    tp.add_column("data_version");
+    nlohmann::json json;
     for (const auto &kv : version_map) {
-        tp.add_row(kv.first);
-        tp.append_data(kv.second);
+        json[std::to_string(kv.first)] = nlohmann::json{
+            {"data_version", std::to_string(kv.second)},
+        };
     }
-    std::ostringstream out;
-    tp.output(out, dsn::utils::table_printer::output_format::kJsonCompact);
-    resp.body = out.str();
     resp.status_code = http_status_code::ok;
+    resp.body = json.dump();
 }
 
 void replica_http_service::query_compaction_handler(const http_request &req, http_response &resp)

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -112,7 +112,7 @@ TEST_F(replica_test, query_data_version_test)
                  {"wrong", http_status_code::bad_request, "invalid app_id=wrong"},
                  {"2",
                   http_status_code::ok,
-                  R"({"1":{"pidx":"1","data_version":"1"}})"},
+                  R"({"1":{"data_version":"1"}})"},
                  {"4", http_status_code::not_found, "app_id=4 not found"}};
     for (const auto &test : tests) {
         http_request req;
@@ -123,9 +123,6 @@ TEST_F(replica_test, query_data_version_test)
         http_svc.query_app_data_version_handler(req, resp);
         ASSERT_EQ(resp.status_code, test.expected_code);
         std::string expected_json = test.expected_response_json;
-        if (test.expected_code == http_status_code::ok) {
-            expected_json += "\n";
-        }
         ASSERT_EQ(resp.body, expected_json);
     }
 }


### PR DESCRIPTION
#731 update replica query data version http interface. The pervious interface is like below:
```
{
    "1":{
        "data_version": "1",
        "pidx" : "1",
    },
    ......
}
```
This pull request simplify this interface, remove the duplicated pidx filed, like below:
```
{
    "1":{
        "data_version": "1",
    },
    ......
}
```