### PR TITLE
fix(bulk_load): remove possible old directory when start bulk load

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -355,6 +355,11 @@ error_code replica_bulk_loader::start_download(const std::string &remote_dir,
     }
 
     // reset local bulk load context and state
+    if (_status == bulk_load_status::BLS_INVALID) {
+        // try to remove possible garbage bulk load data when actually starting bulk load
+        remove_local_bulk_load_dir(utils::filesystem::path_combine(
+            _replica->_dir, bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR));
+    }
     if (status() == partition_status::PS_PRIMARY) {
         _replica->_primary_states.cleanup_bulk_load_states();
     }


### PR DESCRIPTION
#823 fixs the bug that removing bulk load directory failed when replica cleanup bulk load context. This pull request is a supplement of it. This pr adds remove directory before starting bulk load (when replica bulk_load_status is INVALID).