### PR TITLE
fix: response `ERR_OK` though pass  `ERR_INVALID_DATA` when meet too large size request

### DIFF
--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -56,6 +56,7 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
 
     if (dsn_unlikely(_stub->_max_allowed_write_size &&
                      request->body_size() > _stub->_max_allowed_write_size)) {
+        response_client_write(request, ERR_INVALID_DATA);
         std::string request_info = _app->dump_write_request(request);
         dwarn_replica("client from {} write request body size exceed threshold, request = [{}], "
                       "request_body_size "
@@ -65,7 +66,6 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
                       request->body_size(),
                       _stub->_max_allowed_write_size);
         _stub->_counter_recent_write_size_exceed_threshold_count->increment();
-        response_client_write(request, ERR_INVALID_DATA);
         return;
     }
 


### PR DESCRIPTION
#414 forbid too large size write request and reponse `ERR_INVALID_DATA`, but I found the client actually receive `ERR_OK`.

The reason is the `request body` is dumped before `response action`, I fix it but now **I haven't find the root cause**.

## Note:

The root cause has been found and fixed in https://github.com/apache/incubator-pegasus/pull/718