### PR TITLE
fix: add a destructor for `join_point`

### DIFF
--- a/include/dsn/utility/join_point.h
+++ b/include/dsn/utility/join_point.h
@@ -52,7 +52,7 @@ class join_point_base
 public:
     explicit join_point_base(const char *name) : _name(name) {}
 
-    ~join_point_base()
+    virtual ~join_point_base()
     {
         _advice_entries.clear();
         _ret_advice_entries.clear();

--- a/include/dsn/utility/join_point.h
+++ b/include/dsn/utility/join_point.h
@@ -52,6 +52,12 @@ class join_point_base
 public:
     explicit join_point_base(const char *name) : _name(name) {}
 
+    ~join_point_base()
+    {
+        _advice_entries.clear();
+        _ret_advice_entries.clear();
+    }
+
     using ReturnedAdviceT = R(Args...);
     using AdviceT = void(Args...);
 


### PR DESCRIPTION
I met an error when pegasus exit, the progress ouput is:
```
terminate called after throwing an instance of 'std::bad_function_call'
  what():  bad_function_call
```
coredump stack:
```
(gdb) bt
#0  0x00007f23db90d1d7 in raise () from /lib64/libc.so.6
#1  0x00007f23db90e8c8 in abort () from /lib64/libc.so.6
#2  0x00007f23dc23fb3d in __gnu_cxx::__verbose_terminate_handler () at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00007f23dc23dba6 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:47
#4  0x00007f23dc23cbf9 in __cxa_call_terminate (ue_header=0x1bb0060) at ../../../../libstdc++-v3/libsupc++/eh_call.cc:54
#5  0x00007f23dc23d545 in __cxxabiv1::__gxx_personality_v0 (version=<optimized out>, actions=<optimized out>, exception_class=5138137972254386944, ue_header=<optimized out>, 
    context=0x7f235e50bc30) at ../../../../libstdc++-v3/libsupc++/eh_personality.cc:676
#6  0x00007f23dbca8903 in ?? () from /lib64/libgcc_s.so.1
#7  0x00007f23dbca8c9b in _Unwind_RaiseException () from /lib64/libgcc_s.so.1
#8  0x00007f23dc23ddfb in __cxxabiv1::__cxa_throw (obj=0x1bb0080, tinfo=0x7f23dc5327e0 <typeinfo for std::bad_function_call>, 
    dest=0x7f23dc26acd0 <std::bad_function_call::~bad_function_call()>) at ../../../../libstdc++-v3/libsupc++/eh_throw.cc:82
#9  0x00007f23dc26ac62 in std::__throw_bad_function_call () at ../../../../../libstdc++-v3/src/c++11/functexcept.cc:139
#10 0x00007f23df232278 in operator() (__args#0=dsn::SYS_EXIT_EXCEPTION, this=<optimized out>) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/functional:2266
#11 Invoke<std::function<void(dsn::sys_exit_type)>&, dsn::sys_exit_type> (f=...) at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/absl/base/internal/invoke.h:180
#12 Invoke<std::function<void(dsn::sys_exit_type)>&, dsn::sys_exit_type> (f=...) at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/absl/base/internal/invoke.h:212
#13 apply_helper<std::function<void(dsn::sys_exit_type)>&, std::tuple<dsn::sys_exit_type>, 0ul> (t=<optimized out>, functor=...)
    at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/absl/utility/utility.h:155
#14 apply<std::function<void(dsn::sys_exit_type)>&, std::tuple<dsn::sys_exit_type> > (t=<optimized out>, functor=...)
    at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/absl/utility/utility.h:202
#15 execute (args#0=dsn::SYS_EXIT_EXCEPTION, this=<optimized out>) at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/join_point.h:118
#16 dsn::utils::coredump::write () at /home/zhangyifan8/work/pegasus/rdsn/src/utils/coredump.posix.cpp:64
#17 0x00007f23e118a554 in os::Linux::chained_handler(int, siginfo*, void*) () from /opt/soft/openjdk1.8.0/jre/lib/amd64/server/libjvm.so
#18 0x00007f23e118f089 in JVM_handle_linux_signal () from /opt/soft/openjdk1.8.0/jre/lib/amd64/server/libjvm.so
#19 0x00007f23e1182a08 in signalHandler(int, siginfo*, void*) () from /opt/soft/openjdk1.8.0/jre/lib/amd64/server/libjvm.so
#20 <signal handler called>
#21 0x00007f23e0496d38 in ~_Function_base (this=0x1d9fbd0, __in_chrg=<optimized out>) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/functional:1830
#22 ~function (this=0x1d9fbd0, __in_chrg=<optimized out>) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/functional:1974
#23 ~_List_node (this=0x1d9fbc0, __in_chrg=<optimized out>) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/bits/stl_list.h:106
#24 destroy<std::_List_node<std::function<void(dsn::sys_exit_type)> > > (this=<optimized out>, __p=0x1d9fbc0)
    at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/ext/new_allocator.h:124
#25 std::__cxx11::_List_base<std::function<void (dsn::sys_exit_type)>, std::allocator<std::function<void (dsn::sys_exit_type)> > >::_M_clear() (
    this=this@entry=0x7f23e0919cf8 <dsn::tools::sys_exit+24>) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/bits/list.tcc:75
#26 0x00007f23e0496d87 in ~_List_base (this=0x7f23e0919cf8 <dsn::tools::sys_exit+24>, __in_chrg=<optimized out>)
    at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/bits/stl_list.h:446
#27 ~list (this=0x7f23e0919cf8 <dsn::tools::sys_exit+24>, __in_chrg=<optimized out>) at /home/zhangyifan8/local/gcc-5.4.0/include/c++/5.4.0/bits/stl_list.h:507
#28 ~join_point_base (this=0x7f23e0919ce0 <dsn::tools::sys_exit>, __in_chrg=<optimized out>) at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/join_point.h:50
#29 dsn::join_point<void, dsn::sys_exit_type>::~join_point (this=0x7f23e0919ce0 <dsn::tools::sys_exit>, __in_chrg=<optimized out>)
    at /home/zhangyifan8/work/pegasus/rdsn/include/dsn/utility/join_point.h:107
#30 0x00007f23db910dba in __cxa_finalize () from /lib64/libc.so.6
#31 0x00007f23df7b5eb6 in __do_global_dtors_aux () from /home/work/app/pegasus/c4tst-hdfs/replica/package/bin/libdsn_meta_server.so
#32 0x00007f23e1a5e548 in ?? ()
#33 0x0000000000000001 in ?? ()
#34 0x00007f235e50ca70 in ?? ()

```
It shows that`dsn::tools::sys_exit.execute(SYS_EXIT_EXCEPTION)` was called when the `join_point` object is destroyed.

This patch adds a destructor for `join_point` in which all entries were cleared so the 'bad_function' would not be called.