### PR TITLE
feat(http): update query manual compaction interface

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -471,7 +471,7 @@ void replica::close()
     ddebug("%s: replica closed, time_used = %" PRIu64 "ms", name(), dsn_now_ms() - start_time);
 }
 
-std::string replica::query_compact_state() const
+std::string replica::query_manual_compact_state() const
 {
     dassert_replica(_app != nullptr, "");
     return _app->query_compact_state();
@@ -480,22 +480,24 @@ std::string replica::query_compact_state() const
 const char *manual_compaction_status_to_string(manual_compaction_status status)
 {
     switch (status) {
-    case kFinish:
-        return "CompactionFinish";
-    case kRunning:
-        return "CompactionRunning";
+    case kIdle:
+        return "idle";
     case kQueue:
-        return "CompactionQueue";
+        return "queue";
+    case kRunning:
+        return "running";
+    case kFinish:
+        return "finish";
     default:
         dassert(false, "invalid status({})", status);
         __builtin_unreachable();
     }
 }
 
-manual_compaction_status replica::get_compact_status() const
+manual_compaction_status replica::get_manual_compact_status() const
 {
-    std::string compact_state = query_compact_state();
-    // query_compact_state will return a message like:
+    std::string compact_state = query_manual_compact_state();
+    // query_manual_compact_state will return a message like:
     // Case1. last finish at [-]
     // - partition is not manual compaction
     // Case2. last finish at [timestamp], last used {time_used} ms
@@ -508,8 +510,10 @@ manual_compaction_status replica::get_compact_status() const
         return kRunning;
     } else if (compact_state.find("recent enqueue at") != std::string::npos) {
         return kQueue;
-    } else {
+    } else if (compact_state.find("last used") != std::string::npos) {
         return kFinish;
+    } else {
+        return kIdle;
     }
 }
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -482,12 +482,12 @@ const char *manual_compaction_status_to_string(manual_compaction_status status)
     switch (status) {
     case kIdle:
         return "idle";
-    case kQueue:
-        return "queue";
+    case kQueuing:
+        return "queuing";
     case kRunning:
         return "running";
-    case kFinish:
-        return "finish";
+    case kFinished:
+        return "finished";
     default:
         dassert(false, "invalid status({})", status);
         __builtin_unreachable();
@@ -509,9 +509,9 @@ manual_compaction_status replica::get_manual_compact_status() const
     if (compact_state.find("recent start at") != std::string::npos) {
         return kRunning;
     } else if (compact_state.find("recent enqueue at") != std::string::npos) {
-        return kQueue;
+        return kQueuing;
     } else if (compact_state.find("last used") != std::string::npos) {
-        return kFinish;
+        return kFinished;
     } else {
         return kIdle;
     }

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -80,9 +80,10 @@ class test_checker;
 
 enum manual_compaction_status
 {
-    kFinish = 0,
+    kIdle = 0,
+    kQueue,
     kRunning,
-    kQueue
+    kFinish
 };
 const char *manual_compaction_status_to_string(manual_compaction_status status);
 
@@ -408,10 +409,10 @@ private:
     // Used for remote command
     // TODO: remove this interface and only expose the http interface
     // now this remote commend will be used by `scripts/pegasus_manual_compact.sh`
-    std::string query_compact_state() const;
+    std::string query_manual_compact_state() const;
 
     // Used for http interface
-    manual_compaction_status get_compact_status() const;
+    manual_compaction_status get_manual_compact_status() const;
 
     void init_table_level_latency_counters();
 

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -81,9 +81,9 @@ class test_checker;
 enum manual_compaction_status
 {
     kIdle = 0,
-    kQueue,
+    kQueuing,
     kRunning,
-    kFinish
+    kFinished
 };
 const char *manual_compaction_status_to_string(manual_compaction_status status);
 

--- a/src/replica/replica_http_service.cpp
+++ b/src/replica/replica_http_service.cpp
@@ -115,25 +115,26 @@ void replica_http_service::query_manual_compaction_handler(const http_request &r
 
     int32_t idle_count = 0;
     int32_t running_count = 0;
-    int32_t queue_count = 0;
-    int32_t finish_count = 0;
+    int32_t queuing_count = 0;
+    int32_t finished_count = 0;
     for (const auto &kv : partition_compaction_status) {
         if (kv.second == kRunning) {
             running_count++;
-        } else if (kv.second == kQueue) {
-            queue_count++;
-        } else if (kv.second == kFinish) {
-            finish_count++;
+        } else if (kv.second == kQueuing) {
+            queuing_count++;
+        } else if (kv.second == kFinished) {
+            finished_count++;
         } else if (kv.second == kIdle) {
             idle_count++;
         }
     }
 
     nlohmann::json json;
-    json["status"] = nlohmann::json{{manual_compaction_status_to_string(kIdle), idle_count},
-                                    {manual_compaction_status_to_string(kRunning), running_count},
-                                    {manual_compaction_status_to_string(kQueue), queue_count},
-                                    {manual_compaction_status_to_string(kFinish), finish_count}};
+    json["status"] =
+        nlohmann::json{{manual_compaction_status_to_string(kIdle), idle_count},
+                       {manual_compaction_status_to_string(kRunning), running_count},
+                       {manual_compaction_status_to_string(kQueuing), queuing_count},
+                       {manual_compaction_status_to_string(kFinished), finished_count}};
     resp.status_code = http_status_code::ok;
     resp.body = json.dump();
 }

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -26,8 +26,8 @@ public:
                                    std::placeholders::_1,
                                    std::placeholders::_2),
                          "ip:port/replica/data_version?app_id=<app_id>");
-        register_handler("compaction",
-                         std::bind(&replica_http_service::query_compaction_handler,
+        register_handler("manual_compaction",
+                         std::bind(&replica_http_service::query_manual_compaction_handler,
                                    this,
                                    std::placeholders::_1,
                                    std::placeholders::_2),
@@ -38,7 +38,7 @@ public:
 
     void query_duplication_handler(const http_request &req, http_response &resp);
     void query_app_data_version_handler(const http_request &req, http_response &resp);
-    void query_compaction_handler(const http_request &req, http_response &resp);
+    void query_manual_compaction_handler(const http_request &req, http_response &resp);
 
 private:
     replica_stub *_stub;

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -31,7 +31,7 @@ public:
                                    this,
                                    std::placeholders::_1,
                                    std::placeholders::_2),
-                         "ip:port/replica/compaction?app_id=<app_id>");
+                         "ip:port/replica/maual_compaction?app_id=<app_id>");
     }
 
     std::string path() const override { return "replica"; }

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2255,8 +2255,9 @@ void replica_stub::register_ctrl_command()
             "query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
             "query-compact - query full compact status on the underlying storage engine",
             [this](const std::vector<std::string> &args) {
-                return exec_command_on_replica(
-                    args, true, [](const replica_ptr &rep) { return rep->query_compact_state(); });
+                return exec_command_on_replica(args, true, [](const replica_ptr &rep) {
+                    return rep->query_manual_compact_state();
+                });
             });
 
         _query_app_envs_command = ::dsn::command_manager::instance().register_command(
@@ -2846,13 +2847,13 @@ void replica_stub::query_app_data_version(
     }
 }
 
-void replica_stub::query_app_compact_status(
+void replica_stub::query_app_manual_compact_status(
     int32_t app_id, std::unordered_map<gpid, manual_compaction_status> &status)
 {
     zauto_read_lock l(_replicas_lock);
     for (auto it = _replicas.begin(); it != _replicas.end(); ++it) {
         if (it->first.get_app_id() == app_id) {
-            status[it->first] = it->second->get_compact_status();
+            status[it->first] = it->second->get_manual_compact_status();
         }
     }
 }

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -219,9 +219,8 @@ public:
     void on_disk_migrate(replica_disk_migrate_rpc rpc);
 
     // query partitions compact status by app_id
-    void
-    query_app_compact_status(int32_t app_id,
-                             /*out*/ std::unordered_map<gpid, manual_compaction_status> &status);
+    void query_app_manual_compact_status(
+        int32_t app_id, /*out*/ std::unordered_map<gpid, manual_compaction_status> &status);
 
 private:
     enum replica_node_state

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -139,10 +139,10 @@ TEST_F(replica_test, query_compaction_test)
                  {"xxx", http_status_code::bad_request, "invalid app_id=xxx"},
                  {"2",
                   http_status_code::ok,
-                  R"({"status":{"finish":0,"idle":1,"queue":0,"running":0}})"},
+                  R"({"status":{"finished":0,"idle":1,"queuing":0,"running":0}})"},
                  {"4",
                   http_status_code::ok,
-                  R"({"status":{"finish":0,"idle":0,"queue":0,"running":0}})"}};
+                  R"({"status":{"finished":0,"idle":0,"queuing":0,"running":0}})"}};
     for (const auto &test : tests) {
         http_request req;
         http_response resp;

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -135,28 +135,23 @@ TEST_F(replica_test, query_compaction_test)
         std::string app_id;
         http_status_code expected_code;
         std::string expected_response_json;
-    } tests[] = {
-        {"", http_status_code::bad_request, "app_id should not be empty"},
-        {"xxx", http_status_code::bad_request, "invalid app_id=xxx"},
-        {"2",
-         http_status_code::ok,
-         R"({"status":{"CompactionRunning":"0","CompactionQueue":"0","CompactionFinish":"1"}})"},
-        {"4",
-         http_status_code::ok,
-         R"({"status":{"CompactionRunning":"0","CompactionQueue":"0","CompactionFinish":"0"}})"}};
+    } tests[] = {{"", http_status_code::bad_request, "app_id should not be empty"},
+                 {"xxx", http_status_code::bad_request, "invalid app_id=xxx"},
+                 {"2",
+                  http_status_code::ok,
+                  R"({"status":{"finish":0,"idle":1,"queue":0,"running":0}})"},
+                 {"4",
+                  http_status_code::ok,
+                  R"({"status":{"finish":0,"idle":0,"queue":0,"running":0}})"}};
     for (const auto &test : tests) {
         http_request req;
         http_response resp;
         if (!test.app_id.empty()) {
             req.query_args["app_id"] = test.app_id;
         }
-        http_svc.query_compaction_handler(req, resp);
+        http_svc.query_manual_compaction_handler(req, resp);
         ASSERT_EQ(resp.status_code, test.expected_code);
-        std::string expected_json = test.expected_response_json;
-        if (test.expected_code == http_status_code::ok) {
-            expected_json += "\n";
-        }
-        ASSERT_EQ(resp.body, expected_json);
+        ASSERT_EQ(resp.body, test.expected_response_json);
     }
 }
 


### PR DESCRIPTION
#696 adds a http interface to query manual compaction status, this pr updates it:
- rename all `compact` and `compaction` into `manual_compact` and `manual_compaction`
- add a new status `kIdle` to distinguish not execute manual compaction and manual compaction finished
- update count in response from string into integer

The previous request and response is like:
```
curl 'http://localhost:34801/replica/compaction?app_id=1'
{
    "status": {
        "CompactionFinish": "8", 
        "CompactionQueue": "0", 
        "CompactionRunning": "0"
    }
}
```

The new request and response is like:
```
curl 'http://localhost:34801/replica/manual_compaction?app_id=1'
{
    "status": {
        "finished": 8,
        "idle": 0, 
        "queuing": 0, 
        "running": 0
    }
}
```