### PR TITLE
fix: add virtual to destructor of partition_guardian

### DIFF
--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -38,6 +38,7 @@ public:
 
     virtual pc_status
     cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);
+
     void reconfig(meta_view view, const configuration_update_request &request);
     void register_ctrl_commands();
     void unregister_ctrl_commands();

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -34,7 +34,7 @@ public:
     typedef partition_guardian *(*factory)(meta_service *svc);
 
     explicit partition_guardian(meta_service *svc);
-    ~partition_guardian() = default;
+    virtual ~partition_guardian() = default;
 
     virtual pc_status
     cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -38,7 +38,6 @@ public:
 
     virtual pc_status
     cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);
-
     void reconfig(meta_view view, const configuration_update_request &request);
     void register_ctrl_commands();
     void unregister_ctrl_commands();


### PR DESCRIPTION
Because partition_guardian has a sub class, so we  need add virtual to dstor of partition_guardian