### PR TITLE
fix(graceful_exit): adjust the destructing order

### DIFF
--- a/include/dsn/tool-api/timer_service.h
+++ b/include/dsn/tool-api/timer_service.h
@@ -64,6 +64,7 @@ public:
     virtual ~timer_service() = default;
 
     virtual void start() = 0;
+    virtual void stop() = 0;
 
     // after milliseconds, the provider should call task->enqueue()
     virtual void add_timer(task *task) = 0;

--- a/src/aio/test/main.cpp
+++ b/src/aio/test/main.cpp
@@ -9,5 +9,9 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
     dsn_run_config("config.ini", false);
-    return RUN_ALL_TESTS();
+    int g_test_ret = RUN_ALL_TESTS();
+#ifndef ENABLE_GCOV
+    dsn_exit(g_test_ret);
+#endif
+    return g_test_ret;
 }

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -81,10 +81,17 @@ meta_service::meta_service()
     _access_controller = security::create_meta_access_controller();
 }
 
-meta_service::~meta_service()
+meta_service::~meta_service() { stop(); }
+
+void meta_service::stop()
 {
+    zauto_write_lock l(_meta_lock);
+    if (!_started.load()) {
+        return;
+    }
     _tracker.cancel_outstanding_tasks();
     unregister_ctrl_commands();
+    _started = false;
 }
 
 bool meta_service::check_freeze() const

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -73,6 +73,7 @@ public:
     virtual ~meta_service();
 
     error_code start();
+    void stop();
 
     const replication_options &get_options() const { return _opts; }
     const meta_options &get_meta_options() const { return _meta_opts; }

--- a/src/meta/meta_service_app.cpp
+++ b/src/meta/meta_service_app.cpp
@@ -104,7 +104,7 @@ error_code meta_service_app::start(const std::vector<std::string> &args)
 
 error_code meta_service_app::stop(bool /*cleanup*/)
 {
-    _service.reset(nullptr);
+    _service->stop();
     return ERR_OK;
 }
 } // namespace service

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -400,6 +400,8 @@ private:
     // replica count exectuting bulk load downloading concurrently
     std::atomic_int _bulk_load_downloading_count;
 
+    bool _is_running;
+
     // performance counters
     perf_counter_wrapper _counter_replicas_count;
     perf_counter_wrapper _counter_replicas_opening_count;

--- a/src/runtime/rpc/rpc_engine.h
+++ b/src/runtime/rpc/rpc_engine.h
@@ -137,6 +137,7 @@ public:
     //
     ::dsn::error_code start(const service_app_spec &spec);
     void start_serving() { _is_serving = true; }
+    void stop_serving() { _is_serving = false; }
 
     //
     // rpc registrations

--- a/src/runtime/service_engine.h
+++ b/src/runtime/service_engine.h
@@ -135,11 +135,8 @@ private:
 
     bool _simulator;
 
-    // <port, servicenode>
-    typedef std::map<int, service_node *>
-        node_engines_by_port; // multiple ports may share the same node
+    // map app_id to service_node
     service_nodes_by_app_id _nodes_by_app_id;
-    node_engines_by_port _nodes_by_app_port;
 };
 
 // ------------ inline impl ---------------------

--- a/src/runtime/task/simple_task_queue.h
+++ b/src/runtime/task/simple_task_queue.h
@@ -52,16 +52,19 @@ class simple_timer_service : public timer_service
 public:
     simple_timer_service(service_node *node, timer_service *inner_provider);
 
-    ~simple_timer_service() override;
+    ~simple_timer_service() override { stop(); }
 
     // after milliseconds, the provider should call task->enqueue()
     virtual void add_timer(task *task) override;
 
     virtual void start() override;
 
+    virtual void stop() override;
+
 private:
     boost::asio::io_service _ios;
     std::thread _worker;
+    bool _is_running;
 };
 
 } // namespace tools

--- a/src/runtime/task/task_engine.h
+++ b/src/runtime/task/task_engine.h
@@ -58,6 +58,7 @@ public:
     // service management
     void create();
     void start();
+    void stop();
 
     // task procecessing
     void enqueue(task *task);
@@ -95,12 +96,14 @@ class task_engine
 {
 public:
     task_engine(service_node *node);
+    ~task_engine() { stop(); }
 
     //
     // service management routines
     //
     void create(const std::list<dsn::threadpool_code> &pools);
     void start();
+    void stop();
 
     //
     // task management routines

--- a/src/runtime/task/task_engine.sim.h
+++ b/src/runtime/task/task_engine.sim.h
@@ -55,6 +55,8 @@ public:
     virtual void add_timer(task *task) override;
 
     virtual void start() override {}
+
+    virtual void stop() override {}
 };
 
 class sim_task_queue : public task_queue


### PR DESCRIPTION
See https://github.com/apache/incubator-pegasus/issues/734 for coredump stack details.

The stack shows that we still want to enqueue some tasks when `task_worker_pool` is destroyed.

This patch explicitly specified the order in which `service_app` , `rpc_engine` and `task_engine` stop in `~service_node()`, which is the reverese order they start.