### PR TITLE
fix: compilation errors on clang-9

### DIFF
--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -206,9 +206,9 @@ function(dsn_setup_compiler_flags)
     # -Wno-deprecated-register
     #   kbr5.h uses the legacy 'register' keyword.
     add_compile_options(-Wno-deprecated-register)
-    # -Wimplicit-int-float-conversion
+    # -Wno-implicit-float-conversion
     #   Poco/Dynamic/VarHolder.h uses 'unsigned long' to 'float' conversion
-    add_compile_options(-Wno-implicit-int-float-conversion)
+    add_compile_options(-Wno-implicit-float-conversion)
 
     find_program(CCACHE_FOUND ccache)
     if(CCACHE_FOUND)


### PR DESCRIPTION
```
error: unknown warning option '-Wno-implicit-int-float-conversion'; did you mean '-Wno-implicit-float-conversion'? [-Werror,-Wunknown-warning-option]
```

Clang9 can't recognize the flag '-Wno-implicit-int-float-conversion' so I fallback to use '-Wno-implicit-float-conversion'. This flag works at both clang9 and clang10 environments.

Check this failure at here: https://github.com/pegasus-kv/pegasus-docker/runs/2221177367?check_suite_focus=true
