### PR TITLE
fix: fix replica::init_table_level_latency_counter metric name error

### DIFF
--- a/scripts/linux/run-clang-format.sh
+++ b/scripts/linux/run-clang-format.sh
@@ -3,6 +3,6 @@
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 PROJECT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 python ${SCRIPT_DIR}/run-clang-format.py \
-	--clang-format-executable=clang-format3.9 \
+	--clang-format-executable=clang-format-3.9 \
 	-i \
 	-r ${PROJECT_DIR}/src ${PROJECT_DIR}/include

--- a/scripts/linux/run-clang-format.sh
+++ b/scripts/linux/run-clang-format.sh
@@ -3,6 +3,6 @@
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 PROJECT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 python ${SCRIPT_DIR}/run-clang-format.py \
-	--clang-format-executable=clang-format-3.9 \
+	--clang-format-executable=clang-format3.9 \
 	-i \
 	-r ${PROJECT_DIR}/src ${PROJECT_DIR}/include

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -530,7 +530,7 @@ void replica::init_table_level_latency_counters()
         if (get_storage_rpc_req_codes().find(task_code(code)) !=
             get_storage_rpc_req_codes().end()) {
             std::string counter_str =
-                fmt::format("table.level.{}.latency(ns)@{}", task_code(code), _app_info.app_name);
+                fmt::format("table.level.{}.latency(ns)@{}", task_code(code).to_string(), _app_info.app_name);
             _counters_table_level_latency[code] =
                 dsn::perf_counters::instance()
                     .get_app_counter("eon.replica",

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -529,8 +529,8 @@ void replica::init_table_level_latency_counters()
         _counters_table_level_latency[code] = nullptr;
         if (get_storage_rpc_req_codes().find(task_code(code)) !=
             get_storage_rpc_req_codes().end()) {
-            std::string counter_str =
-                fmt::format("table.level.{}.latency(ns)@{}", task_code(code).to_string(), _app_info.app_name);
+            std::string counter_str = fmt::format(
+                "table.level.{}.latency(ns)@{}", task_code(code).to_string(), _app_info.app_name);
             _counters_table_level_latency[code] =
                 dsn::perf_counters::instance()
                     .get_app_counter("eon.replica",


### PR DESCRIPTION
We should use taskcode(code).to_string() to get metric name , not taskcode(code) to get _internal_code.