### PR TITLE
fix(duplication): reset confirmed_decree to delete secondary private log after remove duplication

### DIFF
--- a/src/replica/duplication/replica_duplicator_manager.cpp
+++ b/src/replica/duplication/replica_duplicator_manager.cpp
@@ -127,11 +127,13 @@ void replica_duplicator_manager::update_confirmed_decree_if_secondary(decree con
 
     zauto_lock l(_lock);
     remove_all_duplications();
-    if (confirmed >= 0) {
+    if (confirmed >= 0) { // duplication ongoing
         // confirmed decree never decreases
         if (_primary_confirmed_decree < confirmed) {
             _primary_confirmed_decree = confirmed;
         }
+    } else { // duplication add with freeze but no start or no duplication(include removed)
+        _primary_confirmed_decree = confirmed;
     }
 }
 

--- a/src/replica/duplication/test/replica_duplicator_manager_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_manager_test.cpp
@@ -80,6 +80,10 @@ public:
         ASSERT_EQ(d._primary_confirmed_decree, 101);
         d.update_confirmed_decree_if_secondary(1);
         ASSERT_EQ(d._primary_confirmed_decree, 101);
+
+        // duplication removed and the confimed_decree = -1
+        d.update_confirmed_decree_if_secondary(-1);
+        ASSERT_EQ(d._primary_confirmed_decree, -1);
     }
 
     void test_get_duplication_confirms()

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -116,7 +116,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     //    dassert (err == ERR_OK, "");
     //    return err;
 
-    case partition_status::PS_INACTIVE: // only possible during init 
+    case partition_status::PS_INACTIVE: // only possible during init
         if (mu->data.header.last_committed_decree > max_decree()) {
             reset(mu->data.header.last_committed_decree);
         } else if (mu->data.header.last_committed_decree > _last_committed_decree) {

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -116,7 +116,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     //    dassert (err == ERR_OK, "");
     //    return err;
 
-    case partition_status::PS_INACTIVE: // only possible during init
+    case partition_status::PS_INACTIVE: // only possible during init 
         if (mu->data.header.last_committed_decree > max_decree()) {
             reset(mu->data.header.last_committed_decree);
         } else if (mu->data.header.last_committed_decree > _last_committed_decree) {

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -173,9 +173,8 @@ void replica::on_group_check(const group_check_request &request,
     } else if (is_same_ballot_status_change_allowed(status(), request.config.status)) {
         update_local_configuration(request.config, true);
     }
-    if (request.__isset.confirmed_decree) {
-        _duplication_mgr->update_confirmed_decree_if_secondary(request.confirmed_decree);
-    }
+
+    _duplication_mgr->update_confirmed_decree_if_secondary(request.confirmed_decree);
 
     switch (status()) {
     case partition_status::PS_INACTIVE:


### PR DESCRIPTION
See https://github.com/apache/incubator-pegasus/issues/783, this pr reset confirmed_decree of secondary after duplication is removed