### PR TITLE
feat(bulk_load): meta server adds bulk load ingestion concurrent count restriction

### DIFF
--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1004,6 +1004,7 @@ void bulk_load_service::update_app_status_on_remote_storage_reply(const app_bulk
         _app_bulk_load_info[app_id] = ainfo;
         _apps_pending_sync_flag[app_id] = false;
         _apps_in_progress_count[app_id] = partition_count;
+        // when rollback from ingesting, ingesting_count should be reset
         if (old_status == bulk_load_status::BLS_INGESTING &&
             new_status == bulk_load_status::BLS_DOWNLOADING) {
             _apps_ingesting_count[app_id] = 0;

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1059,6 +1059,15 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
         }
     }
 
+    auto app_status = get_app_bulk_load_status(pid.get_app_id());
+    if (app_status != bulk_load_status::BLS_INGESTING) {
+        dwarn_f("app({}) current status is {}, partition({}), ignore it",
+                app_name,
+                dsn::enum_to_string(app_status),
+                pid);
+        return;
+    }
+
     rpc_address primary_addr;
     {
         zauto_read_lock l(app_lock());
@@ -1071,15 +1080,6 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
             return;
         }
         primary_addr = app->partitions[pid.get_partition_index()].primary;
-    }
-
-    auto app_status = get_app_bulk_load_status(pid.get_app_id());
-    if (app_status != bulk_load_status::BLS_INGESTING) {
-        dwarn_f("app({}) current status is {}, partition({}), ignore it",
-                app_name,
-                dsn::enum_to_string(app_status),
-                pid);
-        return;
     }
 
     if (primary_addr.is_invalid()) {

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1073,6 +1073,15 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
         primary_addr = app->partitions[pid.get_partition_index()].primary;
     }
 
+    auto app_status = get_app_bulk_load_status(pid.get_app_id());
+    if (app_status != bulk_load_status::BLS_INGESTING) {
+        dwarn_f("app({}) current status is {}, partition({}), ignore it",
+                app_name,
+                dsn::enum_to_string(app_status),
+                pid);
+        return;
+    }
+
     if (primary_addr.is_invalid()) {
         dwarn_f("app({}) partition({}) primary is invalid, try it later", app_name, pid);
         tasking::enqueue(LPC_META_STATE_NORMAL,

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -23,6 +23,12 @@
 namespace dsn {
 namespace replication {
 
+DSN_DEFINE_uint32("meta_server",
+                  bulk_load_ingestion_concurrent_count,
+                  4,
+                  "max partition_count executing ingestion at the same time");
+DSN_TAG_VARIABLE(bulk_load_ingestion_concurrent_count, FT_MUTABLE);
+
 bulk_load_service::bulk_load_service(meta_service *meta_svc, const std::string &bulk_load_dir)
     : _meta_svc(meta_svc), _state(meta_svc->get_server_state()), _bulk_load_root(bulk_load_dir)
 {
@@ -200,6 +206,7 @@ void bulk_load_service::do_start_app_bulk_load(std::shared_ptr<app_state> app,
                 zauto_write_lock l(_lock);
                 _bulk_load_app_id.insert(app->app_id);
                 _apps_in_progress_count[app->app_id] = app->partition_count;
+                _apps_ingesting_count[app->app_id] = 0;
             }
             create_app_bulk_load_dir(
                 app->app_name, app->app_id, app->partition_count, std::move(rpc));
@@ -981,12 +988,7 @@ void bulk_load_service::update_app_status_on_remote_storage_reply(const app_bulk
 
     if (new_status == bulk_load_status::BLS_INGESTING) {
         for (int i = 0; i < partition_count; ++i) {
-            tasking::enqueue(LPC_BULK_LOAD_INGESTION,
-                             _meta_svc->tracker(),
-                             std::bind(&bulk_load_service::partition_ingestion,
-                                       this,
-                                       ainfo.app_name,
-                                       gpid(app_id, i)));
+            partition_ingestion(ainfo.app_name, gpid(app_id, i));
         }
     }
 
@@ -1001,10 +1003,32 @@ void bulk_load_service::update_app_status_on_remote_storage_reply(const app_bulk
     }
 }
 
-// ThreadPool: THREAD_POOL_DEFAULT
+// ThreadPool: THREAD_POOL_META_STATE
 void bulk_load_service::partition_ingestion(const std::string &app_name, const gpid &pid)
 {
-    FAIL_POINT_INJECT_F("meta_bulk_load_partition_ingestion", [](dsn::string_view) {});
+    FAIL_POINT_INJECT_F("meta_bulk_load_partition_ingestion", [=](dsn::string_view) {
+        if (_apps_ingesting_count[pid.get_app_id()] < FLAGS_bulk_load_ingestion_concurrent_count) {
+            _apps_ingesting_count[pid.get_app_id()]++;
+        }
+    });
+
+    {
+        zauto_read_lock l(_lock);
+        if (_apps_ingesting_count[pid.get_app_id()] >= FLAGS_bulk_load_ingestion_concurrent_count) {
+            dwarn_f("app({}) has already {} partitions executing ingestion, partition({}) will "
+                    "wait and try it later",
+                    app_name,
+                    _apps_ingesting_count[pid.get_app_id()],
+                    pid);
+            tasking::enqueue(
+                LPC_META_STATE_NORMAL,
+                _meta_svc->tracker(),
+                std::bind(&bulk_load_service::partition_ingestion, this, app_name, pid),
+                pid.thread_hash(),
+                std::chrono::milliseconds(100));
+            return;
+        }
+    }
 
     rpc_address primary_addr;
     {
@@ -1014,12 +1038,7 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
             dwarn_f("app(name={}, id={}) is not existed, set bulk load failed",
                     app_name,
                     pid.get_app_id());
-            tasking::enqueue(
-                LPC_META_STATE_NORMAL,
-                _meta_svc->tracker(),
-                std::bind(
-                    &bulk_load_service::handle_app_unavailable, this, pid.get_app_id(), app_name));
-
+            handle_app_unavailable(pid.get_app_id(), app_name);
             return;
         }
         primary_addr = app->partitions[pid.get_partition_index()].primary;
@@ -1027,7 +1046,7 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
 
     if (primary_addr.is_invalid()) {
         dwarn_f("app({}) partition({}) primary is invalid, try it later", app_name, pid);
-        tasking::enqueue(LPC_BULK_LOAD_INGESTION,
+        tasking::enqueue(LPC_META_STATE_NORMAL,
                          _meta_svc->tracker(),
                          std::bind(&bulk_load_service::partition_ingestion, this, app_name, pid),
                          pid.thread_hash(),
@@ -1039,20 +1058,36 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
         derror_f("app({}) partition({}) doesn't have bulk load metadata, set bulk load failed",
                  app_name,
                  pid);
-        tasking::enqueue(
-            LPC_META_STATE_NORMAL,
-            _meta_svc->tracker(),
-            std::bind(&bulk_load_service::handle_bulk_load_failed, this, pid.get_app_id()));
+        handle_bulk_load_failed(pid.get_app_id());
         return;
     }
 
+    tasking::enqueue(
+        LPC_BULK_LOAD_INGESTION,
+        _meta_svc->tracker(),
+        std::bind(&bulk_load_service::send_ingestion_request, this, app_name, pid, primary_addr));
+    {
+        zauto_write_lock l(_lock);
+        _apps_ingesting_count[pid.get_app_id()]++;
+        ddebug_f("send ingest_request to node({}), app({}) partition({}), ingestion_count({})",
+                 primary_addr.to_string(),
+                 app_name,
+                 pid,
+                 _apps_ingesting_count[pid.get_app_id()]);
+    }
+}
+
+// ThreadPool: THREAD_POOL_DEFAULT
+void bulk_load_service::send_ingestion_request(const std::string &app_name,
+                                               const gpid &pid,
+                                               const rpc_address &primary_addr)
+{
     ingestion_request req;
     req.app_name = app_name;
     {
         zauto_read_lock l(_lock);
         req.metadata = _partition_bulk_load_info[pid].metadata;
     }
-
     // create a client request, whose gpid field in header should be pid
     message_ex *msg = message_ex::create_request(dsn::apps::RPC_RRDB_RRDB_BULK_LOAD,
                                                  0,
@@ -1067,10 +1102,6 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
         [this, app_name, pid](error_code err, ingestion_response &&resp) {
             on_partition_ingestion_reply(err, std::move(resp), app_name, pid);
         });
-    ddebug_f("send ingest_request to node({}), app({}) partition({})",
-             primary_addr.to_string(),
-             app_name,
-             pid);
     _meta_svc->send_request(msg, primary_addr, rpc_callback);
 }
 
@@ -1080,6 +1111,11 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
                                                      const std::string &app_name,
                                                      const gpid &pid)
 {
+    {
+        zauto_write_lock l(_lock);
+        _apps_ingesting_count[pid.get_app_id()]--;
+    }
+
     if (err == ERR_NO_NEED_OPERATE) {
         dwarn_f(
             "app({}) partition({}) has already executing ingestion, ignore this repeated request",
@@ -1184,6 +1220,7 @@ void bulk_load_service::reset_local_bulk_load_states(int32_t app_id, const std::
     erase_map_elem_by_id(app_id, _partitions_cleaned_up);
     _apps_rolling_back.erase(app_id);
     _apps_cleaning_up.erase(app_id);
+    _apps_ingesting_count.erase(app_id);
     _bulk_load_app_id.erase(app_id);
     ddebug_f("reset local app({}) bulk load context", app_name);
 }
@@ -1654,6 +1691,7 @@ void bulk_load_service::do_continue_app_bulk_load(
     {
         zauto_write_lock l(_lock);
         _apps_in_progress_count[app_id] = in_progress_partition_count;
+        _apps_ingesting_count[app_id] = 0;
     }
 
     // if app is paused, no need to send bulk_load_request, just return
@@ -1688,10 +1726,7 @@ void bulk_load_service::do_continue_app_bulk_load(
         gpid pid = gpid(app_id, i);
         partition_bulk_load(ainfo.app_name, pid);
         if (app_status == bulk_load_status::BLS_INGESTING) {
-            tasking::enqueue(
-                LPC_BULK_LOAD_INGESTION,
-                _meta_svc->tracker(),
-                std::bind(&bulk_load_service::partition_ingestion, this, ainfo.app_name, pid));
+            partition_ingestion(ainfo.app_name, pid);
         }
     }
 }

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1031,7 +1031,7 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
                 _meta_svc->tracker(),
                 std::bind(&bulk_load_service::partition_ingestion, this, app_name, pid),
                 pid.thread_hash(),
-                std::chrono::seconds(1));
+                std::chrono::seconds(5));
             return;
         }
     }

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -374,6 +374,15 @@ private:
         return (_bulk_load_app_id.find(app_id) != _bulk_load_app_id.end());
     }
 
+    inline void decrease_app_ingestion_count(const gpid &pid)
+    {
+        zauto_write_lock l(_lock);
+        auto app_id = pid.get_app_id();
+        if (_apps_ingesting_count.find(app_id) != _apps_ingesting_count.end()) {
+            _apps_ingesting_count[app_id]--;
+        }
+    }
+
 private:
     friend class bulk_load_service_test;
     friend class meta_bulk_load_http_test;

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -23,6 +23,8 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_uint32(bulk_load_ingestion_concurrent_count);
+
 ///
 /// bulk load path on remote storage:
 /// <cluster_root>/bulk_load/<app_id> -> app_bulk_load_info
@@ -169,6 +171,10 @@ private:
     // Called when app bulk load status update to ingesting
     // create ingestion_request and send it to primary
     void partition_ingestion(const std::string &app_name, const gpid &pid);
+
+    void send_ingestion_request(const std::string &app_name,
+                                const gpid &pid,
+                                const rpc_address &primary_addr);
 
     void on_partition_ingestion_reply(error_code err,
                                       const ingestion_response &&resp,
@@ -404,6 +410,8 @@ private:
     std::unordered_map<app_id, bool> _apps_cleaning_up;
     // Used for bulk load rolling back to downloading
     std::unordered_map<app_id, bool> _apps_rolling_back;
+    // app_id -> ingesting partition count
+    std::unordered_map<app_id, int32_t> _apps_ingesting_count;
 };
 
 } // namespace replication

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -541,6 +541,7 @@ public:
                                 int32_t in_progress_count,
                                 int32_t ingestion_count)
     {
+        FLAGS_bulk_load_ingestion_concurrent_count = 4;
         mock_meta_bulk_load_context(_app_id, in_progress_count, bulk_load_status::BLS_INGESTING);
         set_app_ingesting_count(_app_id, ingestion_count);
         _ingestion_resp.err = err;
@@ -610,6 +611,7 @@ TEST_F(bulk_load_process_test, start_ingesting)
 {
     fail::cfg("meta_bulk_load_partition_ingestion", "return()");
     mock_response_progress(ERR_OK, true);
+    FLAGS_bulk_load_ingestion_concurrent_count = _partition_count;
     test_on_partition_bulk_load_reply(1, bulk_load_status::BLS_DOWNLOADED);
     ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_INGESTING);
     ASSERT_EQ(get_app_ingesting_count(_app_id), _partition_count);
@@ -619,10 +621,10 @@ TEST_F(bulk_load_process_test, ingestion_count_restriction)
 {
     fail::cfg("meta_bulk_load_partition_ingestion", "return()");
     mock_response_progress(ERR_OK, true);
-    FLAGS_bulk_load_ingestion_concurrent_count = 4;
+    FLAGS_bulk_load_ingestion_concurrent_count = 1;
     test_on_partition_bulk_load_reply(1, bulk_load_status::BLS_DOWNLOADED);
     ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_INGESTING);
-    ASSERT_EQ(get_app_ingesting_count(_app_id), 4);
+    ASSERT_EQ(get_app_ingesting_count(_app_id), 1);
 }
 
 TEST_F(bulk_load_process_test, ingestion_running)


### PR DESCRIPTION
To shorten all partitions ingestion total time, the pervious implementation didn't do any restrction when meta server sent ingestion request to primaries. However, ingestion will cost replica server lots of cpu, io resource, even affect cluster read/write performance. This pull request adds ingestion concurrent count in meta server, if the count is 4, the fifth ingestion request won't be sent to primary partition unless meta received one ingestion response. Besides, this count can be updated dynamically through http interface.

```diff
[meta_server]
+bulk_load_ingestion_concurrent_count=4
```