### PR TITLE
feat(split): add split reject counters

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -112,6 +112,14 @@ replica::replica(
     _counter_dup_disabled_non_idempotent_write_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
+    counter_str = fmt::format("recent.read.splitting.reject.count@{}", gpid);
+    _counter_recent_read_splitting_reject_count.init_app_counter(
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
+
+    counter_str = fmt::format("recent.write.splitting.reject.count@{}", gpid);
+    _counter_recent_write_splitting_reject_count.init_app_counter(
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
+
     // init table level latency perf counters
     init_table_level_latency_counters();
 

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -91,6 +91,7 @@ const char *manual_compaction_status_to_string(manual_compaction_status status);
     if (_validate_partition_hash) {                                                                \
         if (_split_mgr->should_reject_request()) {                                                 \
             response_client_##op_type(request, ERR_SPLITTING);                                     \
+            _counter_recent_##op_type##_splitting_reject_count->increment();                       \
             return;                                                                                \
         }                                                                                          \
         if (!_split_mgr->check_partition_hash(                                                     \
@@ -567,6 +568,8 @@ private:
     perf_counter_wrapper _counter_recent_read_throttling_reject_count;
     perf_counter_wrapper _counter_recent_backup_request_throttling_delay_count;
     perf_counter_wrapper _counter_recent_backup_request_throttling_reject_count;
+    perf_counter_wrapper _counter_recent_write_splitting_reject_count;
+    perf_counter_wrapper _counter_recent_read_splitting_reject_count;
     std::vector<perf_counter *> _counters_table_level_latency;
     perf_counter_wrapper _counter_dup_disabled_non_idempotent_write_count;
     perf_counter_wrapper _counter_backup_request_qps;


### PR DESCRIPTION
This pull requests add replica-level reject read/write requests count during partition split.
```
replica*eon.replica*recent.write.splitting.reject.count@[gpid] - VOLATILE_NUMBER
replica*eon.replica*recent.read.splitting.reject.count@[gpid] - VOLATILE_NUMBER
```