### PR TITLE
fix(backup_policy): do not try again when got fs errors

### DIFF
--- a/src/block_service/local/local_service.h
+++ b/src/block_service/local/local_service.h
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #pragma once
 
 #include <fstream>

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -130,6 +130,7 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
                     start_backup_app_partitions_unlocked(app_id);
                 }
             } else if (resp.err == ERR_FS_INTERNAL) {
+                zauto_lock l(_lock);
                 _is_backup_failed = true;
                 derror_f("write {} failed, err = {}, don't try again when got this error.",
                          remote_file->file_name(),
@@ -245,6 +246,7 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
                     write_callback->enqueue();
                 }
             } else if (resp.err == ERR_FS_INTERNAL) {
+                zauto_lock l(_lock);
                 _is_backup_failed = true;
                 derror_f("write {} failed, err = {}, don't try again when got this error.",
                          remote_file->file_name(),
@@ -352,6 +354,7 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
                     write_callback->enqueue();
                 }
             } else if (resp.err == ERR_FS_INTERNAL) {
+                zauto_lock l(_lock);
                 _is_backup_failed = true;
                 derror_f("write {} failed, err = {}, don't try again when got this error.",
                          remote_file->file_name(),
@@ -529,6 +532,7 @@ void policy_context::on_backup_reply(error_code err,
             }
         }
     } else if (response.err == dsn::ERR_LOCAL_APP_FAILURE) {
+        zauto_lock l(_lock);
         _is_backup_failed = true;
         derror_f("{}: backup got error {} for partition {} from {}, don't try again when got "
                  "this error.",

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -129,6 +129,12 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
                            remote_file->file_name().c_str());
                     start_backup_app_partitions_unlocked(app_id);
                 }
+            } else if (resp.err == ERR_FS_INTERNAL) {
+                _is_backup_failed = true;
+                derror_f("write {} failed, err = {}, don't try again when got this error.",
+                         remote_file->file_name(),
+                         resp.err.to_string());
+                return;
             } else {
                 dwarn("write %s failed, reason(%s), try it later",
                       remote_file->file_name().c_str(),
@@ -238,6 +244,12 @@ void policy_context::write_backup_app_finish_flag_unlocked(int32_t app_id,
                 if (write_callback != nullptr) {
                     write_callback->enqueue();
                 }
+            } else if (resp.err == ERR_FS_INTERNAL) {
+                _is_backup_failed = true;
+                derror_f("write {} failed, err = {}, don't try again when got this error.",
+                         remote_file->file_name(),
+                         resp.err.to_string());
+                return;
             } else {
                 dwarn("write %s failed, reason(%s), try it later",
                       remote_file->file_name().c_str(),
@@ -328,31 +340,37 @@ void policy_context::write_backup_info_unlocked(const backup_info &b_info,
 
     blob buf = dsn::json::json_forwarder<backup_info>::encode(b_info);
 
-    remote_file->write(dist::block_service::write_request{buf},
-                       LPC_DEFAULT_CALLBACK,
-                       [this, b_info, write_callback, remote_file](
-                           const dist::block_service::write_response &resp) {
-                           if (resp.err == ERR_OK) {
-                               ddebug("policy(%s) write backup_info to cold backup media succeed",
-                                      _policy.policy_name.c_str());
-                               if (write_callback != nullptr) {
-                                   write_callback->enqueue();
-                               }
-                           } else {
-                               dwarn("write %s failed, reason(%s), try it later",
-                                     remote_file->file_name().c_str(),
-                                     resp.err.to_string());
-                               tasking::enqueue(
-                                   LPC_DEFAULT_CALLBACK,
-                                   &_tracker,
-                                   [this, b_info, write_callback]() {
-                                       zauto_lock l(_lock);
-                                       write_backup_info_unlocked(b_info, write_callback);
-                                   },
-                                   0,
-                                   _backup_service->backup_option().block_retry_delay_ms);
-                           }
-                       });
+    remote_file->write(
+        dist::block_service::write_request{buf},
+        LPC_DEFAULT_CALLBACK,
+        [this, b_info, write_callback, remote_file](
+            const dist::block_service::write_response &resp) {
+            if (resp.err == ERR_OK) {
+                ddebug("policy(%s) write backup_info to cold backup media succeed",
+                       _policy.policy_name.c_str());
+                if (write_callback != nullptr) {
+                    write_callback->enqueue();
+                }
+            } else if (resp.err == ERR_FS_INTERNAL) {
+                _is_backup_failed = true;
+                derror_f("write {} failed, err = {}, don't try again when got this error.",
+                         remote_file->file_name(),
+                         resp.err.to_string());
+                return;
+            } else {
+                dwarn("write %s failed, reason(%s), try it later",
+                      remote_file->file_name().c_str(),
+                      resp.err.to_string());
+                tasking::enqueue(LPC_DEFAULT_CALLBACK,
+                                 &_tracker,
+                                 [this, b_info, write_callback]() {
+                                     zauto_lock l(_lock);
+                                     write_backup_info_unlocked(b_info, write_callback);
+                                 },
+                                 0,
+                                 _backup_service->backup_option().block_retry_delay_ms);
+            }
+        });
 }
 
 bool policy_context::update_partition_progress_unlocked(gpid pid,
@@ -510,6 +528,15 @@ void policy_context::on_backup_reply(error_code err,
                 return;
             }
         }
+    } else if (response.err == dsn::ERR_LOCAL_APP_FAILURE) {
+        _is_backup_failed = true;
+        derror_f("{}: backup got error {} for partition {} from {}, don't try again when got "
+                 "this error.",
+                 _backup_sig.c_str(),
+                 response.err.to_string(),
+                 pid.to_string(),
+                 primary.to_string());
+        return;
     } else {
         dwarn_f("{}: backup got error for partition {} from {}, rpc error {}, response error {}",
                 _backup_sig.c_str(),
@@ -571,6 +598,7 @@ void policy_context::prepare_current_backup_on_new_unlocked()
     _cur_backup.backup_id = _cur_backup.start_time_ms = static_cast<int64_t>(dsn_now_ms());
     _cur_backup.app_ids = _policy.app_ids;
     _cur_backup.app_names = _policy.app_names;
+    _is_backup_failed = false;
 
     initialize_backup_progress_unlocked();
     _backup_sig =
@@ -838,7 +866,7 @@ std::vector<backup_info> policy_context::get_backup_infos(int cnt)
 bool policy_context::is_under_backuping()
 {
     zauto_lock l(_lock);
-    if (_cur_backup.start_time_ms > 0 && _cur_backup.end_time_ms <= 0) {
+    if (!_is_backup_failed && _cur_backup.start_time_ms > 0 && _cur_backup.end_time_ms <= 0) {
         return true;
     }
     return false;

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -296,6 +296,7 @@ mock_private :
 
     // backup related
     backup_info _cur_backup;
+    bool _is_backup_failed;
     // backup_id --> backup_info
     std::map<int64_t, backup_info> _backup_history;
     backup_progress _progress;

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -307,6 +307,7 @@ private:
 
     FRIEND_TEST(meta_backup_service_test, test_add_backup_policy);
     FRIEND_TEST(policy_context_test, test_app_dropped_during_backup);
+    FRIEND_TEST(policy_context_test, test_backup_failed);
 
     dsn::task_tracker _tracker;
 

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -540,7 +540,7 @@ TEST_F(policy_context_test, test_app_dropped_during_backup)
 TEST_F(policy_context_test, test_backup_failed)
 {
     fail::setup();
-    fail::cfg("mock_local_service_write_failed", "100%1*return()");
+    fail::cfg("mock_local_service_write_failed", "100%1*return(ERR_FS_INTERNAL)");
 
     // app 1 is available.
     dsn::app_info info;

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -25,6 +25,8 @@
 #include "meta_service_test_app.h"
 #include "meta_test_base.h"
 
+DSN_DECLARE_bool(mock_local_service_write_failed);
+
 namespace dsn {
 namespace replication {
 
@@ -534,6 +536,35 @@ TEST_F(policy_context_test, test_app_dropped_during_backup)
             test_policy_name + std::string("@") + std::to_string(bi.backup_id);
         ASSERT_EQ(cur_backup_sig, _mp._backup_sig);
     }
+}
+
+TEST_F(policy_context_test, test_backup_failed)
+{
+    // app 1 is available.
+    dsn::app_info info;
+    info.is_stateful = true;
+    info.app_id = 1;
+    info.app_type = "simple_kv";
+    info.max_replica_count = 3;
+    info.partition_count = 32;
+    info.status = dsn::app_status::AS_AVAILABLE;
+    _service->get_server_state()->_all_apps.emplace(info.app_id, app_state::create(info));
+
+    FLAGS_mock_local_service_write_failed = true;
+    {
+        zauto_lock l(_mp._lock);
+        _mp._backup_history.clear();
+        _mp.reset_records();
+
+        // start backup in this policy
+        _mp.issue_new_backup_unlocked();
+    }
+    sleep(1);
+    {
+        zauto_lock l(_mp._lock);
+        ASSERT_TRUE(_mp._is_backup_failed);
+    }
+    ASSERT_FALSE(_mp.is_under_backuping());
 }
 
 // test should_start_backup_unlock()

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -565,6 +565,7 @@ TEST_F(policy_context_test, test_backup_failed)
         ASSERT_TRUE(_mp._is_backup_failed);
     }
     ASSERT_FALSE(_mp.is_under_backuping());
+    FLAGS_mock_local_service_write_failed = false;
 }
 
 // test should_start_backup_unlock()

--- a/src/meta/test/clear.sh
+++ b/src/meta/test/clear.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-rm -rf core data/ meta_state.dump* zoolog.log backup_data *.xml test_policy_name test_backup_root
+rm -rf core data/ meta_state.dump* zoolog.log backup_data *.xml test_policy_name test_backup_root block_service/

--- a/src/meta/test/config-test.ini
+++ b/src/meta/test/config-test.ini
@@ -102,7 +102,7 @@ logfile = zoolog.log
 
 [block_service.local_service]
 type = local_service
-args =
+args = ./block_service
 
 [block_service.fds_service]
 type = fds_service


### PR DESCRIPTION
Prior to this patch, if we got errors during backup process, meta would retry again and again, the backup would never stop or be disabled until backup success. 
This pr marked a policy failed when got fs errors during backup, and we could disable the policy after it is marked failed.

I tested it on a real cluster, set `fds_burst_size` to 500 bytes to mock fds errors.
```
-_write_token_bucket.reset(new folly::TokenBucket(FLAGS_fds_write_limit_rate << 20, std::numeric_limits<double>::max()));
+_write_token_bucket.reset(new folly::TokenBucket(FLAGS_fds_write_limit_rate << 20,500));

```
test steps:
1. add a backup policy
2. query the policy
```
>>> query_backup_policy -p test_fds
policy_info:
    name                  : test_fds
    backup_provider_type  : fds_wq  
    backup_interval       : 86400s  
    app_ids               : {1}     
    start_time            : 17:25   
    status                : enabled 
    backup_history_count  : 2       

backup_infos:
[1]
    id          : 1617701020841      
    start_time  : 2021-04-06 17:23:40
    end_time    : -                  
    app_ids     : {1}                

query backup policy succeed
```
The backup has started but didn't finish, I checked logs in meta server:
```
D2021-04-06 18:07:30.939 (1617703650939435182 183307)   meta.default3.0201000500000010: meta_backup_service.cpp:493:on_backup_reply(): test_fds@1617701020841: receive backup response for partition 1.6 from server 10.132.15.13:35801.
E2021-04-06 18:07:30.939 (1617703650939451019 183307)   meta.default3.0201000500000010: meta_backup_service.cpp:542:on_backup_reply(): test_fds@1617701020841: backup got error ERR_LOCAL_APP_FAILURE for partition 1.6 from 10.132.15.13:35801, don't try again when got this error.
```
3. try to disable the policy
```
>>> disable_backup_policy -p test_fds
disable policy result: ERR_OK
```
We could disable it because the backup is failed.
Then try to query the policy:(it has been disabled)
```
>>> query_backup_policy -p test_fds
policy_info:
    name                  : test_fds
    backup_provider_type  : fds_wq  
    backup_interval       : 86400s  
    app_ids               : {1}     
    start_time            : 17:25   
    status                : disabled
    backup_history_count  : 2       

backup_infos:
[1]
    id          : 1617701020841      
    start_time  : 2021-04-06 17:23:40
    end_time    : -                  
    app_ids     : {1}                

query backup policy succeed
```
4. try to enable the policy.
```
>>> enable_backup_policy -p test_fds
enable policy result: ERR_OK
```
We could enable the policy, but the backup will still fail if we don't change the burst_size.