### PR TITLE
fix: fix github actions not run when reopen a PR

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ name: pull_request
 on:
   # run on each pull request
   pull_request:
-    types: [ synchronize, opened ]
+    types: [ synchronize, opened, reopened ]
     branches:
       - master
       - 'v[0-9]+.*' # release branch


### PR DESCRIPTION
Sometimes we need to re-run github actions when they failed by reopening th PR.
Ref docs: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request