### PR TITLE
fix(bulk_load): redownload file if local file damaged

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -436,12 +436,12 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
                         f_size = f_meta.size;
                         verified = true;
                     } else {
-                        dwarn_replica(
-                            "file({}) exists, but not verified, try to remove and redownload it",
+                        derror_replica(
+                            "file({}) exists, but not verified, try to remove local file "
+                            "and redownload it",
                             file_name);
-                        // remove unverified local file and redownload
                         if (!utils::filesystem::remove_path(file_name)) {
-                            derror_f("failed to remove file({})", file_name);
+                            derror_replica("failed to remove file({})", file_name);
                             ec = ERR_FILE_OPERATION_FAILED;
                         } else {
                             ec = _stub->_block_service_manager.download_file(
@@ -501,8 +501,11 @@ void replica_bulk_loader::update_bulk_load_download_progress(uint64_t file_size,
                                                              const std::string &file_name)
 {
     if (_metadata.file_total_size <= 0) {
-        derror_replica("bulk_load_metadata has invalid file_total_size({})",
-                       _metadata.file_total_size);
+        derror_replica("update downloading file({}) progress failed, metadata has invalid "
+                       "file_total_size({}), current status = {}",
+                       file_name,
+                       _metadata.file_total_size,
+                       enum_to_string(_status));
         return;
     }
 


### PR DESCRIPTION
In bulk load download stage, replica server will download file from remote file provider, if a same-name file exists,  block service interface `download_file` will return `ERR_PATH_ALREADY_EXIST`. In previous implmentation, if local file doesn't pass verification, it will lead to bulk load failed. This pull request fixs it, if local file doesn't pass verifition, it will remove old file and redownload it.

I test this case in onebox manually in following step:
1. start bulk load
2. pause bulk load
3. modify one file content to simulate downloaded local file is different from remoted file
4. restart bulk load
5. I can find redownload log below
```
W2021-04-26 15:38:04.26 (1619422684026147118 7747) replica.rep_long0.0304000000000420: replica_bulk_loader.cpp:441:operator()(): [2.0@<ip>:<port>] file(<path>/file0.sst) exists, but not verified, try to remove and redownload it
```
6. bulk load succeed