### PR TITLE
feat: make secondary commit asynchronously

### DIFF
--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -79,6 +79,8 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     error_code err;
     switch (status) {
     case partition_status::PS_PRIMARY:
+    case partition_status::PS_SECONDARY:
+    case partition_status::PS_POTENTIAL_SECONDARY:
         // pop committed mutations if buffer is full or pop_all_committed_mutations = true
         while ((d - min_decree() >= capacity() || pop_all_committed_mutations) &&
                last_committed_decree() > min_decree()) {
@@ -86,35 +88,22 @@ error_code prepare_list::prepare(mutation_ptr &mu,
         }
         return mutation_cache::put(mu);
 
-    case partition_status::PS_SECONDARY:
-    case partition_status::PS_POTENTIAL_SECONDARY:
-        // all mutations with lower decree must be ready
-        commit(mu->data.header.last_committed_decree, COMMIT_TO_DECREE_HARD);
-        // pop committed mutations if buffer is full or pop_all_committed_mutations = true
-        while ((d - min_decree() >= capacity() || pop_all_committed_mutations) &&
-               last_committed_decree() > min_decree()) {
-            pop_min();
-        }
-        err = mutation_cache::put(mu);
-        dassert_replica(err == ERR_OK, "mutation_cache::put failed, err = {}", err);
-        return err;
-
-    //// delayed commit - only when capacity is an issue
-    // case partition_status::PS_POTENTIAL_SECONDARY:
-    //    while (true)
-    //    {
-    //        err = mutation_cache::put(mu);
-    //        if (err == ERR_CAPACITY_EXCEEDED)
-    //        {
-    //            dassert(mu->data.header.last_committed_decree >= min_decree(), "");
-    //            commit (min_decree(), true);
-    //            pop_min();
-    //        }
-    //        else
-    //            break;
-    //    }
-    //    dassert (err == ERR_OK, "");
-    //    return err;
+        //// delayed commit - only when capacity is an issue
+        // case partition_status::PS_POTENTIAL_SECONDARY:
+        //    while (true)
+        //    {
+        //        err = mutation_cache::put(mu);
+        //        if (err == ERR_CAPACITY_EXCEEDED)
+        //        {
+        //            dassert(mu->data.header.last_committed_decree >= min_decree(), "");
+        //            commit (min_decree(), true);
+        //            pop_min();
+        //        }
+        //        else
+        //            break;
+        //    }
+        //    dassert (err == ERR_OK, "");
+        //    return err;
 
     case partition_status::PS_INACTIVE: // only possible during init
         if (mu->data.header.last_committed_decree > max_decree()) {

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -569,6 +569,8 @@ void replica::on_append_log_completed(mutation_ptr &mu, error_code err, size_t s
             }
             // always ack
             ack_prepare_message(err, mu);
+            // all mutations with lower decree must be ready
+            _prepare_list->commit(mu->data.header.last_committed_decree, COMMIT_TO_DECREE_HARD);
             break;
         case partition_status::PS_PARTITION_SPLIT:
             if (err != ERR_OK) {

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -490,7 +490,8 @@ void replica::on_prepare(dsn::message_ex *request)
     error_code err = _prepare_list->prepare(mu, status());
     dassert(err == ERR_OK, "prepare mutation failed, err = %s", err.to_string());
 
-    if (partition_status::PS_POTENTIAL_SECONDARY == status()) {
+    if (partition_status::PS_POTENTIAL_SECONDARY == status() ||
+        partition_status::PS_SECONDARY == status()) {
         dassert(mu->data.header.decree <=
                     last_committed_decree() + _options->max_mutation_count_in_prepare_list,
                 "%" PRId64 " VS %" PRId64 "(%" PRId64 " + %d)",
@@ -498,13 +499,6 @@ void replica::on_prepare(dsn::message_ex *request)
                 last_committed_decree() + _options->max_mutation_count_in_prepare_list,
                 last_committed_decree(),
                 _options->max_mutation_count_in_prepare_list);
-    } else if (partition_status::PS_SECONDARY == status()) {
-        dassert(mu->data.header.decree <= last_committed_decree() + _options->staleness_for_commit,
-                "%" PRId64 " VS %" PRId64 "(%" PRId64 " + %d)",
-                mu->data.header.decree,
-                last_committed_decree() + _options->staleness_for_commit,
-                last_committed_decree(),
-                _options->staleness_for_commit);
     } else {
         derror("%s: mutation %s on_prepare failed as invalid replica state, state = %s",
                name(),

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 10
+max_mutation_count_in_prepare_list = 11
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 20
+max_mutation_count_in_prepare_list = 11
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 11
+max_mutation_count_in_prepare_list = 20
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 10
+max_mutation_count_in_prepare_list = 11
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 20
+max_mutation_count_in_prepare_list = 11
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 11
+max_mutation_count_in_prepare_list = 20
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 10
+max_mutation_count_in_prepare_list = 11
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 11
+max_mutation_count_in_prepare_list = 110
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 20
+max_mutation_count_in_prepare_list = 11
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 11
+max_mutation_count_in_prepare_list = 20
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false


### PR DESCRIPTION
Related issue: https://github.com/apache/incubator-pegasus/issues/796

## Manual Test

### insert data into app, and we can read it successfully
```
>>> set a b c 
OK

app_id          : 2
partition_index : 4
decree          : 5
server          : 10.231.57.100:34804
>>> get a b 
"c"

app_id          : 2
partition_index : 4
server          : 10.231.57.100:34804
```

### insert data into app, and kill the corresponding primary replica, then we can also read it successfully.
1. insert data
```
>>> set a b e
OK

app_id          : 2
partition_index : 4
decree          : 26
server          : 10.231.57.100:34804
```
2. kill the corresponding primary replica
```
➜  pegasus git:(master) ✗ kill 25092
```
3. read data
```
>>> get a b 
"e"

app_id          : 2
partition_index : 4
server          : 10.231.57.100:34803
```
### run the pegasus bench, and it can works well
```
➜  pegasus git:(master) ✗ ./run.sh bench
W2021-09-09 13:15:47.443 (1631164547443349845 24518) : overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
W2021-09-09 13:15:47.443 (1631164547443373357 24518) : overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX_ACK from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
Init pegasus succeed
Hashkeys:       16 bytes each
Sortkeys:       16 bytes each
Values:         100 bytes each
Entries:        10000
FileSize:       1 MB (estimated)
WARNING: Assertions are enabled; benchmarks unnecessarily slow
------------------------------------------------
Statistics for write:  
198.211 micros/op; 5045 ops/sec; 0.504512 MB/s 
Count: 10000 Average: 198.2074  StdDev: 186.58
Min: 134  Median: 156.2606  Max: 4104
Percentiles: P50: 156.26 P75: 195.50 P99: 1297.53 P99.9: 1844.90 P99.99: 1900.00
------------------------------------------------------
(     110,     170 ]     6485  64.850%  64.850% #############
(     170,     250 ]     3184  31.840%  96.690% ######
(     250,     380 ]       53   0.530%  97.220% 
(     380,     580 ]        4   0.040%  97.260% 
(     580,     870 ]        1   0.010%  97.270% 
(     870,    1300 ]      174   1.740%  99.010% 
(    1300,    1900 ]       98   0.980%  99.990% 
(    2900,    4400 ]        1   0.010% 100.000% 

Statistics for read:  
56.4356 micros/op; 17719 ops/sec; 1.77193 MB/s (10000 of 10000 found)
Count: 10000 Average: 56.4328  StdDev: 6.13
Min: 41  Median: 60.8794  Max: 191
Percentiles: P50: 60.88 P75: 68.57 P99: 75.95 P99.9: 106.68 P99.99: 170.00
------------------------------------------------------
(      34,      51 ]     1788  17.880%  17.880% ####
(      51,      76 ]     8128  81.280%  99.160% ################
(      76,     110 ]       82   0.820%  99.980% 
(     110,     170 ]        1   0.010%  99.990% 
(     170,     250 ]        1   0.010% 100.000% 

Statistics for delete:  
167.636 micros/op; 5965 ops/sec; 
Count: 10000 Average: 167.6319  StdDev: 14.35
Min: 136  Median: 155.4339  Max: 432
Percentiles: P50: 155.43 P75: 191.30 P99: 248.29 P99.9: 336.67 P99.99: 380.00
------------------------------------------------------
(     110,     170 ]     6603  66.030%  66.030% #############
(     170,     250 ]     3369  33.690%  99.720% #######
(     250,     380 ]       27   0.270%  99.990% 
(     380,     580 ]        1   0.010% 100.000% 
```
### learn test
1. start onebox 
```
./run.sh start_onebox -r 4 -m 3
```
2. restore a app from fds
```
restore_app -c c3srv-stat2 -a stat -i 3 -t 1629710303553 -b fds_c3
```
3. kill one replica server, and the app becomes unhealth
```
>>> ls -d
[general_info]
app_id  status     app_name  app_type  partition_count  replica_count  is_stateful  create_time          drop_time  drop_expire  envs_count  
2       AVAILABLE  temp      pegasus   8                3              true         2021-09-14_12:22:12  -          -            0           
3       AVAILABLE  stat      pegasus   8                3              true         2019-06-27_15:48:22  -          -            6           
4       AVAILABLE  test      pegasus   4                3              true         2021-09-14_12:25:16  -          -            0           

[healthy_info]
app_id  app_name  partition_count  fully_healthy  unhealthy  write_unhealthy  read_unhealthy  
2       temp      8                1              7          0                0               
3       stat      8                2              6          0                0               
4       test      4                4              0          0                0               

[summary]
total_app_count            : 3
fully_healthy_app_count    : 1
unhealthy_app_count        : 2
write_unhealthy_app_count  : 0
read_unhealthy_app_count   : 0

```
4. wait serveral minutes, and the app becomes health
```
>>> ls -d
[general_info]
app_id  status     app_name  app_type  partition_count  replica_count  is_stateful  create_time          drop_time  drop_expire  envs_count  
2       AVAILABLE  temp      pegasus   8                3              true         2021-09-14_12:22:12  -          -            0           
3       AVAILABLE  stat      pegasus   8                3              true         2019-06-27_15:48:22  -          -            6           
4       AVAILABLE  test      pegasus   4                3              true         2021-09-14_12:25:16  -          -            0           

[healthy_info]
app_id  app_name  partition_count  fully_healthy  unhealthy  write_unhealthy  read_unhealthy  
2       temp      8                8              0          0                0               
3       stat      8                8              0          0                0               
4       test      4                4              0          0                0               

[summary]
total_app_count            : 3
fully_healthy_app_count    : 3
unhealthy_app_count        : 0
write_unhealthy_app_count  : 0
read_unhealthy_app_count   : 0
```

```
>>> app stat -d
[parameters]
app_name  : stat
detailed  : true

[general]
app_name           : stat
app_id             : 3   
partition_count    : 8   
max_replica_count  : 3   

[replicas]
pidx  ballot  replica_count  primary              secondaries                                
0     3       3/3            10.231.57.100:34804  [10.231.57.100:34801,10.231.57.100:34803]  
1     6       3/3            10.231.57.100:34801  [10.231.57.100:34804,10.231.57.100:34803]  
2     5       3/3            10.231.57.100:34803  [10.231.57.100:34804,10.231.57.100:34801]  
3     5       3/3            10.231.57.100:34801  [10.231.57.100:34803,10.231.57.100:34804]  
4     5       3/3            10.231.57.100:34804  [10.231.57.100:34803,10.231.57.100:34801]  
5     6       3/3            10.231.57.100:34803  [10.231.57.100:34801,10.231.57.100:34804]  
6     5       3/3            10.231.57.100:34803  [10.231.57.100:34804,10.231.57.100:34801]  
7     3       3/3            10.231.57.100:34801  [10.231.57.100:34804,10.231.57.100:34803]  

[nodes]
node                 primary  secondary  total  
10.231.57.100:34801  3        5          8      
10.231.57.100:34803  3        5          8      
10.231.57.100:34804  2        6          8      
                     8        16         24     

[healthy]
fully_healthy_partition_count    : 8
unhealthy_partition_count        : 0
write_unhealthy_partition_count  : 0
read_unhealthy_partition_count   : 0
```

### Performance

***Secondary commit synchronously***
```
+--------------------------+----------+------------+--------+------------+--------------+--------------------------------------------------+------------------------------------------------+
|      operation_case      | run_time | throughput | length | read_write | thread_count |       read(qps|ave|min|max|95|99|999|9999)       |     write(qps|ave|min|max|95|99|999|9999)      |
+--------------------------+----------+------------+--------+------------+--------------+--------------------------------------------------+------------------------------------------------+
| write=single,read=single | 12078    | 24836      | 1000   | 0 : 1      | 15           | {0 0 0 0 0 0 0 0}                                | {24838 1809 364 421887 4771 9625 22431 37257}  |
| write=single,read=single | 3573     | 252579     | 1000   | 1 : 0      | 50           | {252612 592 120 454228 907 2677 21049 35241}     | {0 0 0 0 0 0 0 0}                              |
| write=single,read=single | 5232     | 45873      | 1000   | 1 : 1      | 30           | {22936 1417 122 1286825 5772 19647 82175 126548} | {22941 2497 360 419668 6580 12825 38297 71455} |
| write=single,read=single | 4727     | 31725      | 1000   | 1 : 3      | 15           | {7931 1019 128 767828 3065 14625 71007 115519}   | {23798 1546 375 562260 3593 8711 22116 35956}  |
| write=single,read=single | 3156     | 28514      | 1000   | 1 : 30     | 15           | {918 1018 153 771753 2934 13724 73289 132095}    | {27598 1592 379 209257 3375 7884 19196 28420}  |
| write=single,read=single | 3851     | 77918      | 1000   | 3 : 1      | 30           | {58448 837 121 558932 2774 9271 35791 57652}     | {19482 2094 375 334505 4969 10004 31188 55327} |
| write=single,read=single | 4321     | 208651     | 1000   | 30 : 1     | 50           | {201937 692 116 350249 1483 3899 25823 38681}    | {6729 1427 413 249791 2329 5619 29855 42457}   |
+--------------------------+----------+------------+--------+------------+--------------+--------------------------------------------------+------------------------------------------------+
```

***Secondary commit asynchronously***

```
+--------------------------+----------+------------+--------+------------+--------------+-------------------------------------------------+------------------------------------------------+
|      operation_case      | run_time | throughput | length | read_write | thread_count |      read(qps|ave|min|max|95|99|999|9999)       |     write(qps|ave|min|max|95|99|999|9999)      |
+--------------------------+----------+------------+--------+------------+--------------+-------------------------------------------------+------------------------------------------------+
| write=single,read=single | 11836    | 25345      | 1000   | 0 : 1      | 15           | {0 0 0 0 0 0 0 0}                               | {25345 1772 362 434345 4879 9855 22319 35668}  |
| write=single,read=single | 3954     | 233521     | 1000   | 1 : 0      | 50           | {233547 656 118 440916 1051 2389 20693 44617}   | {0 0 0 0 0 0 0 0}                              |
| write=single,read=single | 5168     | 46438      | 1000   | 1 : 1      | 30           | {23221 1437 121 827561 6041 19663 80628 128127} | {23219 2429 361 475391 6576 12737 37332 68447} |
| write=single,read=single | 4590     | 32677      | 1000   | 1 : 3      | 15           | {8169 1125 127 1032532 3465 16065 79433 129215} | {24513 1456 363 396372 3513 8313 21089 33337}  |
| write=single,read=single | 3075     | 29261      | 1000   | 1 : 30     | 15           | {944 1131 153 962217 3188 15113 96127 172927}   | {28318 1547 354 305748 3465 8097 18831 27615}  |
| write=single,read=single | 3861     | 77725      | 1000   | 3 : 1      | 30           | {58298 882 121 341503 2899 9572 38393 61748}    | {19437 1972 367 411647 4845 9873 31892 57919}  |
| write=single,read=single | 4279     | 210908     | 1000   | 30 : 1     | 50           | {204129 690 118 218964 1497 3921 18049 29540}   | {6803 1266 395 167359 2157 5423 19628 30623}   |
+--------------------------+----------+------------+--------+------------+--------------+-------------------------------------------------+------------------------------------------------+
```

In most cases, the write performance(avg/p9999) is improved by 5% to 28%