### PR TITLE
refactor: move finish_cure_proposal from simple_load_balancer to partition_guardian

### DIFF
--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -446,7 +446,20 @@ void partition_guardian::finish_cure_proposal(meta_view &view,
                                               const dsn::gpid &gpid,
                                               const configuration_proposal_action &act)
 {
-    // TBD(zlw):
+    newly_partitions *np = get_newly_partitions(*(view.nodes), act.node);
+    if (np == nullptr) {
+        ddebug("can't get the newly_partitions extension structure for node(%s), "
+               "the node may be dead and removed",
+               act.node.to_string());
+    } else {
+        if (act.type == config_type::CT_ASSIGN_PRIMARY) {
+            np->newly_remove_primary(gpid.get_app_id(), false);
+        } else if (act.type == config_type::CT_UPGRADE_TO_PRIMARY) {
+            np->newly_remove_primary(gpid.get_app_id(), true);
+        } else if (act.type == config_type::CT_UPGRADE_TO_SECONDARY) {
+            np->newly_remove_partition(gpid.get_app_id());
+        }
+    }
 }
 } // namespace replication
 } // namespace dsn


### PR DESCRIPTION
simplely move function `finish_cure_proposal`  from `simple_load_balancer` to `partition_guardian`, in order to remove `simple_load_balancer` in the later.

No code changed actually