### PR TITLE
fix: update mutation tracer name to mutation->name()

### DIFF
--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -93,6 +93,8 @@ public:
     // stageA[rpc_message]--stageB[rpc_message]--
     void set_sub_tracer(const std::shared_ptr<latency_tracer> &tracer);
 
+    void set_name(const std::string &name) { _name = name; }
+
 private:
     void dump_trace_points(/*out*/ std::string &traces);
 

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -100,7 +100,7 @@ private:
 
     utils::rw_lock_nr _lock;
 
-    const std::string _name;
+    std::string _name;
     const uint64_t _threshold;
     bool _is_sub;
     const uint64_t _start_time;

--- a/src/replica/mutation.cpp
+++ b/src/replica/mutation.cpp
@@ -64,6 +64,7 @@ mutation::mutation()
         std::make_shared<dsn::utils::latency_tracer>(fmt::format("{}[{}]", "mutation", _tid),
                                                      false,
                                                      FLAGS_abnormal_write_trace_latency_threshold);
+                                                     
 }
 
 mutation_ptr mutation::copy_no_reply(const mutation_ptr &old_mu)

--- a/src/replica/mutation.cpp
+++ b/src/replica/mutation.cpp
@@ -64,7 +64,6 @@ mutation::mutation()
         std::make_shared<dsn::utils::latency_tracer>(fmt::format("{}[{}]", "mutation", _tid),
                                                      false,
                                                      FLAGS_abnormal_write_trace_latency_threshold);
-                                                     
 }
 
 mutation_ptr mutation::copy_no_reply(const mutation_ptr &old_mu)

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -180,6 +180,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
         mu->set_id(get_ballot(), mu->data.header.decree);
     }
 
+    mu->tracer->set_name(fmt::format("mutation[{}]", mu->name()));
     dlog(level,
          "%s: mutation %s init_prepare, mutation_tid=%" PRIu64,
          name(),
@@ -386,6 +387,7 @@ void replica::on_prepare(dsn::message_ex *request)
     decree decree = mu->data.header.decree;
 
     dinfo("%s: mutation %s on_prepare", name(), mu->name());
+    mu->tracer->set_name(fmt::format("mutation[{}]", mu->name()));
 
     dassert(mu->data.header.pid == rconfig.pid,
             "(%d.%d) VS (%d.%d)",


### PR DESCRIPTION
In the past, the mutation tracer name is init "mutation[tid]" to distinct, however, the `tid` is different from `primary` and `secondary` for the same mutation,  which is not conducive to tracking the time-consuming of cross-node requests. this pr use `mutation->name()` to track it, which is same for different node