### PR TITLE
fix: plog may be lost on going duplicating when replica re-open and then learn

### DIFF
--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -79,8 +79,8 @@ void replica::on_config_proposal(configuration_update_request &proposal)
         }
     }
 
-    _app_info.__set_duplicating(proposal.info.duplicating) switch (proposal.type)
-    {
+    _app_info.__set_duplicating(proposal.info.duplicating);
+    switch (proposal.type) {
     case config_type::CT_ASSIGN_PRIMARY:
     case config_type::CT_UPGRADE_TO_PRIMARY:
         assign_primary(proposal);

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -79,7 +79,8 @@ void replica::on_config_proposal(configuration_update_request &proposal)
         }
     }
 
-    switch (proposal.type) {
+    _app_info.__set_duplicating(proposal.info.duplicating) switch (proposal.type)
+    {
     case config_type::CT_ASSIGN_PRIMARY:
     case config_type::CT_UPGRADE_TO_PRIMARY:
         assign_primary(proposal);

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -1476,16 +1476,16 @@ void replica::on_learn_completion_notification_reply(error_code err,
 
 void replica::on_add_learner(const group_check_request &request)
 {
-    ddebug("%s: process add learner, primary = %s, ballot = %" PRId64
-           ", status = %s, last_committed_decree = %" PRId64,
-           name(),
-           request.config.primary.to_string(),
-           request.config.ballot,
-           enum_to_string(request.config.status),
-           request.last_committed_decree);
+    dwarn_replica("process add learner, primary = {}, ballot ={}, status ={}, "
+                  "last_committed_decree = {}, duplicating = {}",
+                  request.config.primary.to_string(),
+                  request.config.ballot,
+                  enum_to_string(request.config.status),
+                  request.last_committed_decree,
+                  request.app.duplicating);
 
     if (request.config.ballot < get_ballot()) {
-        dwarn("%s: on_add_learner ballot is old, skipped", name());
+        dwarn_replica("on_add_learner ballot is old, skipped");
         return;
     }
 
@@ -1494,9 +1494,11 @@ void replica::on_add_learner(const group_check_request &request)
         if (!update_local_configuration(request.config, true))
             return;
 
-        dassert(partition_status::PS_POTENTIAL_SECONDARY == status(),
-                "invalid partition_status, status = %s",
-                enum_to_string(status()));
+        dassert_replica(partition_status::PS_POTENTIAL_SECONDARY == status(),
+                        "invalid partition_status, status = {}",
+                        enum_to_string(status()));
+
+        _duplicating = request.app.duplicating;
         init_learn(request.config.learner_signature);
     }
 }

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -1476,13 +1476,13 @@ void replica::on_learn_completion_notification_reply(error_code err,
 
 void replica::on_add_learner(const group_check_request &request)
 {
-    dwarn_replica("process add learner, primary = {}, ballot ={}, status ={}, "
-                  "last_committed_decree = {}, duplicating = {}",
-                  request.config.primary.to_string(),
-                  request.config.ballot,
-                  enum_to_string(request.config.status),
-                  request.last_committed_decree,
-                  request.app.duplicating);
+    ddebug_replica("process add learner, primary = {}, ballot ={}, status ={}, "
+                   "last_committed_decree = {}, duplicating = {}",
+                   request.config.primary.to_string(),
+                   request.config.ballot,
+                   enum_to_string(request.config.status),
+                   request.last_committed_decree,
+                   request.app.duplicating);
 
     if (request.config.ballot < get_ballot()) {
         dwarn_replica("on_add_learner ballot is old, skipped");


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/740 has describe the problem. 

private log from remote node when learning should be protected, which actually was considered in design of https://github.com/XiaoMi/rdsn/pull/355, but the problem is that the `duplicating status` is false when re-open replica,  and status sync(`on_config_sync` rpc)  is lagging to learning,  which result in the code will be ignored: https://github.com/XiaoMi/rdsn/blob/2b4232809262a1e6102a67ae86db2f37bd58e8ce/src/replica/replica_learn.cpp#L1556-L1559

that is to say, the private log is lost since the log of  path `/learn`don't replay to path `/plog`with the `duplicating = false` when replica re-open. for sync the `duplicating status` in time, this pr don't depend the `config sync`:
https://github.com/XiaoMi/rdsn/blob/2b4232809262a1e6102a67ae86db2f37bd58e8ce/src/replica/replica_config.cpp#L1053

but sync the status from `proposal config` when receive `learng request`, which will make sure the `duplicating status` is right before replay plog

