### PR TITLE
feat: add an env to enable or disable block cache of an app

### DIFF
--- a/include/dsn/dist/replication/replica_envs.h
+++ b/include/dsn/dist/replication/replica_envs.h
@@ -45,6 +45,7 @@ public:
     static const std::string ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT;
     static const std::string ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS;
     static const std::string ROCKSDB_ITERATION_THRESHOLD_TIME_MS;
+    static const std::string ROCKSDB_BLOCK_CACHE_ENABLED;
     static const std::string MANUAL_COMPACT_DISABLED;
     static const std::string MANUAL_COMPACT_MAX_CONCURRENT_RUNNING_COUNT;
     static const std::string MANUAL_COMPACT_ONCE_TRIGGER_TIME;

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -642,8 +642,7 @@ const std::string replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS(
     "rocksdb.checkpoint.reserve_time_seconds");
 const std::string replica_envs::ROCKSDB_ITERATION_THRESHOLD_TIME_MS(
     "replica.rocksdb_iteration_threshold_time_ms");
-const std::string replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED(
-    "replica.rocksdb_block_cache_enabled");
+const std::string replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED("replica.rocksdb_block_cache_enabled");
 const std::string replica_envs::BUSINESS_INFO("business.info");
 const std::string replica_envs::REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS(
     "replica_access_controller.allowed_users");

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -642,6 +642,8 @@ const std::string replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS(
     "rocksdb.checkpoint.reserve_time_seconds");
 const std::string replica_envs::ROCKSDB_ITERATION_THRESHOLD_TIME_MS(
     "replica.rocksdb_iteration_threshold_time_ms");
+const std::string replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED(
+    "replica.rocksdb_block_cache_enabled");
 const std::string replica_envs::BUSINESS_INFO("business.info");
 const std::string replica_envs::REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS(
     "replica_access_controller.allowed_users");

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -174,7 +174,6 @@ void app_env_validator::register_all_validators()
         {replica_envs::ROCKSDB_USAGE_SCENARIO, nullptr},
         {replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT, nullptr},
         {replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS, nullptr},
-        {replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED, nullptr},
         {replica_envs::MANUAL_COMPACT_DISABLED, nullptr},
         {replica_envs::MANUAL_COMPACT_MAX_CONCURRENT_RUNNING_COUNT, nullptr},
         {replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME, nullptr},

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -165,7 +165,8 @@ void app_env_validator::register_all_validators()
         {replica_envs::ROCKSDB_ITERATION_THRESHOLD_TIME_MS,
          std::bind(&check_rocksdb_iteration, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED,
-         std::bind(&check_rocksdb_block_cache_enabled, std::placeholders::_1, std::placeholders::_2)},
+         std::bind(
+             &check_rocksdb_block_cache_enabled, std::placeholders::_1, std::placeholders::_2)},
         // TODO(zhaoliwei): not implemented
         {replica_envs::BUSINESS_INFO, nullptr},
         {replica_envs::DENY_CLIENT_WRITE, nullptr},

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -124,6 +124,16 @@ bool check_split_validation(const std::string &env_value, std::string &hint_mess
     return true;
 }
 
+bool check_rocksdb_block_cache_enabled(const std::string &env_value, std::string &hint_message)
+{
+    bool result = false;
+    if (!dsn::buf2bool(env_value, result)) {
+        hint_message = fmt::format("invalid string {}, should be \"true\" or \"false\"", env_value);
+        return false;
+    }
+    return true;
+}
+
 bool app_env_validator::validate_app_env(const std::string &env_name,
                                          const std::string &env_value,
                                          std::string &hint_message)
@@ -154,6 +164,8 @@ void app_env_validator::register_all_validators()
          std::bind(&check_throttling, std::placeholders::_1, std::placeholders::_2)},
         {replica_envs::ROCKSDB_ITERATION_THRESHOLD_TIME_MS,
          std::bind(&check_rocksdb_iteration, std::placeholders::_1, std::placeholders::_2)},
+        {replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED,
+         std::bind(&check_rocksdb_block_cache_enabled, std::placeholders::_1, std::placeholders::_2)},
         // TODO(zhaoliwei): not implemented
         {replica_envs::BUSINESS_INFO, nullptr},
         {replica_envs::DENY_CLIENT_WRITE, nullptr},

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -161,6 +161,7 @@ void app_env_validator::register_all_validators()
         {replica_envs::ROCKSDB_USAGE_SCENARIO, nullptr},
         {replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT, nullptr},
         {replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS, nullptr},
+        {replica_envs::ROCKSDB_BLOCK_CACHE_ENABLED, nullptr},
         {replica_envs::MANUAL_COMPACT_DISABLED, nullptr},
         {replica_envs::MANUAL_COMPACT_MAX_CONCURRENT_RUNNING_COUNT, nullptr},
         {replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME, nullptr},


### PR DESCRIPTION
Sometimes, there are some apps of different business in a cluster.Some apps  want to enable block cache, others my be not.
So we need add an env to enable or disable block cache of an app.