### PR TITLE
fix(duplication): force wait confirmed_decree sync complete when start duplication

### DIFF
--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -70,9 +70,12 @@ void load_from_private_log::run()
     dassert_replica(_start_decree != invalid_decree, "{}", _start_decree);
     _duplicator->verify_start_decree(_start_decree);
 
+    // last_decree() == invalid_decree is the init status of mutation_buffer when create _mutation_batch, which means
+    // the duplication sync hasn't been completed, so need wait sync complete and the confirmed_decree
+    // != invalid_decree, and then reset mutation_buffer to valid status
     if (_mutation_batch.last_decree() == invalid_decree) {
         if (_duplicator->progress().confirmed_decree == invalid_decree) {
-            dwarn_replica("duplication status hasn't sync completed, try next for delay 1s, "
+            dwarn_replica("duplication status hasn't been sync completed, try next for delay 1s, "
                           "last_commit_decree={}, "
                           "confirmed_decree={}",
                           _duplicator->progress().last_decree,

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -70,9 +70,10 @@ void load_from_private_log::run()
     dassert_replica(_start_decree != invalid_decree, "{}", _start_decree);
     _duplicator->verify_start_decree(_start_decree);
 
-    // last_decree() == invalid_decree is the init status of mutation_buffer when create _mutation_batch, which means
-    // the duplication sync hasn't been completed, so need wait sync complete and the confirmed_decree
-    // != invalid_decree, and then reset mutation_buffer to valid status
+    // last_decree() == invalid_decree is the init status of mutation_buffer when create
+    // _mutation_batch, which means the duplication sync hasn't been completed, so need wait sync
+    // complete and the  confirmed_decree  != invalid_decree, and then reset mutation_buffer to
+    // valid status
     if (_mutation_batch.last_decree() == invalid_decree) {
         if (_duplicator->progress().confirmed_decree == invalid_decree) {
             dwarn_replica("duplication status hasn't been sync completed, try next for delay 1s, "

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -59,6 +59,8 @@ decree mutation_batch::last_decree() const { return _mutation_buffer->last_commi
 
 void mutation_batch::set_start_decree(decree d) { _start_decree = d; }
 
+void mutation_batch::reset_mutation_buffer(decree d) { _mutation_buffer->reset(d); }
+
 mutation_tuple_set mutation_batch::move_all_mutations()
 {
     // free the internal space

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -45,6 +45,8 @@ public:
     // mutations with decree < d will be ignored.
     void set_start_decree(decree d);
 
+    void reset_mutation_buffer(decree d);
+
     size_t size() const { return _loaded_mutations.size(); }
 
 private:

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -103,58 +103,58 @@ public:
 
     void test_start_duplication(int num_entries, int private_log_size_mb)
     {
-        std::vector<std::string> mutations;
         mutation_log_ptr mlog = create_private_log(private_log_size_mb, _replica->get_gpid());
 
+        int last_commit_decree_start = 5;
+        int decree_start = 10;
         {
-            int last_commit_decree_start = 5;
-            int current_decree_start = 10;
-            for (int i = 1; i <= num_entries; i++) {
+            for (int i = decree_start; i <= num_entries + decree_start; i++) {
                 std::string msg = "hello!";
-                mutations.push_back(msg);
-                mutation_ptr mu = create_test_mutation(
-                    i + current_decree_start, msg); //  decree - last_commit_decree  = 1 by default
+                //  decree - last_commit_decree  = 1 by default
+                mutation_ptr mu = create_test_mutation(i, msg);
                 // mock the last_commit_decree of first mu equal with `last_commit_decree_start` and
                 // decree - last_commit_decree  = 1
-                if (i == 0) {
+                if (i == decree_start) {
                     mu->data.header.last_committed_decree = last_commit_decree_start;
                 }
                 mlog->append(mu, LPC_AIO_IMMEDIATE_CALLBACK, nullptr, nullptr, 0);
             }
 
             // commit the last entry
-            mutation_ptr mu = create_test_mutation(1 + num_entries, "hello!");
+            mutation_ptr mu = create_test_mutation(decree_start + num_entries + 1, "hello!");
             mlog->append(mu, LPC_AIO_IMMEDIATE_CALLBACK, nullptr, nullptr, 0);
 
             mlog->close();
         }
 
-        load_and_wait_all_entries_loaded(num_entries, num_entries, 1);
+        load_and_wait_all_entries_loaded(num_entries, num_entries, decree_start);
     }
 
     mutation_tuple_set
     load_and_wait_all_entries_loaded(int total, int last_decree, decree start_decree)
     {
         return load_and_wait_all_entries_loaded(
-            total, last_decree, _replica->get_gpid(), start_decree);
+            total, last_decree, _replica->get_gpid(), start_decree, -1);
     }
+
     mutation_tuple_set load_and_wait_all_entries_loaded(int total, int last_decree)
     {
-        return load_and_wait_all_entries_loaded(total, last_decree, _replica->get_gpid(), 1);
+        return load_and_wait_all_entries_loaded(total, last_decree, _replica->get_gpid(), 0, -1);
     }
-    mutation_tuple_set
-    load_and_wait_all_entries_loaded(int total, int last_decree, gpid id, decree start_decree)
+
+    mutation_tuple_set load_and_wait_all_entries_loaded(
+        int total, int last_decree, gpid id, decree start_decree, decree confirmed_decree)
     {
         mutation_log_ptr mlog = create_private_log(id);
         for (const auto &pr : mlog->get_log_file_map()) {
             EXPECT_TRUE(pr.second->file_handle() == nullptr);
         }
         _replica->init_private_log(mlog);
-        duplicator = create_test_duplicator(start_decree - 1);
+        duplicator = create_test_duplicator(confirmed_decree);
 
         load_from_private_log load(_replica.get(), duplicator.get());
         const_cast<std::chrono::milliseconds &>(load._repeat_delay) = 1_s;
-        load.set_start_decree(duplicator->progress().last_decree + 1);
+        load.set_start_decree(start_decree);
 
         mutation_tuple_set loaded_mutations;
         pipeline::do_when<decree, mutation_tuple_set> end_stage(
@@ -177,6 +177,7 @@ public:
         fail::setup();
         fail::cfg("open_read", "25%1*return()");
         fail::cfg("mutation_log_read_log_block", "25%1*return()");
+        fail::cfg("duplication_sync_complete", "off()");
         duplicator->run_pipeline();
         duplicator->wait_all();
         fail::teardown();
@@ -289,7 +290,7 @@ TEST_F(load_from_private_log_test, handle_real_private_log)
         _replica = create_mock_replica(
             stub.get(), tt.id.get_app_id(), tt.id.get_partition_index(), _log_dir.c_str());
 
-        load_and_wait_all_entries_loaded(tt.puts, tt.total, tt.id, 1);
+        load_and_wait_all_entries_loaded(tt.puts, tt.total, tt.id, 1, 0);
     }
 }
 
@@ -314,18 +315,19 @@ TEST_F(load_from_private_log_test, ignore_useless)
     mlog->close();
 
     // starts from 51
-    mutation_tuple_set result = load_and_wait_all_entries_loaded(50, 100, 51);
+    mutation_tuple_set result =
+        load_and_wait_all_entries_loaded(50, 100, _replica->get_gpid(), 51, 0);
     ASSERT_EQ(result.size(), 50);
 
     // starts from 100
-    result = load_and_wait_all_entries_loaded(1, 100, 100);
+    result = load_and_wait_all_entries_loaded(1, 100, _replica->get_gpid(), 100, 0);
     ASSERT_EQ(result.size(), 1);
 
     // a new duplication's confirmed_decree is invalid_decree,
     // so start_decree is 0.
-    // In this case duplication will starts from last_commit(100),
+    // In this case duplication will starts from last_commit(100) + 1,
     // no mutation will be loaded.
-    result = load_and_wait_all_entries_loaded(0, 100, 0);
+    result = load_and_wait_all_entries_loaded(0, 100, _replica->get_gpid(), 101, -1);
     ASSERT_EQ(result.size(), 0);
 }
 

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -107,10 +107,18 @@ public:
         mutation_log_ptr mlog = create_private_log(private_log_size_mb, _replica->get_gpid());
 
         {
+            int last_commit_decree_start = 5;
+            int current_decree_start = 10;
             for (int i = 1; i <= num_entries; i++) {
                 std::string msg = "hello!";
                 mutations.push_back(msg);
-                mutation_ptr mu = create_test_mutation(i, msg);
+                mutation_ptr mu = create_test_mutation(
+                    i + current_decree_start, msg); //  decree - last_commit_decree  = 1 by default
+                // mock the last_commit_decree of first mu equal with `last_commit_decree_start` and
+                // decree - last_commit_decree  = 1
+                if (i == 0) {
+                    mu->data.header.last_committed_decree = last_commit_decree_start;
+                }
                 mlog->append(mu, LPC_AIO_IMMEDIATE_CALLBACK, nullptr, nullptr, 0);
             }
 

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -112,8 +112,7 @@ public:
                 std::string msg = "hello!";
                 //  decree - last_commit_decree  = 1 by default
                 mutation_ptr mu = create_test_mutation(i, msg);
-                // mock the last_commit_decree of first mu equal with `last_commit_decree_start` and
-                // decree - last_commit_decree  = 1
+                // mock the last_commit_decree of first mu equal with `last_commit_decree_start`
                 if (i == decree_start) {
                     mu->data.header.last_committed_decree = last_commit_decree_start;
                 }


### PR DESCRIPTION
See https://github.com/apache/incubator-pegasus/issues/784, this PR add wait logic berfore `replay log` of duplication 