### PR TITLE
feat: add a remote command to get status of tcmalloc

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -89,6 +89,7 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
 {
 #ifdef DSN_ENABLE_GPERF
     _release_tcmalloc_memory_command = nullptr;
+    _get_tcmalloc_status_command = nullptr;
     _max_reserved_memory_percentage_command = nullptr;
 #endif
     _replica_state_subscriber = subscriber;
@@ -2283,6 +2284,16 @@ void replica_stub::register_ctrl_command()
                     _release_tcmalloc_memory, "release-tcmalloc-memory", args);
             });
 
+        _get_tcmalloc_status_command = ::dsn::command_manager::instance().register_command(
+            {"replica.get-tcmalloc-status"},
+            "replica.get-tcmalloc-status",
+            "replica.get-tcmalloc-status - get status of tcmalloc",
+            [this](const std::vector<std::string> &args) {
+                char buf[4096];
+                MallocExtension::instance()->GetStats(buf, 4096);
+                return std::string(buf);
+            });
+
         _max_reserved_memory_percentage_command = dsn::command_manager::instance().register_command(
             {"replica.mem-release-max-reserved-percentage"},
             "replica.mem-release-max-reserved-percentage [num | DEFAULT]",
@@ -2464,6 +2475,7 @@ void replica_stub::close()
     UNREGISTER_VALID_HANDLER(_query_app_envs_command);
 #ifdef DSN_ENABLE_GPERF
     UNREGISTER_VALID_HANDLER(_release_tcmalloc_memory_command);
+    UNREGISTER_VALID_HANDLER(_get_tcmalloc_status_command);
     UNREGISTER_VALID_HANDLER(_max_reserved_memory_percentage_command);
 #endif
     UNREGISTER_VALID_HANDLER(_max_concurrent_bulk_load_downloading_count_command);
@@ -2477,6 +2489,7 @@ void replica_stub::close()
     _query_app_envs_command = nullptr;
 #ifdef DSN_ENABLE_GPERF
     _release_tcmalloc_memory_command = nullptr;
+    _get_tcmalloc_status_command = nullptr;
     _max_reserved_memory_percentage_command = nullptr;
 #endif
     _max_concurrent_bulk_load_downloading_count_command = nullptr;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -364,6 +364,7 @@ private:
     dsn_handle_t _query_app_envs_command;
 #ifdef DSN_ENABLE_GPERF
     dsn_handle_t _release_tcmalloc_memory_command;
+    dsn_handle_t _get_tcmalloc_status_command;
     dsn_handle_t _max_reserved_memory_percentage_command;
 #endif
     dsn_handle_t _max_concurrent_bulk_load_downloading_count_command;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Sometimes, we need the status of tcmalloc to analyze some issues about memory.

### What is changed and how does it work?
add remote command to get status of tcmalloc

### Tests <!-- At least one of them must be included. -->
Manual test (add detailed scripts or steps below)
remote_command -t replica_server replica.get-tcmalloc-status

### Related changes
Need to update the documentation
Need to be included in the release note