### PR TITLE
feat(duplication): derror and add perf-counter if mutation loss instead of dassert for duplication

### DIFF
--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -134,20 +134,7 @@ void load_from_private_log::replay_log_block()
     error_s err = mutation_log::replay_block(
         _current,
         [this](int log_bytes_length, mutation_ptr &mu) -> bool {
-            derror_f("jiashuo_debug_add_before=={}: last_commit_decree = {}, min.max={}|{} ||||| "
-                     "mu_last_commit_decree={}[{}]",
-                     replica_name(),
-                     _mutation_batch.last_decree(),
-                     _mutation_batch._mutation_buffer->min_decree(),
-                     _mutation_batch._mutation_buffer->max_decree(),
-                     mu->data.header.last_committed_decree,
-                     mu->data.header.decree);
             auto es = _mutation_batch.add(std::move(mu));
-            derror_f("jiashuo_debug_add_after=={}: last_commit_decree = {}, min.max={}|{}",
-                     replica_name(),
-                     _mutation_batch.last_decree(),
-                     _mutation_batch._mutation_buffer->min_decree(),
-                     _mutation_batch._mutation_buffer->max_decree());
             dassert_replica(es.is_ok(), es.description());
             _counter_dup_log_read_bytes_rate->add(log_bytes_length);
             _counter_dup_log_read_mutations_rate->increment();

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -131,17 +131,17 @@ void load_from_private_log::find_log_file_to_start(std::map<int, log_file_ptr> l
 
 void load_from_private_log::replay_log_block()
 {
-    error_s err = mutation_log::replay_block(
-        _current,
-        [this](int log_bytes_length, mutation_ptr &mu) -> bool {
-            auto es = _mutation_batch.add(std::move(mu));
-            dassert_replica(es.is_ok(), es.description());
-            _counter_dup_log_read_bytes_rate->add(log_bytes_length);
-            _counter_dup_log_read_mutations_rate->increment();
-            return true;
-        },
-        _start_offset,
-        _current_global_end_offset);
+    error_s err =
+        mutation_log::replay_block(_current,
+                                   [this](int log_bytes_length, mutation_ptr &mu) -> bool {
+                                       auto es = _mutation_batch.add(std::move(mu));
+                                       dassert_replica(es.is_ok(), es.description());
+                                       _counter_dup_log_read_bytes_rate->add(log_bytes_length);
+                                       _counter_dup_log_read_mutations_rate->increment();
+                                       return true;
+                                   },
+                                   _start_offset,
+                                   _current_global_end_offset);
     if (!err.is_ok()) {
         if (err.code() == ERR_HANDLE_EOF && switch_to_next_log_file()) {
             repeat();

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -131,17 +131,30 @@ void load_from_private_log::find_log_file_to_start(std::map<int, log_file_ptr> l
 
 void load_from_private_log::replay_log_block()
 {
-    error_s err =
-        mutation_log::replay_block(_current,
-                                   [this](int log_bytes_length, mutation_ptr &mu) -> bool {
-                                       auto es = _mutation_batch.add(std::move(mu));
-                                       dassert_replica(es.is_ok(), es.description());
-                                       _counter_dup_log_read_bytes_rate->add(log_bytes_length);
-                                       _counter_dup_log_read_mutations_rate->increment();
-                                       return true;
-                                   },
-                                   _start_offset,
-                                   _current_global_end_offset);
+    error_s err = mutation_log::replay_block(
+        _current,
+        [this](int log_bytes_length, mutation_ptr &mu) -> bool {
+            derror_f("jiashuo_debug_add_before=={}: last_commit_decree = {}, min.max={}|{} ||||| "
+                     "mu_last_commit_decree={}[{}]",
+                     replica_name(),
+                     _mutation_batch.last_decree(),
+                     _mutation_batch._mutation_buffer->min_decree(),
+                     _mutation_batch._mutation_buffer->max_decree(),
+                     mu->data.header.last_committed_decree,
+                     mu->data.header.decree);
+            auto es = _mutation_batch.add(std::move(mu));
+            derror_f("jiashuo_debug_add_after=={}: last_commit_decree = {}, min.max={}|{}",
+                     replica_name(),
+                     _mutation_batch.last_decree(),
+                     _mutation_batch._mutation_buffer->min_decree(),
+                     _mutation_batch._mutation_buffer->max_decree());
+            dassert_replica(es.is_ok(), es.description());
+            _counter_dup_log_read_bytes_rate->add(log_bytes_length);
+            _counter_dup_log_read_mutations_rate->increment();
+            return true;
+        },
+        _start_offset,
+        _current_global_end_offset);
     if (!err.is_ok()) {
         if (err.code() == ERR_HANDLE_EOF && switch_to_next_log_file()) {
             repeat();

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -50,11 +50,10 @@ void mutation_buffer::commit(decree d, commit_type ct)
     for (decree d0 = last_committed_decree() + 1; d0 <= d; d0++) {
         mutation_ptr next_commit_mutation = get_mutation_by_decree(d0);
         if (next_commit_mutation == nullptr || !next_commit_mutation->is_logged()) {
-            derror_replica("mutation[decree={}, last_commit_decree={}] is lost: "
+            derror_replica("mutation[{}] is lost: "
                            "prepare_last_commit_decree={}, prepare_min_decree={}, "
                            "prepare_max_decree={}",
-                           next_commit_mutation->data.header.last_committed_decree,
-                           next_commit_mutation->data.header.decree,
+                           d, 
                            last_committed_decree(),
                            min_decree(),
                            max_decree());

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -49,7 +49,7 @@ void mutation_buffer::commit(decree d, commit_type ct)
     ballot last_bt = 0;
     for (decree d0 = last_committed_decree() + 1; d0 <= d; d0++) {
         mutation_ptr next_commit_mutation = get_mutation_by_decree(d0);
-        // The unexpected case as follow:
+        // The unexpected case as follow: next_commit_decree is out of [start~end]
         //
         // last_commit_decree - next_commit_decree
         //                         |                                       |

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -53,11 +53,11 @@ void mutation_buffer::commit(decree d, commit_type ct)
             derror_replica("mutation[{}] is lost: "
                            "prepare_last_commit_decree={}, prepare_min_decree={}, "
                            "prepare_max_decree={}",
-                           d, 
+                           d0, 
                            last_committed_decree(),
                            min_decree(),
                            max_decree());
-            _counter_dulication_mutation_loss_count->set(min_decree() - _last_committed_decree);
+            _counter_dulication_mutation_loss_count->set(min_decree() - last_committed_decree());
             _last_committed_decree = min_decree() - 1;
             return;
         }

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -32,7 +32,7 @@ mutation_buffer::mutation_buffer(replica_base *r,
                                  mutation_committer committer)
     : prepare_list(r, init_decree, max_count, committer)
 {
-    auto counter_str = fmt::format("recent.duplication.mutation.loss.count@{}", r->get_gpid());
+    auto counter_str = fmt::format("dup_recent_mutation_loss_count@{}", r->get_gpid());
     _counter_dulication_mutation_loss_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 }

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -53,7 +53,7 @@ void mutation_buffer::commit(decree d, commit_type ct)
             derror_replica("mutation[{}] is lost: "
                            "prepare_last_commit_decree={}, prepare_min_decree={}, "
                            "prepare_max_decree={}",
-                           d0, 
+                           d0,
                            last_committed_decree(),
                            min_decree(),
                            max_decree());

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -43,7 +43,7 @@ void mutation_buffer::commit(decree d, commit_type ct)
         return;
 
     if (ct != COMMIT_TO_DECREE_HARD) {
-        dassert_replica(false, "invalid commit type %d", (int)ct);
+        dassert_replica(false, "invalid commit type {}", (int)ct);
     }
 
     ballot last_bt = 0;

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -32,6 +32,9 @@ mutation_buffer::mutation_buffer(replica_base *r,
                                  mutation_committer committer)
     : prepare_list(r, init_decree, max_count, committer)
 {
+    auto counter_str = fmt::format("recent.duplication.mutation.loss.count@{}", r->get_gpid());
+    _counter_dulication_mutation_loss_count.init_app_counter(
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 }
 
 void mutation_buffer::commit(decree d, commit_type ct)
@@ -55,7 +58,8 @@ void mutation_buffer::commit(decree d, commit_type ct)
                            last_committed_decree(),
                            min_decree(),
                            max_decree());
-            _last_committed_decree = d - 1;
+            _counter_dulication_mutation_loss_count->set(min_decree() - _last_committed_decree);
+            _last_committed_decree = min_decree() - 1;
             return;
         }
 

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <dsn/dist/replication/mutation_duplicator.h>
 #include <dsn/dist/replication/replica_base.h>
 
@@ -38,6 +39,9 @@ public:
                     mutation_committer committer);
 
     void commit(decree d, commit_type ct);
+
+private:
+    perf_counter_wrapper _counter_dulication_mutation_loss_count;
 };
 
 // A sorted array of committed mutations that are ready for duplication.
@@ -63,7 +67,7 @@ public:
 private:
     friend class replica_duplicator_test;
 
-    std::unique_ptr<mutation_buffer> _mutation_buffer;
+    std::unique_ptr<prepare_list> _mutation_buffer;
     mutation_tuple_set _loaded_mutations;
     decree _start_decree{invalid_decree};
 };

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -64,10 +64,12 @@ public:
 
     size_t size() const { return _loaded_mutations.size(); }
 
+     std::unique_ptr<prepare_list> _mutation_buffer;
+
 private:
     friend class replica_duplicator_test;
 
-    std::unique_ptr<prepare_list> _mutation_buffer;
+    
     mutation_tuple_set _loaded_mutations;
     decree _start_decree{invalid_decree};
 };

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -63,6 +63,7 @@ public:
 
 private:
     friend class replica_duplicator_test;
+    friend class mutation_batch_test;
 
     std::unique_ptr<prepare_list> _mutation_buffer;
     mutation_tuple_set _loaded_mutations;

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -18,14 +18,27 @@
 #pragma once
 
 #include <dsn/dist/replication/mutation_duplicator.h>
+#include <dsn/dist/replication/replica_base.h>
 
 #include "replica/mutation.h"
-
+#include "replica/prepare_list.h"
 namespace dsn {
 namespace replication {
 
 class replica_duplicator;
 class prepare_list;
+class replica_base;
+
+class mutation_buffer : public prepare_list
+{
+public:
+    mutation_buffer(replica_base *r,
+                    decree init_decree,
+                    int max_count,
+                    mutation_committer committer);
+
+    void commit(decree d, commit_type ct);
+};
 
 // A sorted array of committed mutations that are ready for duplication.
 // Not thread-safe.
@@ -50,7 +63,7 @@ public:
 private:
     friend class replica_duplicator_test;
 
-    std::unique_ptr<prepare_list> _mutation_buffer;
+    std::unique_ptr<mutation_buffer> _mutation_buffer;
     mutation_tuple_set _loaded_mutations;
     decree _start_decree{invalid_decree};
 };

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -19,7 +19,6 @@
 
 #include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <dsn/dist/replication/mutation_duplicator.h>
-#include <dsn/dist/replication/replica_base.h>
 
 #include "replica/mutation.h"
 #include "replica/prepare_list.h"
@@ -27,8 +26,6 @@ namespace dsn {
 namespace replication {
 
 class replica_duplicator;
-class prepare_list;
-class replica_base;
 
 class mutation_buffer : public prepare_list
 {

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -64,12 +64,10 @@ public:
 
     size_t size() const { return _loaded_mutations.size(); }
 
-     std::unique_ptr<prepare_list> _mutation_buffer;
-
 private:
     friend class replica_duplicator_test;
 
-    
+    std::unique_ptr<prepare_list> _mutation_buffer;
     mutation_tuple_set _loaded_mutations;
     decree _start_decree{invalid_decree};
 };

--- a/src/replica/mutation_cache.h
+++ b/src/replica/mutation_cache.h
@@ -57,6 +57,8 @@ public:
     int capacity() const { return _max_count; }
 
 private:
+    friend class mutation_batch_test;
+
     std::vector<mutation_ptr> _array;
     int _max_count;
 

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -68,7 +68,9 @@ public:
     error_code prepare(mutation_ptr &mu,
                        partition_status::type status,
                        bool pop_all_committed_mutations = false); // unordered prepare
-    void commit(decree decree, commit_type ct);                   // ordered commit
+    virtual void commit(decree decree, commit_type ct);           // ordered commit
+
+    virtual ~prepare_list() = default;
 
 private:
     friend class mutation_buffer;

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -71,6 +71,7 @@ public:
     void commit(decree decree, commit_type ct);                   // ordered commit
 
 private:
+    friend class mutation_buffer;
     decree _last_committed_decree;
     mutation_committer _committer;
 };


### PR DESCRIPTION
## Description
In https://github.com/apache/incubator-pegasus/issues/766, we have list many problems related to `mutatiaon loss`:
- [x] XiaoMi/rdsn#838
- [x] XiaoMi/rdsn#845
- [x] XiaoMi/rdsn#860
- [x] XiaoMi/rdsn#861

Whose crush point is the code:
https://github.com/XiaoMi/rdsn/blob/e31d49ca6d98dba7b83b272cae0346edf6026337/src/replica/prepare_list.cpp#L154-L156

This is implementation of prepare_list in `2pc`, which can make sure the request is valid, otherwise, it will crush and need manual intervention.

Since the `crash` has serious impaction for service and it still cause the `duplication failed and mutation loss`, **the `dassert to crash` may be not necessary for `duplication`.**

This PR re-implement the `commit funtion` for `prepare_list` in duplication, which replace `dassert` to `derror`and add `perf-counter`, like:
```diff
- dassert_replica(mu != nullptr && mu->is_logged(), "mutation {} is missing in prepare list", d0);
+ derror_replica..
+ counter_dulication_mutation_loss_count...
```
which still warning user that the duplication failed with mutation loss, user can choose restart or ignore this loss.

`duplication` feature is still unstable, this pr can avoid the follow service crash if has some other problem

## Perf-counter

```diff
+ (todo) support collector
+ replica*eon.replica*dup_recent_mutation_loss_count@{gpid}
```