### PR TITLE
fix: support retry when io write incompletely

### DIFF
--- a/include/dsn/utility/fail_point.h
+++ b/include/dsn/utility/fail_point.h
@@ -22,8 +22,8 @@
 
 #include <dsn/utility/string_view.h>
 
-/// The only entry to define a fail point.
-/// When a fail point is defined, it's referenced via the name.
+/// The only entry to define a fail point with `return()` function: lambda function must be
+/// return non-void type;  When a fail point is defined, it's referenced via the name.
 #define FAIL_POINT_INJECT_F(name, lambda)                                                          \
     do {                                                                                           \
         if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
@@ -32,6 +32,19 @@
         auto __Res = ::dsn::fail::eval(name);                                                      \
         if (__Res != nullptr) {                                                                    \
             return __Func(*__Res);                                                                 \
+        }                                                                                          \
+    } while (0)
+
+/// The only entry to define a fail point with `off()` function: lambda  function must be
+/// return void type; When a fail point is defined, it's referenced via the name.
+#define FAIL_POINT_INJECT_OFF_F(name, lambda)                                                      \
+    do {                                                                                           \
+        if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
+            break;                                                                                 \
+        auto __Func = lambda;                                                                      \
+        auto __Res = ::dsn::fail::eval(name);                                                      \
+        if (__Res == nullptr) {                                                                    \
+            __Func();                                                                              \
         }                                                                                          \
     } while (0)
 

--- a/include/dsn/utility/fail_point.h
+++ b/include/dsn/utility/fail_point.h
@@ -23,7 +23,7 @@
 #include <dsn/utility/string_view.h>
 
 /// The only entry to define a fail point with `return()` function: lambda function must be
-/// return non-void type;  When a fail point is defined, it's referenced via the name.
+/// return non-void type. When a fail point is defined, it's referenced via the name.
 #define FAIL_POINT_INJECT_F(name, lambda)                                                          \
     do {                                                                                           \
         if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
@@ -36,7 +36,7 @@
     } while (0)
 
 /// The only entry to define a fail point with `off()` function: lambda  function must be
-/// return void type; When a fail point is defined, it's referenced via the name.
+/// return void type. When a fail point is defined, it's referenced via the name.
 #define FAIL_POINT_INJECT_OFF_F(name, lambda)                                                      \
     do {                                                                                           \
         if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \

--- a/include/dsn/utility/fail_point.h
+++ b/include/dsn/utility/fail_point.h
@@ -22,7 +22,7 @@
 
 #include <dsn/utility/string_view.h>
 
-/// The only entry to define a fail point with `return()` function: lambda function must be
+/// The only entry to define a fail point with `return` function: lambda function must be
 /// return non-void type. When a fail point is defined, it's referenced via the name.
 #define FAIL_POINT_INJECT_F(name, lambda)                                                          \
     do {                                                                                           \
@@ -35,9 +35,9 @@
         }                                                                                          \
     } while (0)
 
-/// The only entry to define a fail point with `off()` function: lambda  function must be
+/// The only entry to define a fail point with `void` function: lambda  function must be
 /// return void type. When a fail point is defined, it's referenced via the name.
-#define FAIL_POINT_INJECT_OFF_F(name, lambda)                                                      \
+#define FAIL_POINT_INJECT_VOID_F(name, lambda)                                                     \
     do {                                                                                           \
         if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
             break;                                                                                 \

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -69,18 +69,18 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                                             /*out*/ uint32_t *processed_bytes)
 {
     bool enable_retry = true;
-    uint32_t buffert_offset = 0;
+    uint32_t buffer_offset = 0;
     while (true) {
         uint32_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
-                              aio_ctx.buffer + buffert_offset,
-                              aio_ctx.buffer_size - buffert_offset,
-                              aio_ctx.file_offset + buffert_offset);
+                              aio_ctx.buffer + buffer_offset,
+                              aio_ctx.buffer_size - buffer_offset,
+                              aio_ctx.file_offset + buffer_offset);
         if (ret < 0) {
             return ERR_FILE_OPERATION_FAILED;
         }
 
-        buffert_offset += ret;
-        if (buffert_offset != aio_ctx.buffer_size && enable_retry) {
+        buffer_offset += ret;
+        if (buffer_offset != aio_ctx.buffer_size && enable_retry) {
             dwarn_f("write incomplete, request_size={}, write_size={}, will retry delay 10ms",
                     aio_ctx.buffer_size,
                     ret);
@@ -91,7 +91,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
         break;
     }
 
-    *processed_bytes = buffert_offset;
+    *processed_bytes = buffer_offset;
     return ERR_OK;
 }
 
@@ -100,12 +100,12 @@ error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
 {
 
     bool enable_retry = true;
-    uint32_t buffert_offset = 0;
+    uint32_t buffer_offset = 0;
     while (true) {
         ssize_t ret = pread(static_cast<int>((ssize_t)aio_ctx.file),
-                            aio_ctx.buffer + buffert_offset,
-                            aio_ctx.buffer_size - buffert_offset,
-                            aio_ctx.file_offset + buffert_offset);
+                            aio_ctx.buffer + buffer_offset,
+                            aio_ctx.buffer_size - buffer_offset,
+                            aio_ctx.file_offset + buffer_offset);
         if (ret < 0) {
             return ERR_FILE_OPERATION_FAILED;
         }
@@ -113,8 +113,8 @@ error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
             return ERR_HANDLE_EOF;
         }
 
-        buffert_offset += ret;
-        if (buffert_offset != aio_ctx.buffer_size && enable_retry) {
+        buffer_offset += ret;
+        if (buffer_offset != aio_ctx.buffer_size && enable_retry) {
             dwarn_f("read incomplete, request_size={}, read_size={}, will retry delay 10ms",
                     aio_ctx.buffer_size,
                     ret);
@@ -125,7 +125,7 @@ error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
         break;
     }
 
-    *processed_bytes = buffert_offset;
+    *processed_bytes = buffer_offset;
     return ERR_OK;
 }
 

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -72,7 +72,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
 {
     int retries = 2;
     uint32_t buffer_offset = 0;
-    while (retries-- >= 0) {
+    while (--retries >= 0) {
         uint32_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
                               (char *)aio_ctx.buffer + buffer_offset,
                               aio_ctx.buffer_size - buffer_offset,

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -29,6 +29,7 @@
 
 #include <dsn/tool-api/async_calls.h>
 #include <dsn/c/api_utilities.h>
+#include <dsn/dist/fmt_logging.h>
 
 namespace dsn {
 
@@ -72,7 +73,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
     uint32_t buffer_offset = 0;
     while (true) {
         uint32_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
-                              aio_ctx.buffer + buffer_offset,
+                              (char *)aio_ctx.buffer + buffer_offset,
                               aio_ctx.buffer_size - buffer_offset,
                               aio_ctx.file_offset + buffer_offset);
         if (ret < 0) {
@@ -103,7 +104,7 @@ error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
     uint32_t buffer_offset = 0;
     while (true) {
         ssize_t ret = pread(static_cast<int>((ssize_t)aio_ctx.file),
-                            aio_ctx.buffer + buffer_offset,
+                            (char *)aio_ctx.buffer + buffer_offset,
                             aio_ctx.buffer_size - buffer_offset,
                             aio_ctx.file_offset + buffer_offset);
         if (ret < 0) {

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -68,31 +68,64 @@ error_code native_linux_aio_provider::flush(dsn_handle_t fh)
 error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                                             /*out*/ uint32_t *processed_bytes)
 {
-    ssize_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
-                         aio_ctx.buffer,
-                         aio_ctx.buffer_size,
-                         aio_ctx.file_offset);
-    if (ret < 0) {
-        return ERR_FILE_OPERATION_FAILED;
+    bool enable_retry = true;
+    uint32_t buffert_offset = 0;
+    while (true) {
+        uint32_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
+                              aio_ctx.buffer + buffert_offset,
+                              aio_ctx.buffer_size - buffert_offset,
+                              aio_ctx.file_offset + buffert_offset);
+        if (ret < 0) {
+            return ERR_FILE_OPERATION_FAILED;
+        }
+
+        buffert_offset += ret;
+        if (buffert_offset != aio_ctx.buffer_size && enable_retry) {
+            dwarn_f("write incomplete, request_size={}, write_size={}, will retry delay 10ms",
+                    aio_ctx.buffer_size,
+                    ret);
+            enable_retry = false;
+            usleep(10000);
+            continue;
+        }
+        break;
     }
-    *processed_bytes = static_cast<uint32_t>(ret);
+
+    *processed_bytes = buffert_offset;
     return ERR_OK;
 }
 
 error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
                                            /*out*/ uint32_t *processed_bytes)
 {
-    ssize_t ret = pread(static_cast<int>((ssize_t)aio_ctx.file),
-                        aio_ctx.buffer,
-                        aio_ctx.buffer_size,
-                        aio_ctx.file_offset);
-    if (ret < 0) {
-        return ERR_FILE_OPERATION_FAILED;
+
+    bool enable_retry = true;
+    uint32_t buffert_offset = 0;
+    while (true) {
+        ssize_t ret = pread(static_cast<int>((ssize_t)aio_ctx.file),
+                            aio_ctx.buffer + buffert_offset,
+                            aio_ctx.buffer_size - buffert_offset,
+                            aio_ctx.file_offset + buffert_offset);
+        if (ret < 0) {
+            return ERR_FILE_OPERATION_FAILED;
+        }
+        if (ret == 0) {
+            return ERR_HANDLE_EOF;
+        }
+
+        buffert_offset += ret;
+        if (buffert_offset != aio_ctx.buffer_size && enable_retry) {
+            dwarn_f("read incomplete, request_size={}, read_size={}, will retry delay 10ms",
+                    aio_ctx.buffer_size,
+                    ret);
+            enable_retry = false;
+            usleep(10000);
+            continue;
+        }
+        break;
     }
-    if (ret == 0) {
-        return ERR_HANDLE_EOF;
-    }
-    *processed_bytes = static_cast<uint32_t>(ret);
+
+    *processed_bytes = buffert_offset;
     return ERR_OK;
 }
 

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -95,8 +95,10 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
         buffer_offset += ret;
         remaing_size -= ret;
         if (remaing_size > 0) {
-            dwarn_f("write incomplete, request_size={}, write_size={}, will retry delay 10ms",
+            dwarn_f("write incomplete, request_size={}, total_write_size={}, this_write_size={}, "
+                    "will retry delay 10ms",
                     aio_ctx.buffer_size,
+                    buffer_offset,
                     ret);
             usleep(1e4);
         }

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -79,9 +79,10 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                               aio_ctx.file_offset + buffer_offset);
         if (ret < 0) {
             if (errno == EINTR) {
+                dwarn_f("write failed with EINTR, retry it.");
                 continue;
             }
-            derror_f("write failed, errno={}", strerror(errno));
+            derror_f("write failed, errno={}, return ERR_FILE_OPERATION_FAILED", strerror(errno));
             return ERR_FILE_OPERATION_FAILED;
         }
 

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -73,6 +73,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
     dsn::error_code resp = ERR_OK;
     uint32_t buffer_offset = 0;
     do {
+        // ret is the written data size
         uint32_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
                               (char *)aio_ctx.buffer + buffer_offset,
                               aio_ctx.buffer_size - buffer_offset,

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -89,7 +89,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
         }
 
         // mock the `ret` to reproduce the `write incomplete` case in the first write
-        FAIL_POINT_INJECT_OFF_F("aio_pwrite_incomplete", [&]() -> void {
+        FAIL_POINT_INJECT_VOID_F("aio_pwrite_incomplete", [&]() -> void {
             if (dsn_unlikely(buffer_offset == 0)) {
                 --ret;
             }

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -89,7 +89,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
         }
 
         // mock the `ret` to reproduce the `write incomplete` case in the first write
-        FAIL_POINT_INJECT_OFF_F("aio_pwrite", [&]() -> void {
+        FAIL_POINT_INJECT_OFF_F("aio_pwrite_incomplete", [&]() -> void {
             if (dsn_unlikely(buffer_offset == 0)) {
                 --ret;
             }

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -90,7 +90,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
         // mock the `ret` to reproduce the `write incomplete` case in the first write
         FAIL_POINT_INJECT_OFF_F("aio_pwrite", [&]() -> void {
             if (buffer_offset == 0) {
-                ret -= 1;
+                --ret;
             }
         });
 

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -70,6 +70,7 @@ error_code native_linux_aio_provider::flush(dsn_handle_t fh)
 error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                                             /*out*/ uint32_t *processed_bytes)
 {
+    dsn::error_code resp = ERR_OK;
     uint32_t buffer_offset = 0;
     do {
         uint32_t ret = pwrite(static_cast<int>((ssize_t)aio_ctx.file),
@@ -78,11 +79,12 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                               aio_ctx.file_offset + buffer_offset);
         if (dsn_unlikely(ret < 0)) {
             if (errno == EINTR) {
-                dwarn_f("write failed with EINTR and will retry it.");
+                dwarn_f("write failed with errno={} and will retry it.", strerror(errno));
                 continue;
             }
-            derror_f("write failed, errno={}, return ERR_FILE_OPERATION_FAILED.", strerror(errno));
-            return ERR_FILE_OPERATION_FAILED;
+            resp = ERR_FILE_OPERATION_FAILED;
+            derror_f("write failed with errno={}, return {}.", strerror(errno), resp);
+            return resp;
         }
 
         // mock the `ret` to reproduce the `write incomplete` case in the first write
@@ -103,7 +105,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
     } while (dsn_unlikely(buffer_offset < aio_ctx.buffer_size));
 
     *processed_bytes = buffer_offset;
-    return ERR_OK;
+    return resp;
 }
 
 error_code native_linux_aio_provider::read(const aio_context &aio_ctx,

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -88,7 +88,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
             }
         });
         buffer_offset += ret;
-        if (buffer_offset != aio_ctx.buffer_size) {
+        if (buffer_offset != aio_ctx.buffer_size && retries > 0) {
             dwarn_f("write incomplete, request_size={}, write_size={}, will retry delay 10ms",
                     aio_ctx.buffer_size,
                     ret);

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -79,7 +79,8 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                               aio_ctx.file_offset + buffer_offset);
         if (ret < 0) {
             if (errno == EINTR) {
-                dwarn_f("write failed with EINTR, retry it.");
+                dwarn_f("write failed with EINTR, will retry delay 10ms.");
+                usleep(1e4);
                 continue;
             }
             derror_f("write failed, errno={}, return ERR_FILE_OPERATION_FAILED", strerror(errno));

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -148,7 +148,7 @@ TEST(core, aio_share)
 TEST(core, operation_failed)
 {
     fail::setup();
-    fail::cfg("aio_pwrite", "off()");
+    fail::cfg("aio_pwrite_incomplete", "off()");
 
     auto fp = file::open("tmp_test_file", O_WRONLY, 0600);
     EXPECT_TRUE(fp == nullptr);

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -39,7 +39,7 @@ DEFINE_TASK_CODE_AIO(LPC_AIO_TEST, TASK_PRIORITY_COMMON, THREAD_POOL_TEST_SERVER
 TEST(core, aio)
 {
     fail::setup();
-    fail::cfg("aio_pwrite", "off()");
+    fail::cfg("aio_pwrite_incomplete", "off()");
     const char *buffer = "hello, world";
     int len = (int)strlen(buffer);
 

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -27,6 +27,7 @@
 #include <dsn/tool-api/async_calls.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/smart_pointers.h>
+#include <dsn/utility/fail_point.h>
 
 #include <gtest/gtest.h>
 
@@ -37,6 +38,8 @@ DEFINE_TASK_CODE_AIO(LPC_AIO_TEST, TASK_PRIORITY_COMMON, THREAD_POOL_TEST_SERVER
 
 TEST(core, aio)
 {
+    fail::setup();
+    fail::cfg("aio_pwrite", "off()");
     const char *buffer = "hello, world";
     int len = (int)strlen(buffer);
 
@@ -122,6 +125,7 @@ TEST(core, aio)
     }
 
     err = file::close(fp);
+    fail::teardown();
     EXPECT_TRUE(err == ERR_OK);
 
     utils::filesystem::remove_path("tmp");
@@ -143,6 +147,9 @@ TEST(core, aio_share)
 
 TEST(core, operation_failed)
 {
+    fail::setup();
+    fail::cfg("aio_pwrite", "off()");
+
     auto fp = file::open("tmp_test_file", O_WRONLY, 0600);
     EXPECT_TRUE(fp == nullptr);
 
@@ -171,16 +178,19 @@ TEST(core, operation_failed)
     t = ::dsn::file::read(fp2, buffer, 512, 0, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
     EXPECT_TRUE(*err == ERR_OK && *count == strlen(str));
+    EXPECT_TRUE(strncmp(buffer, str, 10) == 0);
 
     t = ::dsn::file::read(fp2, buffer, 5, 0, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
     EXPECT_TRUE(*err == ERR_OK && *count == 5);
+    EXPECT_TRUE(strncmp(buffer, str, 5) == 0);
 
     t = ::dsn::file::read(fp2, buffer, 512, 100, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
     ddebug("error code: %s", err->to_string());
     file::close(fp);
     file::close(fp2);
+    fail::teardown();
 
     EXPECT_TRUE(utils::filesystem::remove_path("tmp_test_file"));
 }


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/659 has reported the io write operation bug and it only `retry` to decrease the probability of occurrence. This pr refer [stackovflow: handling-incomplete-write-calls](https://stackoverflow.com/questions/32683086/handling-incomplete-write-calls) ,  [rocksdb](https://github.com/facebook/rocksdb/blob/d89483098ff4a77bd0ef12454a64554805984cc5/env/io_posix.cc#L119) and add the retry operation.

## Note：
- This pr only decrease the probability but not resolve it completely
- This pr add `FAIL_POINT_INJECT_OFF_F` macro to mock `pwrite` to reproduce the bug 