### PR TITLE
feat(perf_counter): add a perf_counter of server session

### DIFF
--- a/include/dsn/tool-api/network.h
+++ b/include/dsn/tool-api/network.h
@@ -32,6 +32,7 @@
 #include <dsn/tool-api/rpc_address.h>
 #include <dsn/utility/exp_delay.h>
 #include <dsn/utility/dlib.h>
+#include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <atomic>
 
 namespace dsn {
@@ -40,6 +41,8 @@ class rpc_engine;
 class service_node;
 class task_worker_pool;
 class task_queue;
+class perf_counter_wrapper;
+
 /*!
 @addtogroup tool-api-providers
 @{
@@ -186,6 +189,7 @@ protected:
     utils::rw_lock_nr _servers_lock;
 
     uint32_t _cfg_conn_threshold_per_ip;
+    perf_counter_wrapper _client_session_count;
 };
 
 /*!

--- a/include/dsn/tool-api/network.h
+++ b/include/dsn/tool-api/network.h
@@ -41,7 +41,6 @@ class rpc_engine;
 class service_node;
 class task_worker_pool;
 class task_queue;
-class perf_counter_wrapper;
 
 /*!
 @addtogroup tool-api-providers

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -705,11 +705,12 @@ void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
 
 void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr &s)
 {
-    int ip_count =
-        0; // how many unique client(the same ip:port is considered to be a unique client)
-    int ip_conn_count =
-        0; // one unique client may remain more than one connection on the server, which
-           // is a unexpected behavior of client, we should record it in logs.
+    // how many unique client(the same ip:port is considered to be a unique client)
+    int ip_count = 0;
+    // one unique client may remain more than one connection on the server, which
+    // is an unexpected behavior of client, we should record it in logs.
+    int ip_conn_count = 0;
+
     bool session_removed = false;
     {
         utils::auto_write_lock l(_servers_lock);

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -590,9 +590,9 @@ connection_oriented_network::connection_oriented_network(rpc_engine *srv, networ
     : network(srv, inner_provider)
 {
     _cfg_conn_threshold_per_ip = 0;
-    _client_session_count.init_global_counter("replica",
+    _client_session_count.init_global_counter("server",
                                               "network",
-                                              "server_session_count",
+                                              "client_session_count",
                                               COUNTER_TYPE_NUMBER,
                                               "current session count on server");
 }

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -590,8 +590,9 @@ connection_oriented_network::connection_oriented_network(rpc_engine *srv, networ
     : network(srv, inner_provider)
 {
     _cfg_conn_threshold_per_ip = 0;
-    _client_session_count.init_app_counter(
-        "eon.network",
+    _client_session_count.init_global_counter(
+        "replica",
+        "network",
         "client_session_count",
         COUNTER_TYPE_NUMBER,
         "current session count on server");
@@ -632,7 +633,7 @@ void connection_oriented_network::send_message(message_ex *request)
         }
     }
 
-    int scount = 0;
+    int ip_count = 0;
     bool new_client = false;
     if (nullptr == client.get()) {
         utils::auto_write_lock l(_clients_lock);
@@ -644,15 +645,15 @@ void connection_oriented_network::send_message(message_ex *request)
             _clients.insert(client_sessions::value_type(to, client));
             new_client = true;
         }
-        scount = (int)_clients.size();
+        ip_count = (int)_clients.size();
     }
 
     // init connection if necessary
     if (new_client) {
         ddebug("client session created, remote_server = %s, current_count = %d",
                client->remote_address().to_string(),
-               scount);
-        _client_session_count->set(scount);
+               ip_count);
+        _client_session_count->set(ip_count);
         client->connect();
     }
 
@@ -669,8 +670,8 @@ rpc_session_ptr connection_oriented_network::get_server_session(::dsn::rpc_addre
 
 void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
 {
-    int scount = 0;
-    int ecount = 1;
+    int ip_count = 0;
+    int ip_conn_count = 1;
     {
         utils::auto_write_lock l(_servers_lock);
 
@@ -682,25 +683,25 @@ void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
             dwarn("server session already exists, remote_client = %s, preempted",
                   s->remote_address().to_string());
         }
-        scount = (int)_servers.size();
+        ip_count = (int)_servers.size();
 
         auto pr2 =
             _ip_conn_count.insert(ip_connection_count::value_type(s->remote_address().ip(), 1));
         if (!pr2.second) {
-            ecount = ++pr2.first->second;
+            ip_conn_count = ++pr2.first->second;
         }
     }
 
     ddebug("server session accepted, remote_client = %s, current_count = %d",
            s->remote_address().to_string(),
-           scount);
+           ip_count);
 
     ddebug("ip session %s, remote_client = %s, current_count = %d",
-           ecount == 1 ? "inserted" : "increased",
+           ip_conn_count == 1 ? "inserted" : "increased",
            s->remote_address().to_string(),
-           ecount);
+           ip_conn_count);
 
-    _client_session_count->set(scount);
+    _client_session_count->set(ip_count);
 }
 
 void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr &s)
@@ -732,6 +733,7 @@ void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr
         ddebug("session %s disconnected, the total client sessions count remains %d",
                s->remote_address().to_string(),
                ip_count);
+        _client_session_count->set(ip_count);
     }
 
     if (ip_conn_count == 0) {
@@ -778,7 +780,7 @@ bool connection_oriented_network::check_if_conn_threshold_exceeded(::dsn::rpc_ad
 
 void connection_oriented_network::on_client_session_connected(rpc_session_ptr &s)
 {
-    int scount = 0;
+    int ip_count = 0;
     bool r = false;
     {
         utils::auto_read_lock l(_clients_lock);
@@ -786,20 +788,20 @@ void connection_oriented_network::on_client_session_connected(rpc_session_ptr &s
         if (it != _clients.end() && it->second.get() == s.get()) {
             r = true;
         }
-        scount = (int)_clients.size();
+        ip_count = (int)_clients.size();
     }
 
     if (r) {
         ddebug("client session connected, remote_server = %s, current_count = %d",
                s->remote_address().to_string(),
-               scount);
-        _client_session_count->set(scount);
+               ip_count);
+        _client_session_count->set(ip_count);
     }
 }
 
 void connection_oriented_network::on_client_session_disconnected(rpc_session_ptr &s)
 {
-    int scount = 0;
+    int ip_count = 0;
     bool r = false;
     {
         utils::auto_write_lock l(_clients_lock);
@@ -808,14 +810,14 @@ void connection_oriented_network::on_client_session_disconnected(rpc_session_ptr
             _clients.erase(it);
             r = true;
         }
-        scount = (int)_clients.size();
+        ip_count = (int)_clients.size();
     }
 
     if (r) {
         ddebug("client session disconnected, remote_server = %s, current_count = %d",
                s->remote_address().to_string(),
-               scount);
-        _client_session_count->set(scount);
+               ip_count);
+        _client_session_count->set(ip_count);
     }
 }
 

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -705,8 +705,11 @@ void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
 
 void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr &s)
 {
-    int ip_count = 0;      // how many unique client IPs
-    int ip_conn_count = 0; // how many connections bound to the IP of `s`
+    int ip_count =
+        0; // how many unique client(the same ip:port is considered to be a unique client)
+    int ip_conn_count =
+        0; // one unique client may remain more than one connection on the server, which
+           // is a unexpected behavior of client, we should record it in logs.
     bool session_removed = false;
     {
         utils::auto_write_lock l(_servers_lock);

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -593,7 +593,7 @@ connection_oriented_network::connection_oriented_network(rpc_engine *srv, networ
     _client_session_count.init_global_counter(
         "replica",
         "network",
-        "client_session_count",
+        "server_session_count",
         COUNTER_TYPE_NUMBER,
         "current session count on server");
 }

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -590,12 +590,11 @@ connection_oriented_network::connection_oriented_network(rpc_engine *srv, networ
     : network(srv, inner_provider)
 {
     _cfg_conn_threshold_per_ip = 0;
-    _client_session_count.init_global_counter(
-        "replica",
-        "network",
-        "server_session_count",
-        COUNTER_TYPE_NUMBER,
-        "current session count on server");
+    _client_session_count.init_global_counter("replica",
+                                              "network",
+                                              "server_session_count",
+                                              COUNTER_TYPE_NUMBER,
+                                              "current session count on server");
 }
 
 void connection_oriented_network::inject_drop_message(message_ex *msg, bool is_send)

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -590,6 +590,11 @@ connection_oriented_network::connection_oriented_network(rpc_engine *srv, networ
     : network(srv, inner_provider)
 {
     _cfg_conn_threshold_per_ip = 0;
+    _client_session_count.init_app_counter(
+        "eon.network",
+        "client_session_count",
+        COUNTER_TYPE_NUMBER,
+        "current session count on server");
 }
 
 void connection_oriented_network::inject_drop_message(message_ex *msg, bool is_send)
@@ -647,6 +652,7 @@ void connection_oriented_network::send_message(message_ex *request)
         ddebug("client session created, remote_server = %s, current_count = %d",
                client->remote_address().to_string(),
                scount);
+        _client_session_count->set(scount);
         client->connect();
     }
 
@@ -693,6 +699,8 @@ void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
            ecount == 1 ? "inserted" : "increased",
            s->remote_address().to_string(),
            ecount);
+
+    _client_session_count->set(scount);
 }
 
 void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr &s)
@@ -785,6 +793,7 @@ void connection_oriented_network::on_client_session_connected(rpc_session_ptr &s
         ddebug("client session connected, remote_server = %s, current_count = %d",
                s->remote_address().to_string(),
                scount);
+        _client_session_count->set(scount);
     }
 }
 
@@ -806,6 +815,7 @@ void connection_oriented_network::on_client_session_disconnected(rpc_session_ptr
         ddebug("client session disconnected, remote_server = %s, current_count = %d",
                s->remote_address().to_string(),
                scount);
+        _client_session_count->set(scount);
     }
 }
 


### PR DESCRIPTION
Add a perf counter to monitor the session kept on the server.
```
[server*network*client_session_count, NUMBER, 3.00]
[server*network*client_session_count, NUMBER, 4.00]
[server*network*client_session_count, NUMBER, 4.00]
[server*network*client_session_count, NUMBER, 4.00]
[server*network*client_session_count, NUMBER, 5.00]
[server*network*client_session_count, NUMBER, 14.00]
[server*network*client_session_count, NUMBER, 14.00]
[server*network*client_session_count, NUMBER, 4.00]
```