### PR TITLE
refactor: move reconfig from simple_load_balancer to partition_guardian

### DIFF
--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -30,6 +30,7 @@ public:
     ~partition_guardian() = default;
 
     pc_status cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);
+    void reconfig(meta_view view, const configuration_update_request &request);
     void register_ctrl_commands();
     void unregister_ctrl_commands();
 


### PR DESCRIPTION
simplely move function `reconfig`  from `simple_load_balancer` to `partition_guardian`, in order to remove `simple_load_balancer` later.

No code changed actually