### PR TITLE
refactor: move register_ctrl_commands from simple_load_balancer to partition_guardian

### DIFF
--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -30,6 +30,8 @@ public:
     ~partition_guardian() = default;
 
     pc_status cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);
+    void register_ctrl_commands();
+    void unregister_ctrl_commands();
 
 private:
     bool
@@ -44,6 +46,8 @@ private:
     void finish_cure_proposal(meta_view &view,
                               const dsn::gpid &gpid,
                               const configuration_proposal_action &action);
+    std::string ctrl_assign_delay_ms(const std::vector<std::string> &args);
+    std::string ctrl_assign_secondary_black_list(const std::vector<std::string> &args);
 
     void set_ddd_partition(ddd_partition_info &&partition)
     {

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -2077,6 +2077,7 @@ error_code server_state::construct_partitions(
         }
     }
 
+
     int succeed_count = 0;
     int failed_count = 0;
     for (auto &app_kv : _all_apps) {

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -2077,7 +2077,6 @@ error_code server_state::construct_partitions(
         }
     }
 
-
     int succeed_count = 0;
     int failed_count = 0;
     for (auto &app_kv : _all_apps) {


### PR DESCRIPTION
simplely move function `register_ctrl_commands`  from `simple_load_balancer` to `partition_guardian`, in order to remove `simple_load_balancer` later.

No code changed actually