### PR TITLE
feat: throw exception if reads corrupt data

### DIFF
--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -57,6 +57,10 @@ public:
         }
     }
 
+    int read(char *buffer, int sz) { return internal_read(buffer, sz); }
+
+    int read(blob &blob, int len) { return internal_read(blob, len); }
+
     ~rpc_read_stream()
     {
         if (_msg) {

--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -57,9 +57,9 @@ public:
         }
     }
 
-    int read(char *buffer, int sz) { return internal_read(buffer, sz); }
+    int read(char *buffer, int sz) { return inner_read(buffer, sz); }
 
-    int read(blob &blob, int len) { return internal_read(blob, len); }
+    int read(blob &blob, int len) { return inner_read(blob, len); }
 
     ~rpc_read_stream()
     {

--- a/include/dsn/cpp/serialization_helper/thrift_helper.h
+++ b/include/dsn/cpp/serialization_helper/thrift_helper.h
@@ -64,13 +64,9 @@ public:
     uint32_t read(uint8_t *buf, uint32_t len)
     {
         int l = _reader.read((char *)buf, static_cast<int>(len));
-        if (dsn_unlikely(l == 0)) {
+        if (dsn_unlikely(l <= 0)) {
             throw TTransportException(TTransportException::END_OF_FILE,
                                       "no more data to read after end-of-buffer");
-        }
-        if (dsn_unlikely(l < 0)) {
-            throw TTransportException(TTransportException::CORRUPTED_DATA,
-                                      "the data to read is corrupted");
         }
         return (uint32_t)l;
     }

--- a/include/dsn/cpp/serialization_helper/thrift_helper.h
+++ b/include/dsn/cpp/serialization_helper/thrift_helper.h
@@ -64,9 +64,13 @@ public:
     uint32_t read(uint8_t *buf, uint32_t len)
     {
         int l = _reader.read((char *)buf, static_cast<int>(len));
-        if (l == 0) {
+        if (dsn_unlikely(l == 0)) {
             throw TTransportException(TTransportException::END_OF_FILE,
                                       "no more data to read after end-of-buffer");
+        }
+        if (dsn_unlikely(l < 0)) {
+            throw TTransportException(TTransportException::CORRUPTED_DATA,
+                                      "the data to read is corrupted");
         }
         return (uint32_t)l;
     }
@@ -712,4 +716,4 @@ inline void unmarshall_thrift_json(binary_reader &reader, T &val)
     ::apache::thrift::protocol::TJSONProtocol proto(transport);
     unmarshall_thrift_internal(val, &proto);
 }
-}
+} // namespace dsn

--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -50,8 +50,8 @@ public:
     int get_remaining_size() const { return _remaining_size; }
 
 protected:
-    int internal_read(blob &blob, int len);
-    int internal_read(char *buffer, int sz);
+    int inner_read(blob &blob, int len);
+    int inner_read(char *buffer, int sz);
 
     blob _blob;
     int _size;

--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -39,9 +39,9 @@ public:
     int read(/*out*/ bool &val) { return read_pod(val); }
 
     int read(/*out*/ std::string &s);
-    int read(char *buffer, int sz);
+    virtual int read(char *buffer, int sz);
     int read(blob &blob);
-    int read(blob &blob, int len);
+    virtual int read(blob &blob, int len);
 
     blob get_buffer() const { return _blob; }
     blob get_remaining_buffer() const { return _blob.range(static_cast<int>(_ptr - _blob.data())); }
@@ -49,7 +49,10 @@ public:
     int total_size() const { return _size; }
     int get_remaining_size() const { return _remaining_size; }
 
-private:
+protected:
+    int internal_read(blob &blob, int len);
+    int internal_read(char *buffer, int sz);
+
     blob _blob;
     int _size;
     const char *_ptr;
@@ -70,4 +73,4 @@ inline int binary_reader::read_pod(/*out*/ T &val)
         return 0;
     }
 }
-}
+} // namespace dsn

--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -54,12 +54,12 @@ protected:
     int inner_read(blob &blob, int len);
     int inner_read(char *buffer, int sz);
 
+private:
     blob _blob;
     int _size;
     const char *_ptr;
     int _remaining_size;
 
-private:
     FRIEND_TEST(binary_reader_test, inner_read);
 };
 

--- a/include/dsn/utility/binary_reader.h
+++ b/include/dsn/utility/binary_reader.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <dsn/utility/blob.h>
+#include <gtest/gtest_prod.h>
 
 namespace dsn {
 class binary_reader
@@ -57,6 +58,9 @@ protected:
     int _size;
     const char *_ptr;
     int _remaining_size;
+
+private:
+    FRIEND_TEST(binary_reader_test, inner_read);
 };
 
 template <typename T>

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -77,10 +77,10 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
 
     task_spec *spec = task_spec::get(request->rpc_code());
     if (dsn_unlikely(nullptr == spec || request->rpc_code() == TASK_CODE_INVALID)) {
-        dwarn_f("recv message with unhandled rpc name {} from {}, trace_id = {}",
-                request->rpc_code().to_string(),
-                request->header->from_address.to_string(),
-                request->header->trace_id);
+        derror_f("recv message with unhandled rpc name {} from {}, trace_id = {}",
+                 request->rpc_code().to_string(),
+                 request->header->from_address.to_string(),
+                 request->header->trace_id);
         response_client_write(request, ERR_HANDLER_NOT_FOUND);
         return;
     }

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -76,6 +76,13 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
     }
 
     task_spec *spec = task_spec::get(request->rpc_code());
+    if (nullptr == spec) {
+        ddebug_f("request received from {} has invalid rpc code",
+                 request->header->from_address.to_string());
+        response_client_write(request, ERR_INVALID_DATA);
+        return;
+    }
+
     if (is_duplicating() && !spec->rpc_request_is_write_idempotent) {
         // Ignore non-idempotent write, because duplication provides no guarantee of atomicity to
         // make this write produce the same result on multiple clusters.

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -76,7 +76,7 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
     }
 
     task_spec *spec = task_spec::get(request->rpc_code());
-    if (nullptr == spec) {
+    if (dsn_unlikely(nullptr == spec || request->rpc_code() == TASK_CODE_INVALID)) {
         dwarn_f("recv message with unhandled rpc name {} from {}, trace_id = {}",
                 request->rpc_code().to_string(),
                 request->header->from_address.to_string(),

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -77,9 +77,11 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
 
     task_spec *spec = task_spec::get(request->rpc_code());
     if (nullptr == spec) {
-        ddebug_f("request received from {} has invalid rpc code",
-                 request->header->from_address.to_string());
-        response_client_write(request, ERR_INVALID_DATA);
+        dwarn_f("recv message with unhandled rpc name {} from {}, trace_id = {}",
+                request->rpc_code().to_string(),
+                request->header->from_address.to_string(),
+                request->header->trace_id);
+        response_client_write(request, ERR_HANDLER_NOT_FOUND);
         return;
     }
 

--- a/src/utils/binary_reader.cpp
+++ b/src/utils/binary_reader.cpp
@@ -50,7 +50,7 @@ int binary_reader::read(blob &blob)
 
 int binary_reader::read(blob &blob, int len)
 {
-    auto res = internal_read(blob, len);
+    auto res = inner_read(blob, len);
     if (dsn_unlikely(res < 0)) {
         assert(false);
     }
@@ -59,14 +59,14 @@ int binary_reader::read(blob &blob, int len)
 
 int binary_reader::read(char *buffer, int sz)
 {
-    auto res = internal_read(buffer, sz);
+    auto res = inner_read(buffer, sz);
     if (dsn_unlikely(res < 0)) {
         assert(false);
     }
     return res;
 }
 
-int binary_reader::internal_read(blob &blob, int len)
+int binary_reader::inner_read(blob &blob, int len)
 {
     if (len <= get_remaining_size()) {
         blob = _blob.range(static_cast<int>(_ptr - _blob.data()), len);
@@ -86,7 +86,7 @@ int binary_reader::internal_read(blob &blob, int len)
     }
 }
 
-int binary_reader::internal_read(char *buffer, int sz)
+int binary_reader::inner_read(char *buffer, int sz)
 {
     if (sz <= get_remaining_size()) {
         memcpy((void *)buffer, _ptr, sz);

--- a/src/utils/binary_reader.cpp
+++ b/src/utils/binary_reader.cpp
@@ -50,6 +50,24 @@ int binary_reader::read(blob &blob)
 
 int binary_reader::read(blob &blob, int len)
 {
+    auto res = internal_read(blob, len);
+    if (dsn_unlikely(res < 0)) {
+        assert(false);
+    }
+    return res;
+}
+
+int binary_reader::read(char *buffer, int sz)
+{
+    auto res = internal_read(buffer, sz);
+    if (dsn_unlikely(res < 0)) {
+        assert(false);
+    }
+    return res;
+}
+
+int binary_reader::internal_read(blob &blob, int len)
+{
     if (len <= get_remaining_size()) {
         blob = _blob.range(static_cast<int>(_ptr - _blob.data()), len);
 
@@ -64,12 +82,11 @@ int binary_reader::read(blob &blob, int len)
         _remaining_size -= len;
         return len + sizeof(len);
     } else {
-        assert(false);
-        return 0;
+        return -1;
     }
 }
 
-int binary_reader::read(char *buffer, int sz)
+int binary_reader::internal_read(char *buffer, int sz)
 {
     if (sz <= get_remaining_size()) {
         memcpy((void *)buffer, _ptr, sz);
@@ -77,9 +94,7 @@ int binary_reader::read(char *buffer, int sz)
         _remaining_size -= sz;
         return sz;
     } else {
-        assert(false);
         return 0;
     }
 }
-
 } // namespace dsn

--- a/src/utils/binary_reader.cpp
+++ b/src/utils/binary_reader.cpp
@@ -94,7 +94,7 @@ int binary_reader::internal_read(char *buffer, int sz)
         _remaining_size -= sz;
         return sz;
     } else {
-        return 0;
+        return -1;
     }
 }
 } // namespace dsn

--- a/src/utils/test/binary_reader_test.cpp
+++ b/src/utils/test/binary_reader_test.cpp
@@ -50,7 +50,6 @@ TEST(binary_reader_test, inner_read)
         blob input = blob::create_from_bytes(std::string("test10086"));
         binary_reader reader(input);
 
-        blob output;
         int size = 4;
         char *output_str = new char[size + 1];
         auto cleanup = dsn::defer([&output_str]() { delete[] output_str; });
@@ -64,7 +63,6 @@ TEST(binary_reader_test, inner_read)
         blob input = blob::create_from_bytes(std::string("test10086"));
         binary_reader reader(input);
 
-        blob output;
         int size = 10;
         char *output_str = new char[size];
         auto cleanup = dsn::defer([&output_str]() { delete[] output_str; });

--- a/src/utils/test/binary_reader_test.cpp
+++ b/src/utils/test/binary_reader_test.cpp
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <dsn/utility/binary_reader.h>
+#include <gtest/gtest.h>
+#include <dsn/utility/defer.h>
+
+namespace dsn {
+
+TEST(binary_reader_test, inner_read)
+{
+
+    {
+        blob input = blob::create_from_bytes(std::string("test10086"));
+        binary_reader reader(input);
+
+        blob output;
+        int size = 4;
+        auto res = reader.inner_read(output, size);
+        ASSERT_EQ(res, size + sizeof(size));
+        ASSERT_EQ(output.to_string(), "test");
+    }
+
+    {
+        blob input = blob::create_from_bytes(std::string("test10086"));
+        binary_reader reader(input);
+
+        blob output;
+        int size = 10;
+        auto res = reader.inner_read(output, size);
+        ASSERT_EQ(res, -1);
+    }
+
+    {
+
+        blob input = blob::create_from_bytes(std::string("test10086"));
+        binary_reader reader(input);
+
+        blob output;
+        int size = 4;
+        char *output_str = new char[size + 1];
+        auto cleanup = dsn::defer([&output_str]() { delete[] output_str; });
+        auto res = reader.inner_read(output_str, size);
+        output_str[size] = '\0';
+        ASSERT_EQ(res, size);
+        ASSERT_EQ(std::string(output_str), "test");
+    }
+
+    {
+        blob input = blob::create_from_bytes(std::string("test10086"));
+        binary_reader reader(input);
+
+        blob output;
+        int size = 10;
+        char *output_str = new char[size];
+        auto cleanup = dsn::defer([&output_str]() { delete[] output_str; });
+        auto res = reader.inner_read(output_str, size);
+        ASSERT_EQ(res, -1);
+    }
+}
+} // namespace dsn


### PR DESCRIPTION
In previous implementation, server will coredump if it reads corrupt data. 
In this pull request, I changed the way to throw exception. So someone can catch the exception if he don't want to make server crash.