### PR TITLE
feat: add rate limiter for backup request

### DIFF
--- a/include/dsn/dist/replication/replica_envs.h
+++ b/include/dsn/dist/replication/replica_envs.h
@@ -57,7 +57,6 @@ public:
     static const std::string REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS;
     static const std::string READ_QPS_THROTTLING;
     static const std::string BACKUP_REQUEST_QPS_THROTTLING;
-    static const std::string BACKUP_REQUEST_SIZE_THROTTLING;
     static const std::string SPLIT_VALIDATE_PARTITION_HASH;
     static const std::string USER_SPECIFIED_COMPACTION;
 };

--- a/include/dsn/dist/replication/replica_envs.h
+++ b/include/dsn/dist/replication/replica_envs.h
@@ -56,6 +56,8 @@ public:
     static const std::string BUSINESS_INFO;
     static const std::string REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS;
     static const std::string READ_QPS_THROTTLING;
+    static const std::string BACKUP_REQUEST_QPS_THROTTLING;
+    static const std::string BACKUP_REQUEST_SIZE_THROTTLING;
     static const std::string SPLIT_VALIDATE_PARTITION_HASH;
     static const std::string USER_SPECIFIED_COMPACTION;
 };

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -649,6 +649,8 @@ const std::string replica_envs::READ_QPS_THROTTLING("replica.read_throttling");
 const std::string
     replica_envs::SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 const std::string replica_envs::USER_SPECIFIED_COMPACTION("user_specified_compaction");
+const std::string replica_envs::BACKUP_REQUEST_QPS_THROTTLING("backup_request_throttling");
+const std::string replica_envs::BACKUP_REQUEST_SIZE_THROTTLING("backup_request_throttling_by_size");
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -650,7 +650,8 @@ const std::string
     replica_envs::SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 const std::string replica_envs::USER_SPECIFIED_COMPACTION("user_specified_compaction");
 const std::string replica_envs::BACKUP_REQUEST_QPS_THROTTLING("replica.backup_request_throttling");
-const std::string replica_envs::BACKUP_REQUEST_SIZE_THROTTLING("replica.backup_request_throttling_by_size");
+const std::string
+    replica_envs::BACKUP_REQUEST_SIZE_THROTTLING("replica.backup_request_throttling_by_size");
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -649,8 +649,8 @@ const std::string replica_envs::READ_QPS_THROTTLING("replica.read_throttling");
 const std::string
     replica_envs::SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 const std::string replica_envs::USER_SPECIFIED_COMPACTION("user_specified_compaction");
-const std::string replica_envs::BACKUP_REQUEST_QPS_THROTTLING("backup_request_throttling");
-const std::string replica_envs::BACKUP_REQUEST_SIZE_THROTTLING("backup_request_throttling_by_size");
+const std::string replica_envs::BACKUP_REQUEST_QPS_THROTTLING("replica.backup_request_throttling");
+const std::string replica_envs::BACKUP_REQUEST_SIZE_THROTTLING("replica.backup_request_throttling_by_size");
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -650,8 +650,6 @@ const std::string
     replica_envs::SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 const std::string replica_envs::USER_SPECIFIED_COMPACTION("user_specified_compaction");
 const std::string replica_envs::BACKUP_REQUEST_QPS_THROTTLING("replica.backup_request_throttling");
-const std::string
-    replica_envs::BACKUP_REQUEST_SIZE_THROTTLING("replica.backup_request_throttling_by_size");
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -182,8 +182,7 @@ void app_env_validator::register_all_validators()
         {replica_envs::BACKUP_REQUEST_QPS_THROTTLING,
          std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)},
         {replica_envs::BACKUP_REQUEST_SIZE_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)}
-    }
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)}};
 }
 
 } // namespace replication

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -54,7 +54,7 @@ bool check_rocksdb_iteration(const std::string &env_value, std::string &hint_mes
     return true;
 }
 
-bool check_throttling(const std::string &env_value, std::string &hint_message, bool delay_allowed)
+bool check_throttling(const std::string &env_value, std::string &hint_message)
 {
     std::vector<std::string> sargs;
     utils::split_args(env_value.c_str(), sargs, ',');
@@ -87,10 +87,6 @@ bool check_throttling(const std::string &env_value, std::string &hint_message, b
 
         // check the second part, which is must be "delay" or "reject"
         if (sub_sargs[1] == "delay") {
-            if (!delay_allowed) {
-                hint_message = "delay is not allowed";
-                return false;
-            }
             if (delay_parsed) {
                 hint_message = "duplicate delay config";
                 return false;
@@ -153,9 +149,9 @@ void app_env_validator::register_all_validators()
         {replica_envs::SLOW_QUERY_THRESHOLD,
          std::bind(&check_slow_query, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::WRITE_QPS_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, true)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::WRITE_SIZE_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, true)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::ROCKSDB_ITERATION_THRESHOLD_TIME_MS,
          std::bind(&check_rocksdb_iteration, std::placeholders::_1, std::placeholders::_2)},
         // TODO(zhaoliwei): not implemented
@@ -175,14 +171,14 @@ void app_env_validator::register_all_validators()
         {replica_envs::MANUAL_COMPACT_PERIODIC_BOTTOMMOST_LEVEL_COMPACTION, nullptr},
         {replica_envs::REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS, nullptr},
         {replica_envs::READ_QPS_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, true)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::SPLIT_VALIDATE_PARTITION_HASH,
          std::bind(&check_split_validation, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::USER_SPECIFIED_COMPACTION, nullptr},
         {replica_envs::BACKUP_REQUEST_QPS_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::BACKUP_REQUEST_SIZE_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)}};
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)}};
 }
 
 } // namespace replication

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -176,8 +176,6 @@ void app_env_validator::register_all_validators()
          std::bind(&check_split_validation, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::USER_SPECIFIED_COMPACTION, nullptr},
         {replica_envs::BACKUP_REQUEST_QPS_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
-        {replica_envs::BACKUP_REQUEST_SIZE_THROTTLING,
          std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)}};
 }
 

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -54,7 +54,7 @@ bool check_rocksdb_iteration(const std::string &env_value, std::string &hint_mes
     return true;
 }
 
-bool check_throttling(const std::string &env_value, std::string &hint_message)
+bool check_throttling(const std::string &env_value, std::string &hint_message, bool delay_allowed)
 {
     std::vector<std::string> sargs;
     utils::split_args(env_value.c_str(), sargs, ',');
@@ -87,6 +87,10 @@ bool check_throttling(const std::string &env_value, std::string &hint_message)
 
         // check the second part, which is must be "delay" or "reject"
         if (sub_sargs[1] == "delay") {
+            if (!delay_allowed) {
+                hint_message = "delay is not allowed";
+                return false;
+            }
             if (delay_parsed) {
                 hint_message = "duplicate delay config";
                 return false;
@@ -149,9 +153,9 @@ void app_env_validator::register_all_validators()
         {replica_envs::SLOW_QUERY_THRESHOLD,
          std::bind(&check_slow_query, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::WRITE_QPS_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, true)},
         {replica_envs::WRITE_SIZE_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, true)},
         {replica_envs::ROCKSDB_ITERATION_THRESHOLD_TIME_MS,
          std::bind(&check_rocksdb_iteration, std::placeholders::_1, std::placeholders::_2)},
         // TODO(zhaoliwei): not implemented
@@ -171,10 +175,15 @@ void app_env_validator::register_all_validators()
         {replica_envs::MANUAL_COMPACT_PERIODIC_BOTTOMMOST_LEVEL_COMPACTION, nullptr},
         {replica_envs::REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS, nullptr},
         {replica_envs::READ_QPS_THROTTLING,
-         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, true)},
         {replica_envs::SPLIT_VALIDATE_PARTITION_HASH,
          std::bind(&check_split_validation, std::placeholders::_1, std::placeholders::_2)},
-        {replica_envs::USER_SPECIFIED_COMPACTION, nullptr}};
+        {replica_envs::USER_SPECIFIED_COMPACTION, nullptr},
+        {replica_envs::BACKUP_REQUEST_QPS_THROTTLING,
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)},
+        {replica_envs::BACKUP_REQUEST_SIZE_THROTTLING,
+         std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2, false)}
+    }
 }
 
 } // namespace replication

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -98,11 +98,13 @@ replica::replica(
     _counter_recent_read_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
-    counter_str = fmt::format("recent.backup.request.throttling.delay.count@{}", _app_info.app_name);
+    counter_str =
+        fmt::format("recent.backup.request.throttling.delay.count@{}", _app_info.app_name);
     _counter_recent_backup_request_throttling_delay_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
-    counter_str = fmt::format("recent.backup.request.throttling.reject.count@{}", _app_info.app_name);
+    counter_str =
+        fmt::format("recent.backup.request.throttling.reject.count@{}", _app_info.app_name);
     _counter_recent_backup_request_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -98,6 +98,10 @@ replica::replica(
     _counter_recent_read_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
+    counter_str = fmt::format("recent.backup.request.throttling.delay.count@{}", gpid);
+    _counter_recent_backup_request_throttling_delay_count.init_app_counter(
+            "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
+
     counter_str = fmt::format("recent.backup.request.throttling.reject.count@{}", gpid);
     _counter_recent_backup_request_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -98,6 +98,10 @@ replica::replica(
     _counter_recent_read_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
+    counter_str = fmt::format("recent.backup.request.throttling.reject.count@{}", gpid);
+    _counter_recent_backup_request_throttling_reject_count.init_app_counter(
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
+
     counter_str = fmt::format("dup.disabled_non_idempotent_write_count@{}", _app_info.app_name);
     _counter_dup_disabled_non_idempotent_write_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -207,6 +207,9 @@ void replica::on_client_read(dsn::message_ex *request, bool ignore_throttling)
             return;
         }
     } else {
+        if (!throttle_backup_request(request)) {
+            return;
+        }
         _counter_backup_request_qps->increment();
     }
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -98,11 +98,11 @@ replica::replica(
     _counter_recent_read_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
-    counter_str = fmt::format("recent.backup.request.throttling.delay.count@{}", gpid);
+    counter_str = fmt::format("recent.backup.request.throttling.delay.count@{}", _app_info.app_name);
     _counter_recent_backup_request_throttling_delay_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
-    counter_str = fmt::format("recent.backup.request.throttling.reject.count@{}", gpid);
+    counter_str = fmt::format("recent.backup.request.throttling.reject.count@{}", _app_info.app_name);
     _counter_recent_backup_request_throttling_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -189,12 +189,12 @@ void replica::on_client_read(dsn::message_ex *request, bool ignore_throttling)
         return;
     }
 
-    if (!ignore_throttling && throttle_read_request(request)) {
-        return;
-    }
-
     if (!request->is_backup_request()) {
         // only backup request is allowed to read from a stale replica
+
+        if (!ignore_throttling && throttle_read_request(request)) {
+            return;
+        }
 
         if (status() != partition_status::PS_PRIMARY) {
             response_client_read(request, ERR_INVALID_STATE);
@@ -211,7 +211,7 @@ void replica::on_client_read(dsn::message_ex *request, bool ignore_throttling)
             return;
         }
     } else {
-        if (!throttle_backup_request(request)) {
+        if (!ignore_throttling && throttle_backup_request(request)) {
             return;
         }
         _counter_backup_request_qps->increment();

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -100,7 +100,7 @@ replica::replica(
 
     counter_str = fmt::format("recent.backup.request.throttling.delay.count@{}", gpid);
     _counter_recent_backup_request_throttling_delay_count.init_app_counter(
-            "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
     counter_str = fmt::format("recent.backup.request.throttling.reject.count@{}", gpid);
     _counter_recent_backup_request_throttling_reject_count.init_app_counter(

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -433,6 +433,7 @@ private:
     /// return true if request is throttled.
     bool throttle_write_request(message_ex *request);
     bool throttle_read_request(message_ex *request);
+    bool throttle_backup_request(message_ex *request);
     /// update throttling controllers
     /// \see replica::update_app_envs
     void update_throttle_envs(const std::map<std::string, std::string> &envs);
@@ -536,6 +537,8 @@ private:
     throttling_controller _write_qps_throttling_controller;  // throttling by requests-per-second
     throttling_controller _write_size_throttling_controller; // throttling by bytes-per-second
     throttling_controller _read_qps_throttling_controller;
+    throttling_controller _backup_request_qps_throttling_controller;
+    throttling_controller _backup_request_size_throttling_controller;
 
     // duplication
     std::unique_ptr<replica_duplicator_manager> _duplication_mgr;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -566,6 +566,7 @@ private:
     perf_counter_wrapper _counter_recent_write_throttling_reject_count;
     perf_counter_wrapper _counter_recent_read_throttling_delay_count;
     perf_counter_wrapper _counter_recent_read_throttling_reject_count;
+    perf_counter_wrapper _counter_recent_backup_request_throttling_reject_count;
     std::vector<perf_counter *> _counters_table_level_latency;
     perf_counter_wrapper _counter_dup_disabled_non_idempotent_write_count;
     perf_counter_wrapper _counter_backup_request_qps;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -538,7 +538,6 @@ private:
     throttling_controller _write_size_throttling_controller; // throttling by bytes-per-second
     throttling_controller _read_qps_throttling_controller;
     throttling_controller _backup_request_qps_throttling_controller;
-    throttling_controller _backup_request_size_throttling_controller;
 
     // duplication
     std::unique_ptr<replica_duplicator_manager> _duplication_mgr;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -566,6 +566,7 @@ private:
     perf_counter_wrapper _counter_recent_write_throttling_reject_count;
     perf_counter_wrapper _counter_recent_read_throttling_delay_count;
     perf_counter_wrapper _counter_recent_read_throttling_reject_count;
+    perf_counter_wrapper _counter_recent_backup_request_throttling_delay_count;
     perf_counter_wrapper _counter_recent_backup_request_throttling_reject_count;
     std::vector<perf_counter *> _counters_table_level_latency;
     perf_counter_wrapper _counter_dup_disabled_non_idempotent_write_count;

--- a/src/replica/replica_throttle.cpp
+++ b/src/replica/replica_throttle.cpp
@@ -37,7 +37,7 @@ namespace replication {
                 tasking::enqueue(                                                                  \
                     LPC_##op_type##_THROTTLING_DELAY,                                              \
                     &_tracker,                                                                     \
-                    [this, req = message_ptr(request)]() { on_client_##op_type(req, true); },      \
+                    [ this, req = message_ptr(request) ]() { on_client_##op_type(req, true); },      \
                     get_gpid().thread_hash(),                                                      \
                     std::chrono::milliseconds(delay_ms));                                          \
                 _counter_recent_##op_type##_throttling_delay_count->increment();                   \
@@ -45,7 +45,7 @@ namespace replication {
                 if (delay_ms > 0) {                                                                \
                     tasking::enqueue(LPC_##op_type##_THROTTLING_DELAY,                             \
                                      &_tracker,                                                    \
-                                     [this, req = message_ptr(request)]() {                        \
+                                     [ this, req = message_ptr(request) ]() {                        \
                                          response_client_##op_type(req, ERR_BUSY);                 \
                                      },                                                            \
                                      get_gpid().thread_hash(),                                     \
@@ -82,7 +82,7 @@ bool replica::throttle_read_request(message_ex *request)
                 tasking::enqueue(                                                                  \
                     LPC_read_THROTTLING_DELAY,                                                     \
                     &_tracker,                                                                     \
-                    [this, req = message_ptr(request)]() { on_client_read(req, true); },           \
+                    [ this, req = message_ptr(request) ]() { on_client_read(req, true); },           \
                     get_gpid().thread_hash(),                                                      \
                     std::chrono::milliseconds(delay_ms));                                          \
                 _counter_recent_backup_request_throttling_delay_count->increment();                \

--- a/src/replica/replica_throttle.cpp
+++ b/src/replica/replica_throttle.cpp
@@ -81,7 +81,7 @@ bool replica::throttle_backup_request(message_ex *request)
         if (type == throttling_controller::DELAY) {
             tasking::enqueue(LPC_read_THROTTLING_DELAY,
                              &_tracker,
-                             [this, req = message_ptr(request)]() { on_client_read(req, true); },
+                             [ this, req = message_ptr(request) ]() { on_client_read(req, true); },
                              get_gpid().thread_hash(),
                              std::chrono::milliseconds(delay_ms));
             _counter_recent_backup_request_throttling_delay_count->increment();

--- a/src/replica/replica_throttle.cpp
+++ b/src/replica/replica_throttle.cpp
@@ -78,12 +78,14 @@ bool replica::throttle_backup_request(message_ex *request)
     auto type = _backup_request_qps_throttling_controller.control(
         request->header->client.timeout_ms, 1, delay_ms);
     if (type != throttling_controller::PASS) {
+        _counter_recent_backup_request_throttling_reject_count->increment();
         return false;
     }
 
     type = _backup_request_size_throttling_controller.control(
         request->header->client.timeout_ms, request->body_size(), delay_ms);
     if (type != throttling_controller::PASS) {
+        _counter_recent_backup_request_throttling_reject_count->increment();
         return false;
     }
 

--- a/src/replica/replica_throttle.cpp
+++ b/src/replica/replica_throttle.cpp
@@ -37,7 +37,7 @@ namespace replication {
                 tasking::enqueue(                                                                  \
                     LPC_##op_type##_THROTTLING_DELAY,                                              \
                     &_tracker,                                                                     \
-                    [ this, req = message_ptr(request) ]() { on_client_##op_type(req, true); },      \
+                    [ this, req = message_ptr(request) ]() { on_client_##op_type(req, true); },    \
                     get_gpid().thread_hash(),                                                      \
                     std::chrono::milliseconds(delay_ms));                                          \
                 _counter_recent_##op_type##_throttling_delay_count->increment();                   \
@@ -45,7 +45,7 @@ namespace replication {
                 if (delay_ms > 0) {                                                                \
                     tasking::enqueue(LPC_##op_type##_THROTTLING_DELAY,                             \
                                      &_tracker,                                                    \
-                                     [ this, req = message_ptr(request) ]() {                        \
+                                     [ this, req = message_ptr(request) ]() {                      \
                                          response_client_##op_type(req, ERR_BUSY);                 \
                                      },                                                            \
                                      get_gpid().thread_hash(),                                     \
@@ -82,7 +82,7 @@ bool replica::throttle_read_request(message_ex *request)
                 tasking::enqueue(                                                                  \
                     LPC_read_THROTTLING_DELAY,                                                     \
                     &_tracker,                                                                     \
-                    [ this, req = message_ptr(request) ]() { on_client_read(req, true); },           \
+                    [ this, req = message_ptr(request) ]() { on_client_read(req, true); },         \
                     get_gpid().thread_hash(),                                                      \
                     std::chrono::milliseconds(delay_ms));                                          \
                 _counter_recent_backup_request_throttling_delay_count->increment();                \

--- a/src/replica/replica_throttle.cpp
+++ b/src/replica/replica_throttle.cpp
@@ -72,24 +72,32 @@ bool replica::throttle_read_request(message_ex *request)
     return false;
 }
 
+#define THROTTLE_BACKUP_REQUEST(throttling_type, request, request_units)                           \
+    do {                                                                                           \
+        int64_t delay_ms = 0;                                                                      \
+        auto type = _backup_request_##throttling_type##_throttling_controller.control(             \
+            request->header->client.timeout_ms, request_units, delay_ms);                          \
+        if (type != throttling_controller::PASS) {                                                 \
+            if (type == throttling_controller::DELAY) {                                            \
+                tasking::enqueue(                                                                  \
+                    LPC_read_THROTTLING_DELAY,                                                     \
+                    &_tracker,                                                                     \
+                    [this, req = message_ptr(request)]() { on_client_read(req, true); },           \
+                    get_gpid().thread_hash(),                                                      \
+                    std::chrono::milliseconds(delay_ms));                                          \
+                _counter_recent_backup_request_throttling_delay_count->increment();                \
+            } else { /** type == throttling_controller::REJECT **/                                 \
+                _counter_recent_backup_request_throttling_reject_count->increment();               \
+            }                                                                                      \
+            return true;                                                                           \
+        }                                                                                          \
+    } while (0)
+
 bool replica::throttle_backup_request(message_ex *request)
 {
-    int64_t delay_ms = 0;
-    auto type = _backup_request_qps_throttling_controller.control(
-        request->header->client.timeout_ms, 1, delay_ms);
-    if (type != throttling_controller::PASS) {
-        _counter_recent_backup_request_throttling_reject_count->increment();
-        return false;
-    }
-
-    type = _backup_request_size_throttling_controller.control(
-        request->header->client.timeout_ms, request->body_size(), delay_ms);
-    if (type != throttling_controller::PASS) {
-        _counter_recent_backup_request_throttling_reject_count->increment();
-        return false;
-    }
-
-    return true;
+    THROTTLE_BACKUP_REQUEST(qps, request, 1);
+    THROTTLE_BACKUP_REQUEST(size, request, request->body_size());
+    return false;
 }
 
 void replica::update_throttle_envs(const std::map<std::string, std::string> &envs)


### PR DESCRIPTION
Add rate limiter for backup request. Related issue: https://github.com/apache/incubator-pegasus/issues/778

### Manual Test
1. `set_app_envs replica.backup_request_throttling 1*delay*100`
2. send read request to server with backup request
3. log shows that the backup request is delayed: `./data/log/log.1.txt:11761:[replica*eon.replica*recent.backup.request.throttling.delay.count@temp, VOLATILE_NUMBER, 3.00]`
4.  `set_app_envs replica.backup_request_throttling 1*reject*100`
5. send read request to server with backup request
6. log shows that the backup request is rejected: `./replica1/data/log/log.1.txt:9890:[replica*eon.replica*recent.backup.request.throttling.reject.count@temp, VOLATILE_NUMBER, 1.00]`

All requests send by these tests can receive response successfully