### PR TITLE
fix: don't build  HDFSClientTest.test_remove_path_while_writing if sanitizer is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if(ENABLE_GCOV)
     add_definitions(-DENABLE_GCOV=1)
 endif()
 
+if(SANITIZER)
+    add_definitions(-DSANITIZER=1)
+endif()
 # Users don't have to configure CMAKE_INSTALL_PREFIX unless they want to customize
 # the destination.
 set(CMAKE_INSTALL_PREFIX ${DSN_ROOT} CACHE STRING "" FORCE)

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -365,24 +365,3 @@ TEST_F(HDFSClientTest, test_concurrent_upload_download)
         utils::filesystem::remove_path(downloaded_file_names[i]);
     }
 }
-
-TEST_F(HDFSClientTest, test_rename_path_while_writing)
-{
-    task_tracker tracker;
-    write_test_files_async(&tracker);
-    usleep(100);
-    std::string rename_dir = "rename_dir." + std::to_string(dsn_now_ms());
-    // rename succeed but writing failed.
-    ASSERT_TRUE(dsn::utils::filesystem::rename_path(local_test_dir, rename_dir));
-    tracker.cancel_outstanding_tasks();
-}
-
-TEST_F(HDFSClientTest, test_remove_path_while_writing)
-{
-    task_tracker tracker;
-    write_test_files_async(&tracker);
-    usleep(100);
-    // couldn't remove the directory while writing files in it.
-    ASSERT_FALSE(dsn::utils::filesystem::remove_path(local_test_dir));
-    tracker.cancel_outstanding_tasks();
-}

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -365,3 +365,26 @@ TEST_F(HDFSClientTest, test_concurrent_upload_download)
         utils::filesystem::remove_path(downloaded_file_names[i]);
     }
 }
+
+TEST_F(HDFSClientTest, test_rename_path_while_writing)
+{
+    task_tracker tracker;
+    write_test_files_async(&tracker);
+    usleep(100);
+    std::string rename_dir = "rename_dir." + std::to_string(dsn_now_ms());
+    // rename succeed but writing failed.
+    ASSERT_TRUE(dsn::utils::filesystem::rename_path(local_test_dir, rename_dir));
+    tracker.cancel_outstanding_tasks();
+}
+
+#ifndef SANITIZER
+TEST_F(HDFSClientTest, test_remove_path_while_writing)
+{
+    task_tracker tracker;
+    write_test_files_async(&tracker);
+    usleep(100);
+    // couldn't remove the directory while writing files in it.
+    ASSERT_FALSE(dsn::utils::filesystem::remove_path(local_test_dir));
+    tracker.cancel_outstanding_tasks();
+}
+#endif


### PR DESCRIPTION
the `HDFSClientTest.test_remove_path_while_writing` test will produce error if sanitizer is defined, so I remove it when sanitizer is defined in this pull.