### PR TITLE
feat(bulk_load): add bulk load max rollback count

### DIFF
--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -17,11 +17,22 @@
 
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/fail_point.h>
+#include <dsn/utility/flags.h>
 
 #include "meta_bulk_load_service.h"
 
 namespace dsn {
 namespace replication {
+
+DSN_DEFINE_uint32("meta_server",
+                  bulk_load_max_failover_count,
+                  20,
+                  "if bulk load failover count "
+                  "exceed this value, meta won't "
+                  "rollback bulk load process to "
+                  "downloading, but turn it into "
+                  "failed");
+DSN_TAG_VARIABLE(bulk_load_max_failover_count, FT_MUTABLE);
 
 bulk_load_service::bulk_load_service(meta_service *meta_svc, const std::string &bulk_load_dir)
     : _meta_svc(meta_svc), _state(meta_svc->get_server_state()), _bulk_load_root(bulk_load_dir)
@@ -231,6 +242,7 @@ void bulk_load_service::create_app_bulk_load_dir(const std::string &app_name,
                 zauto_write_lock l(_lock);
                 _app_bulk_load_info[ainfo.app_id] = ainfo;
                 _apps_pending_sync_flag[ainfo.app_id] = false;
+                _apps_failover_count[ainfo.app_id] = 0;
             }
             for (int32_t i = 0; i < ainfo.partition_count; ++i) {
                 create_partition_bulk_load_dir(
@@ -730,26 +742,38 @@ void bulk_load_service::try_rollback_to_downloading(const std::string &app_name,
     zauto_write_lock l(_lock);
 
     const auto app_status = get_app_bulk_load_status_unlocked(pid.get_app_id());
-    if (app_status == bulk_load_status::BLS_DOWNLOADING ||
-        app_status == bulk_load_status::BLS_DOWNLOADED ||
-        app_status == bulk_load_status::BLS_INGESTING ||
-        app_status == bulk_load_status::BLS_SUCCEED) {
-        if (_apps_rolling_back[pid.get_app_id()]) {
-            dwarn_f("app({}) is rolling back to downloading, ignore this request", app_name);
-            return;
-        }
-        ddebug_f("app({}) will rolling back from {} to {}",
-                 app_name,
-                 dsn::enum_to_string(app_status),
-                 dsn::enum_to_string(bulk_load_status::BLS_DOWNLOADING));
-        _apps_rolling_back[pid.get_app_id()] = true;
-        update_app_status_on_remote_storage_unlocked(pid.get_app_id(),
-                                                     bulk_load_status::type::BLS_DOWNLOADING);
-    } else {
+    if (app_status != bulk_load_status::BLS_DOWNLOADING &&
+        app_status != bulk_load_status::BLS_DOWNLOADED &&
+        app_status != bulk_load_status::BLS_INGESTING &&
+        app_status != bulk_load_status::BLS_SUCCEED) {
         ddebug_f("app({}) status={}, no need to rollback to downloading, wait for next round",
                  app_name,
                  dsn::enum_to_string(app_status));
+        return;
     }
+
+    if (_apps_rolling_back[pid.get_app_id()]) {
+        dwarn_f("app({}) is rolling back to downloading, ignore this request", app_name);
+        return;
+    }
+    if (_apps_failover_count[pid.get_app_id()] >= FLAGS_bulk_load_max_failover_count) {
+        dwarn_f(
+            "app({}) has been rollback to downloading for {} times, make bulk load process failed",
+            app_name,
+            _apps_failover_count[pid.get_app_id()]);
+        update_app_status_on_remote_storage_unlocked(pid.get_app_id(),
+                                                     bulk_load_status::type::BLS_FAILED);
+        return;
+    }
+    ddebug_f("app({}) will rolling back from {} to {}, current failover_count = {}",
+             app_name,
+             dsn::enum_to_string(app_status),
+             dsn::enum_to_string(bulk_load_status::BLS_DOWNLOADING),
+             _apps_failover_count[pid.get_app_id()]);
+    _apps_rolling_back[pid.get_app_id()] = true;
+    _apps_failover_count[pid.get_app_id()]++;
+    update_app_status_on_remote_storage_unlocked(pid.get_app_id(),
+                                                 bulk_load_status::type::BLS_DOWNLOADING);
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
@@ -1183,6 +1207,7 @@ void bulk_load_service::reset_local_bulk_load_states(int32_t app_id, const std::
     erase_map_elem_by_id(app_id, _partitions_total_download_progress);
     erase_map_elem_by_id(app_id, _partitions_cleaned_up);
     _apps_rolling_back.erase(app_id);
+    _apps_failover_count.erase(app_id);
     _apps_cleaning_up.erase(app_id);
     _bulk_load_app_id.erase(app_id);
     ddebug_f("reset local app({}) bulk load context", app_name);
@@ -1654,6 +1679,7 @@ void bulk_load_service::do_continue_app_bulk_load(
     {
         zauto_write_lock l(_lock);
         _apps_in_progress_count[app_id] = in_progress_partition_count;
+        _apps_failover_count[app_id] = 0;
     }
 
     // if app is paused, no need to send bulk_load_request, just return

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -23,7 +23,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DECLARE_uint32(bulk_load_max_failover_count);
+DSN_DECLARE_uint32(bulk_load_max_rollback_times);
 
 ///
 /// bulk load path on remote storage:
@@ -406,8 +406,8 @@ private:
     std::unordered_map<app_id, bool> _apps_cleaning_up;
     // Used for bulk load rolling back to downloading
     std::unordered_map<app_id, bool> _apps_rolling_back;
-    // Used for restrict bulk load failover count
-    std::unordered_map<app_id, int32_t> _apps_failover_count;
+    // Used for restrict bulk load rollback count
+    std::unordered_map<app_id, int32_t> _apps_rollback_count;
 };
 
 } // namespace replication

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -23,6 +23,8 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_uint32(bulk_load_max_failover_count);
+
 ///
 /// bulk load path on remote storage:
 /// <cluster_root>/bulk_load/<app_id> -> app_bulk_load_info
@@ -404,6 +406,8 @@ private:
     std::unordered_map<app_id, bool> _apps_cleaning_up;
     // Used for bulk load rolling back to downloading
     std::unordered_map<app_id, bool> _apps_rolling_back;
+    // Used for restrict bulk load failover count
+    std::unordered_map<app_id, int32_t> _apps_failover_count;
 };
 
 } // namespace replication

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -86,7 +86,8 @@ public:
 
     void mock_meta_bulk_load_context(int32_t app_id,
                                      int32_t in_progress_partition_count,
-                                     bulk_load_status::type status)
+                                     bulk_load_status::type status,
+                                     bool mock_failover_count = false)
     {
         bulk_svc()._bulk_load_app_id.insert(app_id);
         bulk_svc()._apps_in_progress_count[app_id] = in_progress_partition_count;
@@ -94,6 +95,9 @@ public:
         for (int i = 0; i < in_progress_partition_count; ++i) {
             gpid pid = gpid(app_id, i);
             bulk_svc()._partition_bulk_load_info[pid].status = status;
+        }
+        if (mock_failover_count) {
+            bulk_svc()._apps_failover_count[app_id] = FLAGS_bulk_load_max_failover_count;
         }
     }
 
@@ -515,9 +519,10 @@ public:
 
     void test_on_partition_bulk_load_reply(int32_t in_progress_count,
                                            bulk_load_status::type status,
-                                           error_code resp_err = ERR_OK)
+                                           error_code resp_err = ERR_OK,
+                                           bool mock_failover_count = false)
     {
-        mock_meta_bulk_load_context(_app_id, in_progress_count, status);
+        mock_meta_bulk_load_context(_app_id, in_progress_count, status, mock_failover_count);
         create_request(status);
         auto response = _resp;
         response.err = resp_err;
@@ -699,6 +704,14 @@ TEST_F(bulk_load_process_test, response_object_not_found)
     test_on_partition_bulk_load_reply(
         _partition_count, bulk_load_status::BLS_CANCELED, ERR_OBJECT_NOT_FOUND);
     ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_CANCELED);
+    ASSERT_EQ(get_app_in_process_count(_app_id), _partition_count);
+}
+
+TEST_F(bulk_load_process_test, failover_count_exceed)
+{
+    test_on_partition_bulk_load_reply(
+        _partition_count, bulk_load_status::BLS_DOWNLOADING, ERR_INVALID_STATE, true);
+    ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_FAILED);
     ASSERT_EQ(get_app_in_process_count(_app_id), _partition_count);
 }
 

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -87,7 +87,7 @@ public:
     void mock_meta_bulk_load_context(int32_t app_id,
                                      int32_t in_progress_partition_count,
                                      bulk_load_status::type status,
-                                     bool mock_failover_count = false)
+                                     bool mock_rollback_count = false)
     {
         bulk_svc()._bulk_load_app_id.insert(app_id);
         bulk_svc()._apps_in_progress_count[app_id] = in_progress_partition_count;
@@ -96,8 +96,8 @@ public:
             gpid pid = gpid(app_id, i);
             bulk_svc()._partition_bulk_load_info[pid].status = status;
         }
-        if (mock_failover_count) {
-            bulk_svc()._apps_failover_count[app_id] = FLAGS_bulk_load_max_failover_count;
+        if (mock_rollback_count) {
+            bulk_svc()._apps_rollback_count[app_id] = FLAGS_bulk_load_max_rollback_times;
         }
     }
 
@@ -520,9 +520,9 @@ public:
     void test_on_partition_bulk_load_reply(int32_t in_progress_count,
                                            bulk_load_status::type status,
                                            error_code resp_err = ERR_OK,
-                                           bool mock_failover_count = false)
+                                           bool mock_rollback_count = false)
     {
-        mock_meta_bulk_load_context(_app_id, in_progress_count, status, mock_failover_count);
+        mock_meta_bulk_load_context(_app_id, in_progress_count, status, mock_rollback_count);
         create_request(status);
         auto response = _resp;
         response.err = resp_err;
@@ -707,7 +707,7 @@ TEST_F(bulk_load_process_test, response_object_not_found)
     ASSERT_EQ(get_app_in_process_count(_app_id), _partition_count);
 }
 
-TEST_F(bulk_load_process_test, failover_count_exceed)
+TEST_F(bulk_load_process_test, rollback_count_exceed)
 {
     test_on_partition_bulk_load_reply(
         _partition_count, bulk_load_status::BLS_DOWNLOADING, ERR_INVALID_STATE, true);


### PR DESCRIPTION
During bulk load process, meta server will control the bulk load status switch: downloading -> downloaded -> ingesting -> succeed, if replica configuration changed or network failed, meta server will rollback status into downloading. In pervious implementation, it is possible for bulk load process rollback for long time. This pull request adds `bulk_load_max_rollback_times`, if the table has been rollback to downloading for too many times, it will turn status into failed to stop the process.

configuration update:
```diff
[meta_server]
+bulk_load_max_rollback_times = 10
```