### PR TITLE
test: add workflow for new tag creation and regular build

### DIFF
--- a/.github/workflows/compilation.yaml
+++ b/.github/workflows/compilation.yaml
@@ -21,8 +21,12 @@ name: rdsn compilation
 
 on:
   push:
+    # when new tag created
     tags:
       - v*
+    # when this file is updated
+    paths:
+      - '.github/workflows/compilation.yml'
 
   # for manually triggering workflow
   workflow_dispatch:

--- a/.github/workflows/compilation.yaml
+++ b/.github/workflows/compilation.yaml
@@ -1,0 +1,72 @@
+##############################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+##############################################################################
+
+name: rdsn compilation
+
+on:
+  push:
+    tags:
+      - v*
+
+  # for manually triggering workflow
+  workflow_dispatch:
+
+  # run for every day 2am UTC+8(Beijing)
+  schedule:
+    - cron:  '0 18 */1 * *'
+
+jobs:
+  compilation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu1604
+          - ubuntu1804
+          - ubuntu2004
+          #- centos6 is EOL
+          - centos7
+        compiler-family:
+          - gcc
+        include:
+          - compiler-family: clang
+            compiler: "clang-10,clang++-10"
+            os: ubuntu2004
+          - compiler-family: clang
+            compiler: "clang-9,clang++-9"
+            os: ubuntu1804
+    container:
+      image: ghcr.io/pegasus-kv/thirdparties-bin:${{ matrix.os }}
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: Unpack prebuilt third-parties
+        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+      -
+        name: Compilation on GCC
+        if: ${{ matrix.compiler-family == 'gcc' }}
+        run: ./run.sh build -c --skip_thirdparty
+      -
+        name: Compilation on Clang
+        if: ${{ matrix.compiler-family == 'clang' }}
+        env:
+          COMPILER: ${{ matrix.compiler }}
+        run: ./run.sh build --compiler $COMPILER --skip_thirdparty


### PR DESCRIPTION
When a new tag is created (for example, when we are preparing a release), this workflow will run compilation on multiple platforms.