### PR TITLE
feat: add copy secondary for cluster balance

### DIFF
--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -1012,7 +1012,8 @@ void greedy_load_balancer::balance_cluster()
         return;
     }
 
-    cluster_replica_balance(t_global_view, cluster_balance_type::COPY_SECONDARY, *t_migration_result);
+    cluster_replica_balance(
+        t_global_view, cluster_balance_type::COPY_SECONDARY, *t_migration_result);
 }
 
 bool greedy_load_balancer::cluster_replica_balance(const meta_view *global_view,


### PR DESCRIPTION
### Manual Test
1. start onebox with 5 replica servers and 3 meta servers
```
 ./run.sh start_onebox -r 5 -m 3
```
2. create several tables with 4 partitions, for example:
```
>>> create test1
create app test1 succeed, waiting for app ready
test1 not ready yet, still waiting... (0/4)
test1 not ready yet, still waiting... (2/4)
test1 not ready yet, still waiting... (2/4)
test1 not ready yet, still waiting... (2/4)
test1 not ready yet, still waiting... (2/4)
test1 not ready yet, still waiting... (2/4)
test1 is ready now: (4/4)
test1 is ready now!
create app "test1" succeed
```
3. get information about load balance, and we can see the cluster is not balanced
```
>>> nodes -d
[details]
address              status    replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                28              9               19
10.231.57.100:34802  ALIVE                25              9               16
10.231.57.100:34803  ALIVE                28              8               20
10.231.57.100:34804  ALIVE                26              9               17
10.231.57.100:34805  ALIVE                25              9               16
```
4. enable cluster load balance
```
http://127.0.0.1:34601/updateConfig?balance_cluster=true
```
5. set meta_level to lively to enable load balance
```
>>> set_meta_level lively
control meta level ok, the old level is fl_steady
```
6. get information about load balance, and now the cluster is balanced. 
```
>>> nodes -d
[details]
address              status    replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                27              9               18
10.231.57.100:34802  ALIVE                26              9               17
10.231.57.100:34803  ALIVE                26              8               18
10.231.57.100:34804  ALIVE                27              9               18
10.231.57.100:34805  ALIVE                26              9               17
```