### PR TITLE
feat: make the block size configurable for mutation logs

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -95,6 +95,7 @@ replication_options::replication_options()
     log_private_batch_buffer_flush_interval_ms = 10000;
     log_private_reserve_max_size_mb = 0;
     log_private_reserve_max_time_seconds = 0;
+    log_private_block_bytes = 1024 * 1024;
 
     log_shared_file_size_mb = 32;
     log_shared_file_count_limit = 100;
@@ -102,6 +103,7 @@ replication_options::replication_options()
     log_shared_force_flush = false;
     log_shared_pending_size_throttling_threshold_kb = 0;
     log_shared_pending_size_throttling_delay_ms = 0;
+    log_shared_block_bytes = 1024 * 1024;
 
     config_sync_disabled = false;
     config_sync_interval_ms = 30000;
@@ -348,6 +350,10 @@ void replication_options::initialize()
         "log_private_reserve_max_time_seconds",
         log_private_reserve_max_time_seconds,
         "max time in seconds of useless private log to be reserved");
+    log_private_block_bytes = dsn_config_get_value_int64("replication",
+                                                         "log_private_block_bytes",
+                                                         log_private_block_bytes,
+                                                         "block size by bytes for private log");
 
     log_shared_file_size_mb =
         (int)dsn_config_get_value_uint64("replication",
@@ -378,6 +384,10 @@ void replication_options::initialize()
                                          "log_shared_pending_size_throttling_delay_ms",
                                          log_shared_pending_size_throttling_delay_ms,
                                          "log_shared_pending_size_throttling_delay_ms");
+    log_shared_block_bytes = dsn_config_get_value_int64("replication",
+                                                        "log_shared_block_bytes",
+                                                        log_shared_block_bytes,
+                                                        "block size by bytes for shared log");
 
     config_sync_disabled = dsn_config_get_value_bool(
         "replication",

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -106,6 +106,7 @@ public:
     int32_t log_private_batch_buffer_flush_interval_ms;
     int32_t log_private_reserve_max_size_mb;
     int32_t log_private_reserve_max_time_seconds;
+    int64_t log_private_block_bytes;
 
     int32_t log_shared_file_size_mb;
     int32_t log_shared_file_count_limit;
@@ -113,6 +114,7 @@ public:
     bool log_shared_force_flush;
     int32_t log_shared_pending_size_throttling_threshold_kb;
     int32_t log_shared_pending_size_throttling_delay_ms;
+    int64_t log_shared_block_bytes;
 
     bool config_sync_disabled;
     int32_t config_sync_interval_ms;

--- a/src/replica/log_file.h
+++ b/src/replica/log_file.h
@@ -91,14 +91,18 @@ public:
     // returns:
     //   - non-null if open succeed
     //   - null if open failed
-    static log_file_ptr open_read(const char *path, /*out*/ error_code &err);
+    static log_file_ptr
+    open_read(const char *path, /*out*/ error_code &err, size_t block_bytes = 1024 * 1024);
 
     // open the log file for write
     // the file path is '{dir}/log.{index}.{start_offset}'
     // returns:
     //   - non-null if open succeed
     //   - null if open failed
-    static log_file_ptr create_write(const char *dir, int index, int64_t start_offset);
+    static log_file_ptr create_write(const char *dir,
+                                     int index,
+                                     int64_t start_offset,
+                                     size_t block_bytes = 1024 * 1024);
 
     // close the log file
     void close();
@@ -186,7 +190,12 @@ public:
 
 private:
     // make private, user should create log_file through open_read() or open_write()
-    log_file(const char *path, disk_file *handle, int index, int64_t start_offset, bool is_read);
+    log_file(const char *path,
+             disk_file *handle,
+             int index,
+             int64_t start_offset,
+             bool is_read,
+             size_t block_bytes = 1024 * 1024);
 
 private:
     friend class mock_log_file;
@@ -203,6 +212,7 @@ private:
     int _index;                // file index
     log_file_header _header;   // file header
     uint64_t _last_write_time; // seconds from epoch time
+    const size_t _block_bytes; // file block bytes
 
     mutable zlock _write_lock;
 

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -97,7 +97,11 @@ public:
     // ctors
     // when is_private = true, should specify "private_gpid"
     //
-    mutation_log(const std::string &dir, int32_t max_log_file_mb, gpid gpid, replica *r = nullptr);
+    mutation_log(const std::string &dir,
+                 int32_t max_log_file_mb,
+                 gpid gpid,
+                 replica *r = nullptr,
+                 size_t block_bytes = 1024 * 1024);
 
     virtual ~mutation_log() = default;
 
@@ -121,7 +125,8 @@ public:
     //
     static error_code replay(std::vector<std::string> &log_files,
                              replay_callback callback,
-                             /*out*/ int64_t &end_offset);
+                             /*out*/ int64_t &end_offset,
+                             size_t block_bytes = 1024 * 1024);
 
     // Reads a series of mutations from the log file (from `start_offset` of `log`),
     // and iterates over the mutations, executing the provided `callback` for each
@@ -336,6 +341,7 @@ protected:
     int64_t _max_log_file_size_in_bytes;
     int64_t _min_log_file_size_in_bytes;
     bool _force_flush;
+    const size_t _block_bytes;
 
     dsn::task_tracker _tracker;
 
@@ -382,8 +388,9 @@ public:
     mutation_log_shared(const std::string &dir,
                         int32_t max_log_file_mb,
                         bool force_flush,
-                        perf_counter_wrapper *write_size_counter = nullptr)
-        : mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr),
+                        perf_counter_wrapper *write_size_counter = nullptr,
+                        size_t block_bytes = 1024 * 1024)
+        : mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr, block_bytes),
           _is_writing(false),
           _force_flush(force_flush),
           _write_size_counter(write_size_counter)
@@ -445,7 +452,8 @@ public:
                          replica *r,
                          uint32_t batch_buffer_bytes,
                          uint32_t batch_buffer_max_count,
-                         uint64_t batch_buffer_flush_interval_ms);
+                         uint64_t batch_buffer_flush_interval_ms,
+                         size_t block_bytes = 1024 * 1024);
 
     ~mutation_log_private() override
     {

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -114,12 +114,13 @@ namespace replication {
 
 /*static*/ error_code mutation_log::replay(std::vector<std::string> &log_files,
                                            replay_callback callback,
-                                           /*out*/ int64_t &end_offset)
+                                           /*out*/ int64_t &end_offset,
+                                           size_t block_bytes)
 {
     std::map<int, log_file_ptr> logs;
     for (auto &fpath : log_files) {
         error_code err;
-        log_file_ptr log = log_file::open_read(fpath.c_str(), err);
+        log_file_ptr log = log_file::open_read(fpath.c_str(), err, block_bytes);
         if (log == nullptr) {
             if (err == ERR_HANDLE_EOF || err == ERR_INCOMPLETE_DATA ||
                 err == ERR_INVALID_PARAMETERS) {

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -243,7 +243,8 @@ error_code replica::init_app_and_prepare_list(bool create_new)
                                          this,
                                          _options->log_private_batch_buffer_kb * 1024,
                                          _options->log_private_batch_buffer_count,
-                                         _options->log_private_batch_buffer_flush_interval_ms);
+                                         _options->log_private_batch_buffer_flush_interval_ms,
+                                         _options->log_private_block_bytes);
             ddebug("%s: plog_dir = %s", name(), log_dir.c_str());
 
             // sync valid_start_offset between app and logs
@@ -342,7 +343,8 @@ error_code replica::init_app_and_prepare_list(bool create_new)
                                          this,
                                          _options->log_private_batch_buffer_kb * 1024,
                                          _options->log_private_batch_buffer_count,
-                                         _options->log_private_batch_buffer_flush_interval_ms);
+                                         _options->log_private_batch_buffer_flush_interval_ms,
+                                         _options->log_private_block_bytes);
             ddebug("%s: plog_dir = %s", name(), log_dir.c_str());
 
             err = _private_log->open(nullptr, [this](error_code err) {

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -1591,7 +1591,8 @@ error_code replica::apply_learned_state_from_private_log(learn_state &state)
                                    plist.prepare(mu, partition_status::PS_SECONDARY);
                                    return true;
                                },
-                               offset);
+                               offset,
+                               _options->log_private_block_bytes);
 
     // update first_learn_start_decree, the position where the first round of LT_LOG starts from.
     // we use this value to determine whether to learn back from min_confirmed_decree

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -523,7 +523,8 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     _log = new mutation_log_shared(_options.slog_dir,
                                    _options.log_shared_file_size_mb,
                                    _options.log_shared_force_flush,
-                                   &_counter_shared_log_recent_write_size);
+                                   &_counter_shared_log_recent_write_size,
+                                   _options.log_shared_block_bytes);
     ddebug("slog_dir = %s", _options.slog_dir.c_str());
 
     // init rps
@@ -651,7 +652,8 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
         _log = new mutation_log_shared(_options.slog_dir,
                                        _options.log_shared_file_size_mb,
                                        _options.log_shared_force_flush,
-                                       &_counter_shared_log_recent_write_size);
+                                       &_counter_shared_log_recent_write_size,
+                                       _options.log_shared_block_bytes);
         auto lerr = _log->open(nullptr, [this](error_code err) { this->handle_log_failure(err); });
         dassert(lerr == ERR_OK, "restart log service must succeed");
     }

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -115,7 +115,8 @@ public:
                                      this,
                                      _options->log_private_batch_buffer_kb * 1024,
                                      _options->log_private_batch_buffer_count,
-                                     _options->log_private_batch_buffer_flush_interval_ms);
+                                     _options->log_private_batch_buffer_flush_interval_ms,
+                                     _options->log_private_block_bytes);
 
         error_code err =
             _private_log->open(nullptr, [this](error_code err) { dcheck_eq_replica(err, ERR_OK); });


### PR DESCRIPTION
The block size used to read the files of mutation logs should be configurable to limit the memory consumed by rDSN, with `log_private_block_bytes` specified for private logs and `log_shared_block_bytes` for shared logs.

The default block size is still 1MB, as it's used before.