### PR TITLE
feat: supporting release all tcmalloc reserved but not used memory

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2661,9 +2661,9 @@ static int64_t get_tcmalloc_numeric_property(const char *prop)
     return value;
 }
 
-int64_t replica_stub::gc_tcmalloc_memory(bool release_all)
+uint64_t replica_stub::gc_tcmalloc_memory(bool release_all)
 {
-    int64_t tcmalloc_released_bytes = 0;
+    auto tcmalloc_released_bytes = 0;
     if (!_release_tcmalloc_memory) {
         _is_releasing_memory.store(false);
         _counter_tcmalloc_release_memory_size->set(tcmalloc_released_bytes);

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -2313,8 +2313,8 @@ void replica_stub::register_ctrl_command()
 
         _get_tcmalloc_status_command = ::dsn::command_manager::instance().register_command(
             {"replica.get-tcmalloc-status"},
-            "replica.get-tcmalloc-status",
             "replica.get-tcmalloc-status - get status of tcmalloc",
+            "get status of tcmalloc",
             [](const std::vector<std::string> &args) {
                 char buf[4096];
                 MallocExtension::instance()->GetStats(buf, 4096);
@@ -2350,8 +2350,8 @@ void replica_stub::register_ctrl_command()
 
         _release_all_reserved_memory_command = ::dsn::command_manager::instance().register_command(
             {"replica.release-all-reserved-memory"},
-            "replica.release-all-reserved-memory",
             "replica.release-all-reserved-memory - release tcmalloc all reserved-not-used memory",
+            "release tcmalloc all reserverd not-used memory back to operating system",
             [this](const std::vector<std::string> &args) {
                 auto release_bytes = gc_tcmalloc_memory(true);
                 return "OK, release_bytes=" + std::to_string(release_bytes);

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -300,7 +300,7 @@ private:
 #ifdef DSN_ENABLE_GPERF
     // Try to release tcmalloc memory back to operating system
     // If release_all = true, it will release all reserved-not-used memory
-    int64_t gc_tcmalloc_memory(bool release_all);
+    uint64_t gc_tcmalloc_memory(bool release_all);
 #endif
 
 private:

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -299,7 +299,8 @@ private:
 
 #ifdef DSN_ENABLE_GPERF
     // Try to release tcmalloc memory back to operating system
-    void gc_tcmalloc_memory();
+    // If release_all = true, it will release all reserved-not-used memory
+    int64_t gc_tcmalloc_memory(bool release_all);
 #endif
 
 private:
@@ -370,6 +371,7 @@ private:
     dsn_handle_t _release_tcmalloc_memory_command;
     dsn_handle_t _get_tcmalloc_status_command;
     dsn_handle_t _max_reserved_memory_percentage_command;
+    dsn_handle_t _release_all_reserved_memory_command;
 #endif
     dsn_handle_t _max_concurrent_bulk_load_downloading_count_command;
 
@@ -401,6 +403,10 @@ private:
     std::atomic_int _bulk_load_downloading_count;
 
     bool _is_running;
+
+#ifdef DSN_ENABLE_GPERF
+    std::atomic_bool _is_releasing_memory{false};
+#endif
 
     // performance counters
     perf_counter_wrapper _counter_replicas_count;


### PR DESCRIPTION
As [pegasus#789](https://github.com/apache/incubator-pegasus/issues/789) shows, this pull request support releasing all tcmalloc reserved not-used memory by remote command.
NOTICE: Strongly recommend using this command when seriously lack of memory, releasing all reserved memory may affect performance.

I test this function on onebox:
```
>>> remote_command -t replica-server replica.release-all-reserved-memory
COMMAND: replica.release-all-reserved-memory

CALL [replica-server] [ip:por1] succeed: OK, release_bytes=933888
CALL [replica-server] [ip:por2] succeed: OK, release_bytes=6512640
CALL [replica-server] [ip:por3] succeed: OK, release_bytes=6709248

Succeed count: 3
Failed count: 0
```

The log is like:
```
D2021-07-23 10:22:36.125 (1627006956125927036 7178) replica.default1.03001bf2000100c4: replica_stub.cpp:2724:gc_tcmalloc_memory(): Memory release started, almost 933888 bytes will be released
```

The perf-counter is like:
```
[replica*eon.replica_stub*tcmalloc.release.memory.size, NUMBER, 933888.00]
```
