### PR TITLE
feat: support nfs server rate limit

### DIFF
--- a/include/dsn/http/http_server.h
+++ b/include/dsn/http/http_server.h
@@ -28,8 +28,7 @@ namespace dsn {
 DSN_DECLARE_bool(enable_http_server);
 
 /// The rpc code for all the HTTP RPCs.
-/// Since http is used only for system monitoring, it is restricted to lowest priority.
-DEFINE_TASK_CODE_RPC(RPC_HTTP_SERVICE, TASK_PRIORITY_LOW, THREAD_POOL_DEFAULT);
+DEFINE_TASK_CODE_RPC(RPC_HTTP_SERVICE, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT);
 
 enum http_method
 {

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -75,7 +75,7 @@ DSN_DEFINE_int32("nfs",
                  "maximum retry count when copy failed");
 DSN_DEFINE_int32("nfs",
                  rpc_timeout_ms,
-                 200000,
+                 100000,
                  "rpc timeout in milliseconds for nfs copy, "
                  "0 means use default timeout of rpc engine");
 

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -75,7 +75,7 @@ DSN_DEFINE_int32("nfs",
                  "maximum retry count when copy failed");
 DSN_DEFINE_int32("nfs",
                  rpc_timeout_ms,
-                 100000,
+                 1e5, // 100s
                  "rpc timeout in milliseconds for nfs copy, "
                  "0 means use default timeout of rpc engine");
 

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -75,7 +75,7 @@ DSN_DEFINE_int32("nfs",
                  "maximum retry count when copy failed");
 DSN_DEFINE_int32("nfs",
                  rpc_timeout_ms,
-                 10000,
+                 200000,
                  "rpc timeout in milliseconds for nfs copy, "
                  "0 means use default timeout of rpc engine");
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -36,7 +36,6 @@
 #include <sys/stat.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/tool-api/async_calls.h>
-#include <dsn/tool-api/command_manager.h>
 
 #include "nfs_server_impl.h"
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -44,6 +44,7 @@ namespace dsn {
 namespace service {
 
 DSN_DEFINE_int32("nfs", max_send_rate_megabytes, 50, "max rate of send to remote node(MB/s)");
+DSN_TAG_VARIABLE(max_send_rate_megabytes, FT_MUTABLE);
 
 DSN_DECLARE_int32(file_close_timer_interval_ms_on_server);
 DSN_DECLARE_int32(file_close_expire_time_ms);

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -37,11 +37,15 @@
 #include <sys/stat.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/tool-api/async_calls.h>
+#include <dsn/utility/singleton.h>
+#include <dsn/tool-api/command_manager.h>
 
 #include "nfs_server_impl.h"
 
 namespace dsn {
 namespace service {
+
+static uint32_t current_send_copy_rate_megabytes = 0;
 
 DSN_DEFINE_int32("nfs", max_send_rate_megabytes, 50, "max rate of send to remote node(MB/s)");
 DSN_TAG_VARIABLE(max_send_rate_megabytes, FT_MUTABLE);
@@ -67,7 +71,10 @@ nfs_service_impl::nfs_service_impl() : ::dsn::serverlet<nfs_service_impl>("nfs")
         COUNTER_TYPE_VOLATILE_NUMBER,
         "nfs server copy fail count count in the recent period");
 
-    _send_token_bucket = std::make_unique<folly::DynamicTokenBucket>();
+    _send_token_bucket = std::make_unique<TokenBucket>(FLAGS_max_send_rate_megabytes << 20,
+                                                       1.5 * (FLAGS_max_send_rate_megabytes << 20));
+    current_send_copy_rate_megabytes = FLAGS_max_send_rate_megabytes;
+    register_cli_commands();
 }
 
 void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
@@ -137,8 +144,7 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
 
 void nfs_service_impl::internal_read_callback(error_code err, size_t sz, callback_para &cp)
 {
-    _send_token_bucket->consumeWithBorrowAndWait(
-        sz, FLAGS_max_send_rate_megabytes << 20, 1.5 * (FLAGS_max_send_rate_megabytes << 20));
+    _send_token_bucket->consumeWithBorrowAndWait(sz);
     {
         zauto_lock l(_handles_map_lock);
         auto it = _handles_map.find(cp.file_path);
@@ -249,5 +255,41 @@ void nfs_service_impl::close_file() // release out-of-date file handle
             it++;
     }
 }
+
+void nfs_service_impl::register_cli_commands()
+{
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        _nfs_max_send_rate_megabytes_cmd = dsn::command_manager::instance().register_command(
+            {"nfs.max_send_rate_megabytes"},
+            "nfs.max_send_rate_megabytes [num | DEFAULT]",
+            "control the max rate(MB/s) to copy file from remote node",
+            [this](const std::vector<std::string> &args) {
+                std::string result("OK");
+
+                if (args.empty()) {
+                    return std::to_string(current_send_copy_rate_megabytes);
+                }
+
+                if (args[0] == "DEFAULT") {
+                    uint32_t max_send_rate_bytes = FLAGS_max_send_rate_megabytes << 20;
+                    _send_token_bucket->reset(max_send_rate_bytes, 1.5 * max_send_rate_bytes);
+                    current_send_copy_rate_megabytes = FLAGS_max_send_rate_megabytes;
+                    return result;
+                }
+
+                int32_t max_send_rate_megabytes = 0;
+                if (!dsn::buf2int32(args[0], max_send_rate_megabytes) ||
+                    max_send_rate_megabytes <= 0) {
+                    return std::string("ERR: invalid arguments");
+                }
+
+                _send_token_bucket->reset(max_send_rate_megabytes, 1.5 * max_send_rate_megabytes);
+                current_send_copy_rate_megabytes = max_send_rate_megabytes;
+                return result;
+            });
+    });
+}
+
 } // namespace service
 } // namespace dsn

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -284,7 +284,7 @@ void nfs_service_impl::register_cli_commands()
                     return std::string("ERR: invalid arguments");
                 }
 
-                _send_token_bucket->reset(max_send_rate_megabytes, 1.5 * max_send_rate_megabytes);
+                _send_token_bucket->reset(max_send_rate_megabytes << 20, 1.5 * (max_send_rate_megabytes <<20));
                 current_send_copy_rate_megabytes = max_send_rate_megabytes;
                 return result;
             });

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -33,11 +33,9 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 #include <cstdlib>
-#include <memory>
 #include <sys/stat.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/tool-api/async_calls.h>
-#include <dsn/utility/singleton.h>
 #include <dsn/tool-api/command_manager.h>
 
 #include "nfs_server_impl.h"

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -126,8 +126,7 @@ private:
 
     ::dsn::task_ptr _file_close_timer;
 
-    std::unique_ptr<folly::DynamicTokenBucket>
-        _send_token_bucket; // rate limiter of send to remote
+    std::unique_ptr<folly::DynamicTokenBucket> _send_token_bucket; // rate limiter of send to remote
 
     perf_counter_wrapper _recent_copy_data_size;
     perf_counter_wrapper _recent_copy_fail_count;

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -38,7 +38,6 @@
 
 namespace dsn {
 namespace service {
-
 class nfs_service_impl : public ::dsn::serverlet<nfs_service_impl>
 {
 public:

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -122,6 +122,9 @@ private:
 
     ::dsn::task_ptr _file_close_timer;
 
+    std::unique_ptr<folly::DynamicTokenBucket>
+        _send_token_bucket; // rate limiter of copy from remote
+
     perf_counter_wrapper _recent_copy_data_size;
     perf_counter_wrapper _recent_copy_fail_count;
 

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -127,7 +127,7 @@ private:
     ::dsn::task_ptr _file_close_timer;
 
     std::unique_ptr<folly::DynamicTokenBucket>
-        _send_token_bucket; // rate limiter of copy from remote
+        _send_token_bucket; // rate limiter of send to remote
 
     perf_counter_wrapper _recent_copy_data_size;
     perf_counter_wrapper _recent_copy_fail_count;

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -39,8 +39,6 @@
 namespace dsn {
 namespace service {
 
-using TokenBucket = folly::BasicTokenBucket<std::chrono::steady_clock>;
-
 class nfs_service_impl : public ::dsn::serverlet<nfs_service_impl>
 {
 public:
@@ -129,7 +127,8 @@ private:
 
     ::dsn::task_ptr _file_close_timer;
 
-    std::unique_ptr<folly::TokenBucket> _send_token_bucket; // rate limiter of copy from remote
+    std::unique_ptr<folly::DynamicTokenBucket>
+        _send_token_bucket; // rate limiter of copy from remote
 
     perf_counter_wrapper _recent_copy_data_size;
     perf_counter_wrapper _recent_copy_fail_count;


### PR DESCRIPTION
In some test, we found that the influence usually caused by nfs_server side under `learning` copy checkpoint. this pr support the nfs server send rate limit.

## Note
- limit server send rate may casuse the rpc timeout,so this pr update `nfs rpc timeout` from `10s` to `100s`
- update `max_send_rate` via admin-cli [server-config ](https://github.com/pegasus-kv/admin-cli/blob/main/cmd/server_config.go) may be block for a long time, this pr update the task priority
- for compatibility with `remote-command`, this pr support it too