### PR TITLE
feat: update dropped-timeout-rpc-count counter type

### DIFF
--- a/include/dsn/tool-api/task.h
+++ b/include/dsn/tool-api/task.h
@@ -435,7 +435,7 @@ public:
                 _handler(_request);
             }
         } else {
-            dwarn("rpc_request_task(%s) from(%s) stop to execute due to timeout_ms(%d) exceed",
+            dinfo("rpc_request_task(%s) from(%s) stop to execute due to timeout_ms(%d) exceed",
                   spec().name.c_str(),
                   _request->header->from_address.to_string(),
                   _request->header->client.timeout_ms);

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -109,7 +109,7 @@ counter_info *counter_info_ptr[] = {
         {"task.inqueue", "tiq"}, TASK_IN_QUEUE, COUNTER_TYPE_NUMBER, "InQueue(#)", "#"),
     new counter_info({"rpc.dropped", "rdit"},
                      RPC_DROPPED_IF_TIMEOUT,
-                     COUNTER_TYPE_NUMBER,
+                     COUNTER_TYPE_VOLATILE_NUMBER,
                      "RPC.DROPPED(#)",
                      "#")};
 
@@ -484,7 +484,7 @@ void profiler::install(service_spec &)
                     "zion",
                     "profiler",
                     (name + std::string(".rpc.dropped")).c_str(),
-                    COUNTER_TYPE_NUMBER,
+                    COUNTER_TYPE_VOLATILE_NUMBER,
                     "rpc dropped if queue time exceed client timeout");
         } else if (spec->type == dsn_task_type_t::TASK_TYPE_RPC_RESPONSE) {
             if (dsn_config_get_value_bool(section_name.c_str(),


### PR DESCRIPTION
#859 adds perf counters to record dropped timeout rpc count ([pegasus#786](https://github.com/apache/incubator-pegasus/issues/786)). This pr update counter type and log level.