### PR TITLE
fix(bulk_load): fix remove_local_bulk_load_dir()

### DIFF
--- a/src/block_service/test/CMakeLists.txt
+++ b/src/block_service/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MY_PROJ_LIBS
 set(MY_BINPLACES
     config-test.ini
     run.sh
+    clear.sh
 )
 
 dsn_add_test()

--- a/src/block_service/test/clear.sh
+++ b/src/block_service/test/clear.sh
@@ -18,4 +18,4 @@
 # under the License.
 ##############################################################################
 
-rm -rf log.* *.log data dsn_block_service_test.xml randomfile*
+rm -rf log.* *.log data dsn_block_service_test.xml randomfile* rename_dir* test_dir

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -52,14 +52,22 @@ protected:
     virtual void SetUp() override;
     virtual void TearDown() override;
     void generate_test_file(const char *filename);
+    void write_test_files_async();
     std::string name_node;
     std::string backup_path;
+    std::string local_test_dir;
+    std::string test_data_str;
 };
 
 void HDFSClientTest::SetUp()
 {
     name_node = FLAGS_test_name_node;
     backup_path = FLAGS_test_backup_path;
+    local_test_dir = "test_dir";
+    test_data_str = "";
+    for (int i = 0; i < FLAGS_num_test_file_lines; ++i) {
+        test_data_str += "test";
+    }
 }
 
 void HDFSClientTest::TearDown() {}
@@ -73,6 +81,22 @@ void HDFSClientTest::generate_test_file(const char *filename)
         fprintf(fp, "%04d_this_is_a_simple_test_file\n", i);
     }
     fclose(fp);
+}
+
+void HDFSClientTest::write_test_files_async()
+{
+    dsn::utils::filesystem::create_directory(local_test_dir);
+    for (int i = 0; i < 100; ++i) {
+        tasking::enqueue(LPC_TEST_HDFS, nullptr, [this, i]() {
+            // mock the writing process in hdfs_file_object::download().
+            std::string test_file_name = local_test_dir + "/test_file_" + std::to_string(i);
+            std::ofstream out(test_file_name, std::ios::binary | std::ios::out | std::ios::trunc);
+            if (out.is_open()) {
+                out.write(test_data_str.c_str(), test_data_str.length());
+            }
+            out.close();
+        });
+    }
 }
 
 TEST_F(HDFSClientTest, test_basic_operation)
@@ -340,4 +364,21 @@ TEST_F(HDFSClientTest, test_concurrent_upload_download)
         utils::filesystem::remove_path(local_file_names[i]);
         utils::filesystem::remove_path(downloaded_file_names[i]);
     }
+}
+
+TEST_F(HDFSClientTest, test_rename_path_while_writing)
+{
+    write_test_files_async();
+    usleep(100);
+    std::string rename_dir = "rename_dir." + std::to_string(dsn_now_ms());
+    // rename succeed but writing failed.
+    ASSERT_TRUE(dsn::utils::filesystem::rename_path(local_test_dir, rename_dir));
+}
+
+TEST_F(HDFSClientTest, test_remove_path_while_writing)
+{
+    write_test_files_async();
+    usleep(100);
+    // couldn't remove the directory while writing files in it.
+    ASSERT_FALSE(dsn::utils::filesystem::remove_path(local_test_dir));
 }

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -392,11 +392,8 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
     }
     const std::string local_dir = utils::filesystem::path_combine(
         _replica->_dir, bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR);
-    if (utils::filesystem::directory_exists(local_dir)) {
-        // remove old files before downloading sst files.
-        remove_local_bulk_load_dir(local_dir);
-    }
-    if (!utils::filesystem::create_directory(local_dir)) {
+    if (!utils::filesystem::directory_exists(local_dir) &&
+        !utils::filesystem::create_directory(local_dir)) {
         derror_replica("create bulk_load_dir({}) failed", local_dir);
         return ERR_FILE_OPERATION_FAILED;
     }

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -610,10 +610,13 @@ void replica_bulk_loader::remove_local_bulk_load_dir(const std::string &bulk_loa
                                           bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR,
                                           std::to_string(dsn_now_ms()),
                                           kFolderSuffixGar);
-    utils::filesystem::rename_path(bulk_load_dir, garbage_dir);
+    if (!utils::filesystem::rename_path(bulk_load_dir, garbage_dir)) {
+        derror_replica("rename bulk_load dir({}) failed.", bulk_load_dir);
+        return;
+    }
     if (!utils::filesystem::remove_path(garbage_dir)) {
         derror_replica(
-            "remove bulk_load gar dir({}) failed, disk cleaner would retry to remote it.",
+            "remove bulk_load gar dir({}) failed, disk cleaner would retry to remove it.",
             garbage_dir);
     }
 }

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -603,7 +603,7 @@ void replica_bulk_loader::remove_local_bulk_load_dir(const std::string &bulk_loa
     if (!utils::filesystem::directory_exists(bulk_load_dir)) {
         return;
     }
-    // Rename bulk_load_dir to replica_dir.bulkload.timestamp.gar before remove it.
+    // Rename bulk_load_dir to ${replica_dir}.bulk_load.timestamp.gar before remove it.
     // Because we download sst files asynchronously and couldn't remove a directory while writing
     // files in it.
     std::string garbage_dir = fmt::format("{}.{}.{}.{}",

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -603,7 +603,9 @@ void replica_bulk_loader::remove_local_bulk_load_dir(const std::string &bulk_loa
     if (!utils::filesystem::directory_exists(bulk_load_dir)) {
         return;
     }
-    // rename bulk_load_dir to replica_dir.bulkload.timestamp.gar.
+    // Rename bulk_load_dir to replica_dir.bulkload.timestamp.gar before remove it.
+    // Because we download sst files asynchronously and couldn't remove a directory while writing
+    // files in it.
     std::string garbage_dir = fmt::format("{}.{}.{}.{}",
                                           _replica->_dir,
                                           bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR,

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -393,6 +393,7 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
     const std::string local_dir = utils::filesystem::path_combine(
         _replica->_dir, bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR);
     if (utils::filesystem::directory_exists(local_dir)) {
+        // remove old files before downloading sst files.
         remove_local_bulk_load_dir(local_dir);
     }
     if (!utils::filesystem::create_directory(local_dir)) {
@@ -605,6 +606,7 @@ void replica_bulk_loader::remove_local_bulk_load_dir(const std::string &bulk_loa
     if (!utils::filesystem::directory_exists(bulk_load_dir)) {
         return;
     }
+    // rename bulk_load_dir to replica_dir.bulkload.timestamp.gar.
     std::string garbage_dir = fmt::format("{}.{}.{}.{}",
                                           _replica->_dir,
                                           bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR,

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -82,7 +82,7 @@ private:
     void handle_bulk_load_finish(bulk_load_status::type new_status);
     void pause_bulk_load();
 
-    error_code remove_local_bulk_load_dir(const std::string &bulk_load_dir);
+    void remove_local_bulk_load_dir(const std::string &bulk_load_dir);
     void cleanup_download_task();
     void clear_bulk_load_states();
     bool is_cleaned_up();


### PR DESCRIPTION
Recently our users encountered problems while using bulk_load, their job always failed, and we found remove_directory errors in replica server log:
```
W2021-04-22 11:15:40.633 (1619061340633182759 122434) replica.replica20.0400de080018c494: filesystem.cpp:329:remove_directory(): remove /home/work/ssd3/pegasus/c4tst-bulkload/replica/reps/46.18.pegasus/bulk_load failed, err = Directory not empty
E2021-04-22 11:15:40.633 (1619061340633219926 122434) replica.replica20.0400de080018c494: replica_bulk_loader.cpp:599:remove_local_bulk_load_dir(): [46.18@10.132.5.22:34801] remove bulk_load dir(/home/work/ssd3/pegasus/c4tst-bulkload/replica/reps/46.18.pegasus/bulk_load) failed
```
The reason is that we couldn't remove a directory using whiling writing files in this directory(see the added tests in HDFSClientTest). This patch rename unused bulkload dir to a garbage dir instead of just removing it, then remove garbage dir, disk cleaner would retry to remove it if failed.