### PR TITLE
fix(one-time backup): mark a backup failed when write backup info failed

### DIFF
--- a/src/meta/backup_engine.h
+++ b/src/meta/backup_engine.h
@@ -68,6 +68,7 @@ private:
     friend class backup_engine_test;
     FRIEND_TEST(backup_engine_test, test_on_backup_reply);
     FRIEND_TEST(backup_engine_test, test_backup_completed);
+    FRIEND_TEST(backup_engine_test, test_write_backup_info_failed);
 
     error_code write_backup_file(const std::string &file_name, const dsn::blob &write_buffer);
     error_code backup_app_meta();


### PR DESCRIPTION
This patch fixed the issue that backup engine would keep retrying to write backup_info when ERR_FS_INTERNAL occured.