### PR TITLE
feat(task): add dynamic control of task queue length

### DIFF
--- a/include/dsn/tool-api/task_queue.h
+++ b/include/dsn/tool-api/task_queue.h
@@ -38,6 +38,7 @@
 #include <dsn/tool-api/task.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <dsn/utility/dlib.h>
+#include <dsn/utility/flags.h>
 
 namespace dsn {
 
@@ -99,8 +100,10 @@ private:
     int _index;
     std::atomic<int> _queue_length;
     dsn::perf_counter_wrapper _queue_length_counter;
+    dsn::perf_counter_wrapper _delay_task_counter;
+    dsn::perf_counter_wrapper _reject_task_counter;
     threadpool_spec *_spec;
     volatile int _virtual_queue_length;
 };
 /*@}*/
-} // end namespace
+} // namespace dsn

--- a/include/dsn/tool-api/task_queue.h
+++ b/include/dsn/tool-api/task_queue.h
@@ -38,7 +38,6 @@
 #include <dsn/tool-api/task.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <dsn/utility/dlib.h>
-#include <dsn/utility/flags.h>
 
 namespace dsn {
 

--- a/src/runtime/task/task_engine.cpp
+++ b/src/runtime/task/task_engine.cpp
@@ -26,7 +26,6 @@
 
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/tool-api/command_manager.h>
-#include <dsn/tool-api/command_manager.h>
 #include <fmt/format.h>
 
 #include "task_engine.h"

--- a/src/runtime/task/task_engine.cpp
+++ b/src/runtime/task/task_engine.cpp
@@ -313,6 +313,7 @@ void task_engine::register_cli_commands()
                         continue;
                     }
                     if (it->_spec.pool_code.to_string() == args[0]) {
+                        // when args length is 1, return current value
                         if (args.size() == 1) {
                             return fmt::format("task queue {}, length {}",
                                                args[0],

--- a/src/runtime/task/task_engine.h
+++ b/src/runtime/task/task_engine.h
@@ -39,6 +39,7 @@
 #include <dsn/tool-api/task_queue.h>
 #include <dsn/tool-api/task_worker.h>
 #include <dsn/tool-api/timer_service.h>
+#include <dsn/tool-api/command_manager.h>
 
 namespace dsn {
 
@@ -80,6 +81,8 @@ public:
     std::vector<task_worker *> &workers() { return _workers; }
 
 private:
+    friend class task_engine;
+
     threadpool_spec _spec;
     task_engine *_owner;
     service_node *_node;
@@ -96,7 +99,11 @@ class task_engine
 {
 public:
     task_engine(service_node *node);
-    ~task_engine() { stop(); }
+    ~task_engine()
+    {
+        stop();
+        UNREGISTER_VALID_HANDLER(_task_queue_max_length_cmd);
+    }
 
     //
     // service management routines
@@ -122,11 +129,14 @@ public:
     void get_queue_info(/*out*/ std::stringstream &ss);
 
 private:
+    void register_cli_commands();
+
     std::vector<task_worker_pool *> _pools;
     volatile bool _is_running;
     service_node *_node;
+    dsn_handle_t _task_queue_max_length_cmd;
 };
 
 // -------------------- inline implementation ----------------------------
 
-} // end namespace
+} // namespace dsn

--- a/src/runtime/task/task_queue.cpp
+++ b/src/runtime/task/task_queue.cpp
@@ -87,7 +87,6 @@ void task_queue::enqueue_internal(task *task)
                 }
             }
         } else {
-            ;
             dbg_dassert(TM_REJECT == throttle_mode, "unknow mode %d", (int)throttle_mode);
 
             if (ac_value > _spec->queue_length_throttling_threshold) {

--- a/src/runtime/task/task_queue.cpp
+++ b/src/runtime/task/task_queue.cpp
@@ -27,6 +27,7 @@
 #include <dsn/tool-api/task_queue.h>
 #include "task_engine.h"
 #include <dsn/tool-api/network.h>
+#include <dsn/dist/fmt_logging.h>
 #include "runtime/rpc/rpc_engine.h"
 
 namespace dsn {
@@ -44,12 +45,26 @@ task_queue::task_queue(task_worker_pool *pool, int index, task_queue *inner_prov
                                               (_name + ".queue.length").c_str(),
                                               COUNTER_TYPE_NUMBER,
                                               "task queue length");
+    _delay_task_counter.init_global_counter(_pool->node()->full_name(),
+                                            "engine",
+                                            (_name + ".queue.delay_task").c_str(),
+                                            COUNTER_TYPE_VOLATILE_NUMBER,
+                                            "delay count of tasks before enqueue");
+    _reject_task_counter.init_global_counter(_pool->node()->full_name(),
+                                             "engine",
+                                             (_name + ".queue.reject_task").c_str(),
+                                             COUNTER_TYPE_VOLATILE_NUMBER,
+                                             "reject count of tasks before enqueue");
     _virtual_queue_length = 0;
     _spec = (threadpool_spec *)&pool->spec();
 }
 
 task_queue::~task_queue() = default;
 
+// This function is used to throttle tasks before they enter the queue
+// `queue_length_throttling_threshold` is configured by task pool
+// `throttling_mode` is configured by the specific task
+// Because not all tasks in the queue can handle the `ERR_BUSY` exception
 void task_queue::enqueue_internal(task *task)
 {
     auto &sp = task->spec();
@@ -68,26 +83,18 @@ void task_queue::enqueue_internal(task *task)
             if (delay_ms > 0) {
                 auto rtask = static_cast<rpc_request_task *>(task);
                 if (rtask->get_request()->io_session->delay_recv(delay_ms)) {
-                    dwarn("too many pending tasks (%d), delay traffic from %s for %d milliseconds",
-                          ac_value,
-                          rtask->get_request()->header->from_address.to_string(),
-                          delay_ms);
+                    _delay_task_counter->increment();
                 }
             }
         } else {
+            ;
             dbg_dassert(TM_REJECT == throttle_mode, "unknow mode %d", (int)throttle_mode);
 
             if (ac_value > _spec->queue_length_throttling_threshold) {
                 auto rtask = static_cast<rpc_request_task *>(task);
                 auto resp = rtask->get_request()->create_response();
                 task::get_current_rpc()->reply(resp, ERR_BUSY);
-
-                dwarn("too many pending tasks (%d), reject message from %s with trace_id = "
-                      "%016" PRIx64,
-                      ac_value,
-                      rtask->get_request()->header->from_address.to_string(),
-                      rtask->get_request()->header->trace_id);
-
+                _reject_task_counter->increment();
                 task->release_ref(); // added in task::enqueue(pool)
                 return;
             }


### PR DESCRIPTION
In some cases, we found the task queue will be blocked by a lot of tasks. So I add a parameter to control the max length of the task queue, in order to control the memory unlimited growing.

This PR provides two functions:
1. add a remote command to control the specific task queue length
2. add a perf counter to record the count of tasks delayed/rejected to enqueue.

remote_command help:
```
>>> remote_command -l 10.231.57.104:34801 task.queue_max_length help
COMMAND: task.queue_max_length help

CALL [user-specified] [10.231.57.104:34801] succeed: 
get/set the max task queue length of specific thread_pool, `INT_MAX` means no limit 
pool_code can be found by `remote_command -t replica-server system.queue`
task.queue_max_length <pool_code> [queue_max_length | INT_MAX] [queue_max_length]
```


get queue_max_length
```
>>> remote_command -l 10.231.57.104:34801 task.queue_max_length THREAD_POOL_LOCAL_APP
COMMAND: task.queue_max_length THREAD_POOL_LOCAL_APP

CALL [user-specified] [10.231.57.104:34801] succeed: task queue THREAD_POOL_LOCAL_APP, length 1000000
```

set queue_max_length
```
>>> remote_command -l 10.132.7.51:34801 task.queue_max_length THREAD_POOL_LOCAL_APP INT_MAX
COMMAND: task.queue_max_length THREAD_POOL_LOCAL_APP INT_MAX

CALL [user-specified] [10.132.7.51:34801] succeed: task queue THREAD_POOL_LOCAL_APP, length 2147483647
```

perf counter:
```
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 0.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 0.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 0.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 319.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 17589.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 21971.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 22302.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 22335.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 22298.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 22133.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 14868.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 0.00]
[replica*engine*local_app.0.queue.reject_task, VOLATILE_NUMBER, 0.00]

```

configure change:
```
// add rpc_request_throttling_mode for the specific rpc task
[task.RPC_RRDB_RRDB_PUT]
  is_profile = true
  profiler::size.request.server = true
  rpc_request_throttling_mode = TM_REJECT
```

Related issue: https://github.com/apache/incubator-pegasus/issues/812