### PR TITLE
fix: fix data loss

### DIFF
--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -776,7 +776,7 @@ void replica::on_learn_reply(error_code err, learn_request &&req, learn_response
             this,
             _stub->_log->on_partition_reset(get_gpid(), _app->last_committed_decree()),
             _private_log->on_partition_reset(get_gpid(), _app->last_committed_decree()),
-            _app->last_committed_decree());
+            _app->last_durable_decree());
 
         // switch private log to make learning easier
         _private_log->demand_switch_file();


### PR DESCRIPTION
### What problem does this PR solve?
Data loss becase wrong init_durable_decree in .init-info file.
For details, see apache/incubator-pegasus#719

### What is changed and how it works?
using last_durable_decree for init_durable_decree in .init-info file.

### Check List
Tests

Manual test (add detailed scripts or steps below)
