### PR TITLE
build: warn on missing virtual on base class desctructor

### DIFF
--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -199,6 +199,8 @@ function(dsn_setup_compiler_flags)
     add_compile_options(-Wno-deprecated-declarations)
     add_compile_options(-Wno-inconsistent-missing-override)
     add_compile_options(-Wno-attributes)
+    # Must add virtual on all base destructors.
+    add_compile_options(-Wnon-virtual-dtor)
     # -fno-omit-frame-pointer
     #   use frame pointers to allow simple stack frame walking for backtraces.
     #   This has a small perf hit but worth it for the ability to profile in production

--- a/include/dsn/utility/work_queue.h
+++ b/include/dsn/utility/work_queue.h
@@ -50,7 +50,7 @@ public:
         _current_op_count = 0;
     }
 
-    ~work_queue()
+    virtual ~work_queue()
     {
         scope_lk l(_lock);
         assert(_hdr.is_empty());

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -47,9 +47,9 @@ set(OSS_URL_PREFIX "http://pegasus-thirdparties.oss-cn-beijing.aliyuncs.com")
 message(STATUS "Setting up third-parties...")
 
 ExternalProject_Add(boost
-        URL ${OSS_URL_PREFIX}/boost_1_69_0.tar.bz2
-        https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2
-        URL_MD5 a1332494397bf48332cb152abfefcec2
+        URL ${OSS_URL_PREFIX}/boost_1_71_0.tar.bz2
+        https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2
+        URL_MD5 4cdf9b5c2dc01fb2b7b733d5af30e558
         CONFIGURE_COMMAND ./bootstrap.sh --prefix=. --with-libraries=system,filesystem,regex --with-toolset=gcc
         BUILD_COMMAND ./b2 toolset=gcc cxxflags=-fPIC cxxstd=11 install
         INSTALL_COMMAND cp -R include/boost ${TP_OUTPUT}/include && cp -R lib ${TP_OUTPUT}/


### PR DESCRIPTION
This option is to prevent further issues like https://github.com/XiaoMi/rdsn/pull/841 

Boost 1.69 has the same errors if this option is turned on. If the reviewers have agreed, we can use a newer version of boost, 1.71 for example (which is the default on ubuntu20.04), then this PR can pass.

