### PR TITLE
fix: fix a compilation error on clang

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -513,7 +513,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     std::string cdir;
     std::string err_msg;
     if (!dsn::utils::filesystem::create_directory(_options.slog_dir, cdir, err_msg)) {
-        dassert(false, "{}", err_msg);
+        dassert_f(false, "{}", err_msg);
     }
     _options.slog_dir = cdir;
     initialize_fs_manager(_options.data_dirs, _options.data_dir_tags);


### PR DESCRIPTION
Fix a compilation error: https://github.com/XiaoMi/rdsn/runs/2786707126?check_suite_focus=true, which was introduced by https://github.com/XiaoMi/rdsn/pull/834