### PR TITLE
fix(backup_policy): ignore current backup when policy is diabled

### DIFF
--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -661,6 +661,19 @@ void policy_context::sync_backup_to_remote_storage_unlocked(const backup_info &b
 
 void policy_context::continue_current_backup_unlocked()
 {
+    if (_policy.is_disable) {
+        ddebug_f("{}: policy is disable, ignore this backup and try it later", _policy.policy_name);
+        tasking::enqueue(LPC_DEFAULT_CALLBACK,
+                         &_tracker,
+                         [this]() {
+                             zauto_lock l(_lock);
+                             issue_new_backup_unlocked();
+                         },
+                         0,
+                         _backup_service->backup_option().issue_backup_interval_ms);
+        return;
+    }
+
     for (const int32_t &app : _cur_backup.app_ids) {
         if (_progress.unfinished_partitions_per_app.find(app) !=
             _progress.unfinished_partitions_per_app.end()) {

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -662,7 +662,8 @@ void policy_context::sync_backup_to_remote_storage_unlocked(const backup_info &b
 void policy_context::continue_current_backup_unlocked()
 {
     if (_policy.is_disable) {
-        ddebug_f("{}: policy is disable, ignore this backup and try it later", _policy.policy_name);
+        ddebug_f("{}: policy is disabled, ignore this backup and try it later",
+                 _policy.policy_name);
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this]() {
@@ -747,7 +748,7 @@ void policy_context::issue_new_backup_unlocked()
 {
     // before issue new backup, we check whether the policy is dropped
     if (_policy.is_disable) {
-        ddebug("%s: policy is disable, just ignore backup, try it later",
+        ddebug("%s: policy is disabled, just ignore backup, try it later",
                _policy.policy_name.c_str());
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -537,6 +537,28 @@ TEST_F(policy_context_test, test_app_dropped_during_backup)
     }
 }
 
+TEST_F(policy_context_test, test_disable_backup_policy)
+{
+    _policy = _mp.get_policy();
+    _policy.is_disable = true;
+    _mp.set_policy(_policy);
+
+    _mp._backup_history.clear();
+    _mp._cur_backup.backup_id = 0;
+    _mp._cur_backup.end_time_ms = 0;
+
+    backup_info bi;
+    bi.start_time_ms = dsn_now_ms();
+    bi.end_time_ms = 0;
+    bi.app_ids = {1};
+    bi.backup_id = bi.start_time_ms;
+    _mp.add_backup_history(bi);
+
+    // 'start_backup_app_meta_unlocked()' should not be called because policy is disabled
+    _mp.continue_current_backup_unlocked();
+    ASSERT_FALSE(_mp.notifier_start_backup_app_meta_unlocked().wait_for(5000));
+}
+
 TEST_F(policy_context_test, test_backup_failed)
 {
     fail::setup();


### PR DESCRIPTION
Before this patch meta will continue last unfinished backup after restarted, however, whether the policy is disabled or not is not considered. This patch fixed it.

