### PR TITLE
refactor: move get_ddd_partitions from server_load_balancer to partition_guardian

### DIFF
--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -753,5 +753,27 @@ partition_guardian::ctrl_assign_secondary_black_list(const std::vector<std::stri
     _assign_secondary_black_list = std::move(addr_list);
     return "set ok";
 }
+
+void partition_guardian::get_ddd_partitions(const gpid &pid, std::vector<ddd_partition_info> &partitions)
+{
+    zauto_lock l(_ddd_partitions_lock);
+    if (pid.get_app_id() == -1) {
+        partitions.reserve(_ddd_partitions.size());
+        for (const auto &kv : _ddd_partitions) {
+            partitions.push_back(kv.second);
+        }
+    } else if (pid.get_partition_index() == -1) {
+        for (const auto &kv : _ddd_partitions) {
+            if (kv.first.get_app_id() == pid.get_app_id()) {
+                partitions.push_back(kv.second);
+            }
+        }
+    } else {
+        auto find = _ddd_partitions.find(pid);
+        if (find != _ddd_partitions.end()) {
+            partitions.push_back(find->second);
+        }
+    }
+}
 } // namespace replication
 } // namespace dsn

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -754,7 +754,8 @@ partition_guardian::ctrl_assign_secondary_black_list(const std::vector<std::stri
     return "set ok";
 }
 
-void partition_guardian::get_ddd_partitions(const gpid &pid, std::vector<ddd_partition_info> &partitions)
+void partition_guardian::get_ddd_partitions(const gpid &pid,
+                                            std::vector<ddd_partition_info> &partitions)
 {
     zauto_lock l(_ddd_partitions_lock);
     if (pid.get_app_id() == -1) {

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -33,6 +33,12 @@ public:
     void reconfig(meta_view view, const configuration_update_request &request);
     void register_ctrl_commands();
     void unregister_ctrl_commands();
+    void get_ddd_partitions(const gpid &pid, std::vector<ddd_partition_info> &partitions);
+    void clear_ddd_partitions()
+    {
+        zauto_lock l(_ddd_partitions_lock);
+        _ddd_partitions.clear();
+    }
 
 private:
     bool


### PR DESCRIPTION
simplely move function `get_ddd_partitions`  from `server_load_balancer` to `partition_guardian`. In order to simplify `server_load_balancer`

No code changed actually