### PR TITLE
feat: add env check entry in `app_env_validator` for user specified compaction

### DIFF
--- a/include/dsn/dist/replication/replica_envs.h
+++ b/include/dsn/dist/replication/replica_envs.h
@@ -57,6 +57,7 @@ public:
     static const std::string REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS;
     static const std::string READ_QPS_THROTTLING;
     static const std::string SPLIT_VALIDATE_PARTITION_HASH;
+    static const std::string USER_SPECIFIED_COMPACTION;
 };
 
 } // namespace replication

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -648,6 +648,7 @@ const std::string replica_envs::REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS(
 const std::string replica_envs::READ_QPS_THROTTLING("replica.read_throttling");
 const std::string
     replica_envs::SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
+const std::string replica_envs::USER_SPECIFIED_COMPACTION("user_specified_compaction");
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -173,7 +173,8 @@ void app_env_validator::register_all_validators()
         {replica_envs::READ_QPS_THROTTLING,
          std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::SPLIT_VALIDATE_PARTITION_HASH,
-         std::bind(&check_split_validation, std::placeholders::_1, std::placeholders::_2)}};
+         std::bind(&check_split_validation, std::placeholders::_1, std::placeholders::_2)},
+        {replica_envs::USER_SPECIFIED_COMPACTION, nullptr}};
 }
 
 } // namespace replication


### PR DESCRIPTION
### Manual Test

```
➜  pegasus git:(master) ✗ ./run.sh shell
W2021-07-02 11:48:40.629 (1625197720629655537 28820) : overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
W2021-07-02 11:48:40.629 (1625197720629708604 28820) : overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX_ACK from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
Pegasus Shell 2.1.SNAPSHOT
Type "help" for more information.
Type "Ctrl-D" or "Ctrl-C" to exit the shell.

The config file is: /home/mi/workspace/pegasus/config-shell.ini.28813
The cluster name is: onebox
The cluster meta list is: 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
>>> ls
[general_info]
app_id  status     app_name  app_type  partition_count  replica_count  is_stateful  create_time          drop_time  drop_expire  envs_count  
1       AVAILABLE  stat      pegasus   4                3              true         2021-07-02_11:48:39  -          -            0           
2       AVAILABLE  temp      pegasus   8                3              true         2021-07-02_11:48:39  -          -            0           

[summary]
total_app_count  : 2

>>> use test
OK
>>> use temp
OK
>>> ls
[general_info]
app_id  status     app_name  app_type  partition_count  replica_count  is_stateful  create_time          drop_time  drop_expire  envs_count  
1       AVAILABLE  stat      pegasus   4                3              true         2021-07-02_11:48:39  -          -            0           
2       AVAILABLE  temp      pegasus   8                3              true         2021-07-02_11:48:39  -          -            0           

[summary]
total_app_count  : 2

>>> set_app_envs user_specified_compaction aaa
set app envs succeed
>>> 

```