### PR TITLE
feat(bulk_load): add replica-level bulk load reject write counter

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -120,6 +120,10 @@ replica::replica(
     _counter_recent_write_splitting_reject_count.init_app_counter(
         "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
 
+    counter_str = fmt::format("recent.write.bulk.load.ingestion.reject.count@{}", gpid);
+    _counter_recent_write_bulk_load_ingestion_reject_count.init_app_counter(
+        "eon.replica", counter_str.c_str(), COUNTER_TYPE_VOLATILE_NUMBER, counter_str.c_str());
+
     // init table level latency perf counters
     init_table_level_latency_counters();
 

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -570,6 +570,7 @@ private:
     perf_counter_wrapper _counter_recent_backup_request_throttling_reject_count;
     perf_counter_wrapper _counter_recent_write_splitting_reject_count;
     perf_counter_wrapper _counter_recent_read_splitting_reject_count;
+    perf_counter_wrapper _counter_recent_write_bulk_load_ingestion_reject_count;
     std::vector<perf_counter *> _counters_table_level_latency;
     perf_counter_wrapper _counter_dup_disabled_non_idempotent_write_count;
     perf_counter_wrapper _counter_backup_request_qps;

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -109,7 +109,7 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
     if (_is_bulk_load_ingestion) {
         if (request->rpc_code() != dsn::apps::RPC_RRDB_RRDB_BULK_LOAD) {
             // reject write requests during ingestion
-            _stub->_counter_bulk_load_ingestion_reject_write_count->increment();
+            _counter_recent_write_bulk_load_ingestion_reject_count->increment();
             response_client_write(request, ERR_OPERATION_DISABLED);
         } else {
             response_client_write(request, ERR_NO_NEED_OPERATE);

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -379,11 +379,6 @@ void replica_stub::install_perf_counters()
                                                      "bulk.load.failed.count",
                                                      COUNTER_TYPE_VOLATILE_NUMBER,
                                                      "current bulk load failed count");
-    _counter_bulk_load_ingestion_reject_write_count.init_app_counter(
-        "eon.replica_stub",
-        "bulk.load.ingestion.reject.write.count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "bulk load ingestion reject write requests count");
     _counter_bulk_load_download_file_succ_count.init_app_counter(
         "eon.replica_stub",
         "bulk.load.download.file.success.count",

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -482,7 +482,6 @@ private:
     perf_counter_wrapper _counter_bulk_load_ingestion_count;
     perf_counter_wrapper _counter_bulk_load_succeed_count;
     perf_counter_wrapper _counter_bulk_load_failed_count;
-    perf_counter_wrapper _counter_bulk_load_ingestion_reject_write_count;
     perf_counter_wrapper _counter_bulk_load_download_file_succ_count;
     perf_counter_wrapper _counter_bulk_load_download_file_fail_count;
     perf_counter_wrapper _counter_bulk_load_download_file_size;


### PR DESCRIPTION
This pull request adds replica-level bulk load ingestion reject write counter, and remove the old stub-level counter.
```diff
+ replica*eon.replica*recent.write.bulk.load.ingestion.reject.count@[gpid] - VOLATILE_NUMBER
- replica_stub.bulk.load.ingestion.reject.write.count - VOLATILE_NUMBER
```