### PR TITLE
fix(restore): fix not found error when restore app metadata

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -995,7 +995,6 @@ dsn::error_code replication_ddl_client::do_restore(const std::string &backup_pro
         dsn::unmarshall(resp_task->get_response(), resp);
         if (resp.err == ERR_OBJECT_NOT_FOUND) {
             std::cout << "restore app failed: couldn't find valid app metadata" << std::endl;
-            return ERR_OK;
         } else if (resp.err == ERR_OK) {
             std::cout << "\t"
                       << "new app_id = " << resp.appid << std::endl;

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -994,8 +994,7 @@ dsn::error_code replication_ddl_client::do_restore(const std::string &backup_pro
         configuration_create_app_response resp;
         dsn::unmarshall(resp_task->get_response(), resp);
         if (resp.err == ERR_OBJECT_NOT_FOUND) {
-            std::cout << "app metadata is damaged on cold backup media, restore app failed"
-                      << std::endl;
+            std::cout << "restore app failed: couldn't find valid app metadata" << std::endl;
             return ERR_OK;
         } else if (resp.err == ERR_OK) {
             std::cout << "\t"

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -233,6 +233,7 @@ private:
     friend class meta_split_service_test;
     friend class meta_test_base;
     friend class policy_context_test;
+    friend class server_state_restore_test;
     friend class test::test_checker;
 
     replication_options _opts;

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -1,32 +1,23 @@
-/*
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
- * The MIT License (MIT)
- *
- * Copyright (c) 2015 Microsoft Corporation
- *
- * -=- Robust Distributed System Nucleus (rDSN) -=-
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-
-#include <dsn/dist/block_service.h>
 #include <boost/lexical_cast.hpp>
+#include <dsn/dist/block_service.h>
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/filesystem.h>
 
 #include "block_service/block_service_manager.h"


### PR DESCRIPTION
#816 introduced a not found error when restore app metadata with no specified path,  this patch fixed it and added a test to verify it has been fixed.