### PR TITLE
fix(sanitizer): fix heap-use-after free in hdfs client test

### DIFF
--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -52,7 +52,7 @@ protected:
     virtual void SetUp() override;
     virtual void TearDown() override;
     void generate_test_file(const char *filename);
-    void write_test_files_async();
+    void write_test_files_async(task_tracker *tracker = nullptr);
     std::string name_node;
     std::string backup_path;
     std::string local_test_dir;
@@ -83,11 +83,11 @@ void HDFSClientTest::generate_test_file(const char *filename)
     fclose(fp);
 }
 
-void HDFSClientTest::write_test_files_async()
+void HDFSClientTest::write_test_files_async(task_tracker *tracker)
 {
     dsn::utils::filesystem::create_directory(local_test_dir);
     for (int i = 0; i < 100; ++i) {
-        tasking::enqueue(LPC_TEST_HDFS, nullptr, [this, i]() {
+        tasking::enqueue(LPC_TEST_HDFS, tracker, [this, i]() {
             // mock the writing process in hdfs_file_object::download().
             std::string test_file_name = local_test_dir + "/test_file_" + std::to_string(i);
             std::ofstream out(test_file_name, std::ios::binary | std::ios::out | std::ios::trunc);
@@ -368,17 +368,21 @@ TEST_F(HDFSClientTest, test_concurrent_upload_download)
 
 TEST_F(HDFSClientTest, test_rename_path_while_writing)
 {
-    write_test_files_async();
+    task_tracker tracker;
+    write_test_files_async(&tracker);
     usleep(100);
     std::string rename_dir = "rename_dir." + std::to_string(dsn_now_ms());
     // rename succeed but writing failed.
     ASSERT_TRUE(dsn::utils::filesystem::rename_path(local_test_dir, rename_dir));
+    tracker.cancel_outstanding_tasks();
 }
 
 TEST_F(HDFSClientTest, test_remove_path_while_writing)
 {
-    write_test_files_async();
+    task_tracker tracker;
+    write_test_files_async(&tracker);
     usleep(100);
     // couldn't remove the directory while writing files in it.
     ASSERT_FALSE(dsn::utils::filesystem::remove_path(local_test_dir));
+    tracker.cancel_outstanding_tasks();
 }

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -52,7 +52,7 @@ protected:
     virtual void SetUp() override;
     virtual void TearDown() override;
     void generate_test_file(const char *filename);
-    void write_test_files_async(task_tracker *tracker = nullptr);
+    void write_test_files_async(task_tracker *tracker);
     std::string name_node;
     std::string backup_path;
     std::string local_test_dir;


### PR DESCRIPTION
error log:
```
1 FAILED TEST
==19244==AddressSanitizer: while reporting a bug found another one. Ignoring.
    #0 0x5638f789a0fa in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /usr/include/c++/7/bits/basic_string.h:440
    #1 0x5638f789a0fa in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::operator+<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*) /usr/include/c++/7/bits/basic_string.h:5928
    #2 0x5638f789a0fa in operator() /home/mi/workspace/rdsn/src/block_service/test/hdfs_service_test.cpp:92
    #3 0x5638f7b51e3c in dsn::task::exec_internal() /home/mi/workspace/rdsn/src/runtime/task/task.cpp:176
    #4 0x5638f7bb2225 in dsn::task_worker::loop() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:211
    #5 0x5638f7bb30fc in dsn::task_worker::run_internal() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:191
    #6 0x5638f7bb3693 in void std::__invoke_impl<void, void (dsn::task_worker::*&)(), dsn::task_worker*&>(std::__invoke_memfun_deref, void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:73
    #7 0x5638f7bb3693 in std::__invoke_result<void (dsn::task_worker::*&)(), dsn::task_worker*&>::type std::__invoke<void (dsn::task_worker::*&)(), dsn::task_worker*&>(void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:95
    #8 0x5638f7bb3693 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/7/functional:467
    #9 0x5638f7bb3693 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::operator()<, void>() /usr/include/c++/7/functional:551
    #10 0x5638f7bb3693 in void std::__invoke_impl<void, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::__invoke_other, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:60
    #11 0x5638f7bb3693 in std::__invoke_result<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>::type std::__invoke<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:95
    #12 0x5638f7bb3693 in decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/7/thread:234
    #13 0x5638f7bb3693 in std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::operator()() /usr/include/c++/7/thread:243
    #14 0x5638f7bb3693 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > > >::_M_run() /usr/include/c++/7/thread:186
    #15 0x7f8835a276de  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd6de)
    #16 0x7f88368ed6da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
    #17 0x7f8835482a3e in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x121a3e)

0x60d0000ad260 is located 80 bytes inside of 144-byte region [0x60d0000ad210,0x60d0000ad2a0)
freed by thread T12 (replica.THREAD_) here:
    #0 0x7f8837e799c8 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19c8)
    #1 0x5638f7d96659 in testing::Test::DeleteSelf_() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8ad659)
    #2 0x5638f7da2e87 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8b9e87)
    #3 0x5638f7d9d4bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8b44bc)
    #4 0x5638f7d81f55 in testing::TestInfo::Run() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x898f55)
    #5 0x5638f7d82583 in testing::TestCase::Run() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x899583)
    #6 0x5638f7d89427 in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8a0427)
    #7 0x5638f7da3f9e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8baf9e)
    #8 0x5638f7d9e28a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8b528a)
    #9 0x5638f7d8800d in testing::UnitTest::Run() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x89f00d)
    #10 0x5638f7922260 in RUN_ALL_TESTS() /home/mi/workspace/rdsn/thirdparty/output/include/gtest/gtest.h:2233
    #11 0x5638f7922260 in gtest_app::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /home/mi/workspace/rdsn/src/block_service/test/main.cpp:32
    #12 0x5638f7a2bbd4 in dsn::service_node::start_app() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:74
    #13 0x5638f7a5b6b3 in dsn::service_control_task::exec() /home/mi/workspace/rdsn/src/runtime/tool_api.cpp:60
    #14 0x5638f7b51e3c in dsn::task::exec_internal() /home/mi/workspace/rdsn/src/runtime/task/task.cpp:176
    #15 0x5638f7bb2225 in dsn::task_worker::loop() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:211
    #16 0x5638f7bb30fc in dsn::task_worker::run_internal() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:191
    #17 0x5638f7bb3693 in void std::__invoke_impl<void, void (dsn::task_worker::*&)(), dsn::task_worker*&>(std::__invoke_memfun_deref, void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:73
    #18 0x5638f7bb3693 in std::__invoke_result<void (dsn::task_worker::*&)(), dsn::task_worker*&>::type std::__invoke<void (dsn::task_worker::*&)(), dsn::task_worker*&>(void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:95
    #19 0x5638f7bb3693 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/7/functional:467
    #20 0x5638f7bb3693 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::operator()<, void>() /usr/include/c++/7/functional:551
    #21 0x5638f7bb3693 in void std::__invoke_impl<void, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::__invoke_other, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:60
    #22 0x5638f7bb3693 in std::__invoke_result<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>::type std::__invoke<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:95
    #23 0x5638f7bb3693 in decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/7/thread:234
    #24 0x5638f7bb3693 in std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::operator()() /usr/include/c++/7/thread:243
    #25 0x5638f7bb3693 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > > >::_M_run() /usr/include/c++/7/thread:186
    #26 0x7f8835a276de  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd6de)

previously allocated by thread T12 (replica.THREAD_) here:
    #0 0x7f8837e78448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x5638f78af452 in testing::internal::TestFactoryImpl<HDFSClientTest_test_rename_path_while_writing_Test>::CreateTest() /home/mi/workspace/rdsn/thirdparty/output/include/gtest/internal/gtest-internal.h:484
    #2 0x5638f7da2f4b in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8b9f4b)
    #3 0x5638f7d9d740 in testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8b4740)
    #4 0x5638f7d81ed8 in testing::TestInfo::Run() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x898ed8)
    #5 0x5638f7d82583 in testing::TestCase::Run() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x899583)
    #6 0x5638f7d89427 in testing::internal::UnitTestImpl::RunAllTests() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8a0427)
    #7 0x5638f7da3f9e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8baf9e)
    #8 0x5638f7d9e28a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x8b528a)
    #9 0x5638f7d8800d in testing::UnitTest::Run() (/home/mi/workspace/rdsn/builder/src/block_service/test/dsn_block_service_test+0x89f00d)
    #10 0x5638f7922260 in RUN_ALL_TESTS() /home/mi/workspace/rdsn/thirdparty/output/include/gtest/gtest.h:2233
    #11 0x5638f7922260 in gtest_app::start(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /home/mi/workspace/rdsn/src/block_service/test/main.cpp:32
    #12 0x5638f7a2bbd4 in dsn::service_node::start_app() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:74
    #13 0x5638f7a5b6b3 in dsn::service_control_task::exec() /home/mi/workspace/rdsn/src/runtime/tool_api.cpp:60
    #14 0x5638f7b51e3c in dsn::task::exec_internal() /home/mi/workspace/rdsn/src/runtime/task/task.cpp:176
    #15 0x5638f7bb2225 in dsn::task_worker::loop() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:211
    #16 0x5638f7bb30fc in dsn::task_worker::run_internal() /home/mi/workspace/rdsn/src/runtime/task/task_worker.cpp:191
    #17 0x5638f7bb3693 in void std::__invoke_impl<void, void (dsn::task_worker::*&)(), dsn::task_worker*&>(std::__invoke_memfun_deref, void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:73
    #18 0x5638f7bb3693 in std::__invoke_result<void (dsn::task_worker::*&)(), dsn::task_worker*&>::type std::__invoke<void (dsn::task_worker::*&)(), dsn::task_worker*&>(void (dsn::task_worker::*&)(), dsn::task_worker*&) /usr/include/c++/7/bits/invoke.h:95
    #19 0x5638f7bb3693 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/7/functional:467
    #20 0x5638f7bb3693 in void std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>::operator()<, void>() /usr/include/c++/7/functional:551
    #21 0x5638f7bb3693 in void std::__invoke_impl<void, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::__invoke_other, std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:60
    #22 0x5638f7bb3693 in std::__invoke_result<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>::type std::__invoke<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>>(std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()>&&) /usr/include/c++/7/bits/invoke.h:95
    #23 0x5638f7bb3693 in decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/7/thread:234
    #24 0x5638f7bb3693 in std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > >::operator()() /usr/include/c++/7/thread:243
    #25 0x5638f7bb3693 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (dsn::task_worker::*(dsn::task_worker*))()> > > >::_M_run() /usr/include/c++/7/thread:186
    #26 0x7f8835a276de  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd6de)

Thread T13 (replica.THREAD_) created by T0 here:
    #0 0x7f8837dcfd2f in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x37d2f)
    #1 0x7f8835a27994 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd994)
    #2 0x5638f7b6b97b in dsn::task_worker_pool::start() /home/mi/workspace/rdsn/src/runtime/task/task_engine.cpp:87
    #3 0x5638f7b6df50 in dsn::task_engine::start() /home/mi/workspace/rdsn/src/runtime/task/task_engine.cpp:235
    #4 0x5638f7a349ed in dsn::service_node::start() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:122
    #5 0x5638f7a3606e in dsn::service_engine::start_node(dsn::service_app_spec&) /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:247
    #6 0x5638f7a1e99c in run /home/mi/workspace/rdsn/src/runtime/service_api_c.cpp:504
    #7 0x5638f7a237e3 in dsn_run_config(char const*, bool) /home/mi/workspace/rdsn/src/runtime/service_api_c.cpp:183
    #8 0x5638f77b8ba4 in main /home/mi/workspace/rdsn/src/block_service/test/main.cpp:46
    #9 0x7f8835382b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Thread T12 (replica.THREAD_) created by T0 here:
    #0 0x7f8837dcfd2f in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x37d2f)
    #1 0x7f8835a27994 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd994)
    #2 0x5638f7b6b97b in dsn::task_worker_pool::start() /home/mi/workspace/rdsn/src/runtime/task/task_engine.cpp:87
    #3 0x5638f7b6df50 in dsn::task_engine::start() /home/mi/workspace/rdsn/src/runtime/task/task_engine.cpp:235
    #4 0x5638f7a349ed in dsn::service_node::start() /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:122
    #5 0x5638f7a3606e in dsn::service_engine::start_node(dsn::service_app_spec&) /home/mi/workspace/rdsn/src/runtime/service_engine.cpp:247
    #6 0x5638f7a1e99c in run /home/mi/workspace/rdsn/src/runtime/service_api_c.cpp:504
    #7 0x5638f7a237e3 in dsn_run_config(char const*, bool) /home/mi/workspace/rdsn/src/runtime/service_api_c.cpp:183
    #8 0x5638f77b8ba4 in main /home/mi/workspace/rdsn/src/block_service/test/main.cpp:46
    #9 0x7f8835382b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/7/bits/basic_string.h:440 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
Shadow bytes around the buggy address:
  0x0c1a8000d9f0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c1a8000da00: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fd fd
  0x0c1a8000da10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c1a8000da20: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c1a8000da30: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
=>0x0c1a8000da40: fa fa fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd
  0x0c1a8000da50: fd fd fd fd fa fa fa fa fa fa fa fa fd fd fd fd
  0x0c1a8000da60: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
  0x0c1a8000da70: fa fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x0c1a8000da80: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0c1a8000da90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==19244==ABORTING
```