### PR TITLE
fix: incorrect help info of meta/replica remote commands

### DIFF
--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -93,7 +93,7 @@ void greedy_load_balancer::register_ctrl_commands()
 
     _ctrl_balancer_in_turn = dsn::command_manager::instance().register_command(
         {"meta.lb.balancer_in_turn"},
-        "lb.balancer_in_turn <true|false>",
+        "meta.lb.balancer_in_turn <true|false>",
         "control whether do app balancer in turn",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_balancer_in_turn, "lb.balancer_in_turn", args);
@@ -101,7 +101,7 @@ void greedy_load_balancer::register_ctrl_commands()
 
     _ctrl_only_primary_balancer = dsn::command_manager::instance().register_command(
         {"meta.lb.only_primary_balancer"},
-        "lb.only_primary_balancer <true|false>",
+        "meta.lb.only_primary_balancer <true|false>",
         "control whether do only primary balancer",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(
@@ -110,7 +110,7 @@ void greedy_load_balancer::register_ctrl_commands()
 
     _ctrl_only_move_primary = dsn::command_manager::instance().register_command(
         {"meta.lb.only_move_primary"},
-        "lb.only_move_primary <true|false>",
+        "meta.lb.only_move_primary <true|false>",
         "control whether only move primary in balancer",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(_only_move_primary, "lb.only_move_primary", args);
@@ -118,13 +118,13 @@ void greedy_load_balancer::register_ctrl_commands()
 
     _get_balance_operation_count = dsn::command_manager::instance().register_command(
         {"meta.lb.get_balance_operation_count"},
-        "lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]",
+        "meta.lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]",
         "get balance operation count",
         [this](const std::vector<std::string> &args) { return get_balance_operation_count(args); });
 
     _ctrl_balancer_ignored_apps = dsn::command_manager::instance().register_command(
         {"meta.lb.ignored_app_list"},
-        "lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]",
+        "meta.lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]",
         "get, set and clear balancer ignored_app_list",
         [this](const std::vector<std::string> &args) {
             return remote_command_balancer_ignored_app_ids(args);

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -255,7 +255,7 @@ void meta_service::register_ctrl_commands()
     _ctrl_node_live_percentage_threshold_for_update =
         dsn::command_manager::instance().register_command(
             {"meta.live_percentage"},
-            "live_percentage [num | DEFAULT]",
+            "meta.live_percentage [num | DEFAULT]",
             "node live percentage threshold for update",
             [this](const std::vector<std::string> &args) {
                 std::string result("OK");

--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -856,13 +856,13 @@ void simple_load_balancer::register_ctrl_commands()
 
     _ctrl_assign_delay_ms = dsn::command_manager::instance().register_command(
         {"meta.lb.assign_delay_ms"},
-        "lb.assign_delay_ms [num | DEFAULT]",
+        "meta.lb.assign_delay_ms [num | DEFAULT]",
         "control the replica_assign_delay_ms_for_dropouts config",
         [this](const std::vector<std::string> &args) { return ctrl_assign_delay_ms(args); });
 
     _ctrl_assign_secondary_black_list = dsn::command_manager::instance().register_command(
         {"meta.lb.assign_secondary_black_list"},
-        "lb.assign_secondary_black_list [<ip:port,ip:port,ip:port>|clear]",
+        "meta.lb.assign_secondary_black_list [<ip:port,ip:port,ip:port>|clear]",
         "control the assign secondary black list",
         [this](const std::vector<std::string> &args) {
             return ctrl_assign_secondary_black_list(args);

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -81,7 +81,7 @@ void server_state::register_cli_commands()
 {
     _cli_dump_handle = dsn::command_manager::instance().register_command(
         {"meta.dump"},
-        "dump: dump app_states of meta server to local file",
+        "meta.dump - dump app_states of meta server to local file",
         "dump -t|--target target_file",
         [this](const std::vector<std::string> &args) {
             dsn::error_code err;
@@ -106,7 +106,7 @@ void server_state::register_cli_commands()
 
     _ctrl_add_secondary_enable_flow_control = dsn::command_manager::instance().register_command(
         {"meta.lb.add_secondary_enable_flow_control"},
-        "lb.add_secondary_enable_flow_control <true|false>",
+        "meta.lb.add_secondary_enable_flow_control <true|false>",
         "control whether enable add secondary flow control",
         [this](const std::vector<std::string> &args) {
             return remote_command_set_bool_flag(
@@ -116,7 +116,7 @@ void server_state::register_cli_commands()
 
     _ctrl_add_secondary_max_count_for_one_node = dsn::command_manager::instance().register_command(
         {"meta.lb.add_secondary_max_count_for_one_node"},
-        "lb.add_secondary_max_count_for_one_node [num | DEFAULT]",
+        "meta.lb.add_secondary_max_count_for_one_node [num | DEFAULT]",
         "control the max count to add secondary for one node",
         [this](const std::vector<std::string> &args) {
             std::string result("OK");

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -82,7 +82,7 @@ void server_state::register_cli_commands()
     _cli_dump_handle = dsn::command_manager::instance().register_command(
         {"meta.dump"},
         "meta.dump - dump app_states of meta server to local file",
-        "dump -t|--target target_file",
+        "meta.dump -t|--target target_file",
         [this](const std::vector<std::string> &args) {
             dsn::error_code err;
             if (args.size() != 2) {

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2189,8 +2189,8 @@ void replica_stub::register_ctrl_command()
     std::call_once(flag, [&]() {
         _kill_partition_command = ::dsn::command_manager::instance().register_command(
             {"replica.kill_partition"},
-            "kill_partition [app_id [partition_index]]",
-            "kill_partition: kill partitions by (all, one app, one partition)",
+            "replica.kill_partition [app_id [partition_index]]",
+            "replica.kill_partition: kill partitions by (all, one app, one partition)",
             [this](const std::vector<std::string> &args) {
                 dsn::gpid pid;
                 if (args.size() == 0) {
@@ -2211,16 +2211,16 @@ void replica_stub::register_ctrl_command()
 
         _deny_client_command = ::dsn::command_manager::instance().register_command(
             {"replica.deny-client"},
-            "deny-client <true|false>",
-            "deny-client - control if deny client read & write request",
+            "replica.deny-client <true|false>",
+            "replica.deny-client - control if deny client read & write request",
             [this](const std::vector<std::string> &args) {
                 return remote_command_set_bool_flag(_deny_client, "deny-client", args);
             });
 
         _verbose_client_log_command = ::dsn::command_manager::instance().register_command(
             {"replica.verbose-client-log"},
-            "verbose-client-log <true|false>",
-            "verbose-client-log - control if print verbose error log when reply read & write "
+            "replica.verbose-client-log <true|false>",
+            "replica.verbose-client-log - control if print verbose error log when reply read & write "
             "request",
             [this](const std::vector<std::string> &args) {
                 return remote_command_set_bool_flag(
@@ -2229,8 +2229,8 @@ void replica_stub::register_ctrl_command()
 
         _verbose_commit_log_command = ::dsn::command_manager::instance().register_command(
             {"replica.verbose-commit-log"},
-            "verbose-commit-log <true|false>",
-            "verbose-commit-log - control if print verbose log when commit mutation",
+            "replica.verbose-commit-log <true|false>",
+            "replica.verbose-commit-log - control if print verbose log when commit mutation",
             [this](const std::vector<std::string> &args) {
                 return remote_command_set_bool_flag(
                     _verbose_commit_log, "verbose-commit-log", args);
@@ -2238,8 +2238,8 @@ void replica_stub::register_ctrl_command()
 
         _trigger_chkpt_command = ::dsn::command_manager::instance().register_command(
             {"replica.trigger-checkpoint"},
-            "trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
-            "trigger-checkpoint - trigger replicas to do checkpoint",
+            "replica.trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "replica.trigger-checkpoint - trigger replicas to do checkpoint",
             [this](const std::vector<std::string> &args) {
                 return exec_command_on_replica(args, true, [this](const replica_ptr &rep) {
                     tasking::enqueue(LPC_PER_REPLICA_CHECKPOINT_TIMER,
@@ -2252,8 +2252,8 @@ void replica_stub::register_ctrl_command()
 
         _query_compact_command = ::dsn::command_manager::instance().register_command(
             {"replica.query-compact"},
-            "query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
-            "query-compact - query full compact status on the underlying storage engine",
+            "replica.query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "replica.query-compact - query full compact status on the underlying storage engine",
             [this](const std::vector<std::string> &args) {
                 return exec_command_on_replica(args, true, [](const replica_ptr &rep) {
                     return rep->query_manual_compact_state();
@@ -2262,8 +2262,8 @@ void replica_stub::register_ctrl_command()
 
         _query_app_envs_command = ::dsn::command_manager::instance().register_command(
             {"replica.query-app-envs"},
-            "query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
-            "query-app-envs - query app envs on the underlying storage engine",
+            "replica.query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "replica.query-app-envs - query app envs on the underlying storage engine",
             [this](const std::vector<std::string> &args) {
                 return exec_command_on_replica(args, true, [](const replica_ptr &rep) {
                     std::map<std::string, std::string> kv_map;
@@ -2275,8 +2275,8 @@ void replica_stub::register_ctrl_command()
 #ifdef DSN_ENABLE_GPERF
         _release_tcmalloc_memory_command = ::dsn::command_manager::instance().register_command(
             {"replica.release-tcmalloc-memory"},
-            "release-tcmalloc-memory <true|false>",
-            "release-tcmalloc-memory - control if try to release tcmalloc memory",
+            "replica.release-tcmalloc-memory <true|false>",
+            "replica.release-tcmalloc-memory - control if try to release tcmalloc memory",
             [this](const std::vector<std::string> &args) {
                 return remote_command_set_bool_flag(
                     _release_tcmalloc_memory, "release-tcmalloc-memory", args);
@@ -2284,7 +2284,7 @@ void replica_stub::register_ctrl_command()
 
         _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_command(
             {"replica.mem-release-max-reserved-percentage"},
-            "mem-release-max-reserved-percentage [num | DEFAULT]",
+            "replica.mem-release-max-reserved-percentage [num | DEFAULT]",
             "control tcmalloc max reserved but not-used memory percentage",
             [this](const std::vector<std::string> &args) {
                 std::string result("OK");
@@ -2312,7 +2312,7 @@ void replica_stub::register_ctrl_command()
         _max_concurrent_bulk_load_downloading_count_command =
             dsn::command_manager::instance().register_command(
                 {"replica.max-concurrent-bulk-load-downloading-count"},
-                "max-concurrent-bulk-load-downloading-count [num | DEFAULT]",
+                "replica.max-concurrent-bulk-load-downloading-count [num | DEFAULT]",
                 "control stub max_concurrent_bulk_load_downloading_count",
                 [this](const std::vector<std::string> &args) {
                     std::string result("OK");

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2220,8 +2220,8 @@ void replica_stub::register_ctrl_command()
         _verbose_client_log_command = ::dsn::command_manager::instance().register_command(
             {"replica.verbose-client-log"},
             "replica.verbose-client-log <true|false>",
-            "replica.verbose-client-log - control if print verbose error log when reply read & write "
-            "request",
+            "replica.verbose-client-log - control if print verbose error log when reply read & "
+            "write request",
             [this](const std::vector<std::string> &args) {
                 return remote_command_set_bool_flag(
                     _verbose_client_log, "verbose-client-log", args);
@@ -2238,7 +2238,8 @@ void replica_stub::register_ctrl_command()
 
         _trigger_chkpt_command = ::dsn::command_manager::instance().register_command(
             {"replica.trigger-checkpoint"},
-            "replica.trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')",
+            "replica.trigger-checkpoint [id1,id2,...] (where id is 'app_id' or "
+            "'app_id.partition_id')",
             "replica.trigger-checkpoint - trigger replicas to do checkpoint",
             [this](const std::vector<std::string> &args) {
                 return exec_command_on_replica(args, true, [this](const replica_ptr &rep) {


### PR DESCRIPTION
```
-------------------------------------------------
help|Help|h|H [command] - display help information
help|Help|h|H [command] - display help information
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
config-dump - dump configuration
engine - get engine internal information
fd.allow_list
flush-log - flush log to stderr or log file
help|Help|h|H [command] - display help information
help|Help|h|H [command] - display help information
dump: dump app_states of meta server to local file
lb.add_secondary_enable_flow_control <true|false>
lb.add_secondary_max_count_for_one_node [num | DEFAULT]
lb.assign_delay_ms [num | DEFAULT]
lb.assign_secondary_black_list [<ip:port,ip:port,ip:port>|clear]
lb.balancer_in_turn <true|false>
lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]
lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]
lb.only_move_primary <true|false>
lb.only_primary_balancer <true|false>
live_percentage [num | DEFAULT]
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
perf-counters - query perf counters, filtered by OR of POSIX basic regular expressions
perf-counters-by-postfix - query perf counters, filtered by OR of postfix strings
perf-counters-by-prefix - query perf counters, filtered by OR of prefix strings
perf-counters-by-substr - query perf counters, filtered by OR of substrs
profiler.query|pq - query profiling data, output in json format
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
profiler.query|pq - query profiling data, output in json format
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
reset-log-start-level - reset the log start level
server-info - query server information
server-stat - query selected perf counters
system.queue - get queue internal information
task-code - query task code containing any given keywords
```

This was the help info of remote commands. Commands like "lb.add_secondary_enable_flow_control" are actually not existed.
It was due to the modification of a former refactoring https://github.com/XiaoMi/rdsn/pull/522 that didn't accordingly update the help info. It certainly will make system admin puzzled about the usage.

After this PR, the help info of meta remote commands become:

```
CALL [meta-server] [127.0.0.1:34602] succeed: help|Help|h|H [command] - display help information
help|Help|h|H [command] - display help information
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
config-dump - dump configuration
engine - get engine internal information
fd.allow_list
flush-log - flush log to stderr or log file
help|Help|h|H [command] - display help information
help|Help|h|H [command] - display help information
meta.dump - dump app_states of meta server to local file
meta.lb.add_secondary_enable_flow_control <true|false>
meta.lb.add_secondary_max_count_for_one_node [num | DEFAULT]
meta.lb.assign_delay_ms [num | DEFAULT]
meta.lb.assign_secondary_black_list [<ip:port,ip:port,ip:port>|clear]
meta.lb.balancer_in_turn <true|false>
meta.lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]
meta.lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]
meta.lb.only_move_primary <true|false>
meta.lb.only_primary_balancer <true|false>
meta.live_percentage [num | DEFAULT]
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
perf-counters - query perf counters, filtered by OR of POSIX basic regular expressions
perf-counters-by-postfix - query perf counters, filtered by OR of postfix strings
perf-counters-by-prefix - query perf counters, filtered by OR of prefix strings
perf-counters-by-substr - query perf counters, filtered by OR of substrs
profiler.query|pq - query profiling data, output in json format
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
profiler.query|pq - query profiling data, output in json format
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
reset-log-start-level - reset the log start level
server-info - query server information
server-stat - query selected perf counters
system.queue - get queue internal information
task-code - query task code containing any given keywords
```

Replica:

```
help|Help|h|H [command] - display help information
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
config-dump - dump configuration
engine - get engine internal information
flush-log - flush log to stderr or log file
help|Help|h|H [command] - display help information
help|Help|h|H [command] - display help information
nfs.max_copy_rate_megabytes [num | DEFAULT]
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
perf-counters - query perf counters, filtered by OR of POSIX basic regular expressions
perf-counters-by-postfix - query perf counters, filtered by OR of postfix strings
perf-counters-by-prefix - query perf counters, filtered by OR of prefix strings
perf-counters-by-substr - query perf counters, filtered by OR of substrs
profiler.query|pq - query profiling data, output in json format
profile|Profile|p|P - performance profiling
profiler data - get appointed data, using by pjs
profiler.query|pq - query profiling data, output in json format
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
repeat|Repeat|r|R interval_seconds max_count command - execute command periodically
replica.deny-client <true|false>
replica.kill_partition [app_id [partition_index]]
replica.max-concurrent-bulk-load-downloading-count [num | DEFAULT]
replica.mem-release-max-reserved-percentage [num | DEFAULT]
replica.query-app-envs [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')
replica.query-compact [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')
replica.release-tcmalloc-memory <true|false>
replica.trigger-checkpoint [id1,id2,...] (where id is 'app_id' or 'app_id.partition_id')
replica.verbose-client-log <true|false>
replica.verbose-commit-log <true|false>
reset-log-start-level - reset the log start level
server-info - query server information
server-stat - query selected perf counters
system.queue - get queue internal information
task-code - query task code containing any given keywords
```