### PR TITLE
feat: support to set/get dirty_decay_ms and muzzy_decay_ms for jemalloc

### DIFF
--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -304,6 +304,8 @@ private:
     // Try to release tcmalloc memory back to operating system
     // If release_all = true, it will release all reserved-not-used memory
     uint64_t gc_tcmalloc_memory(bool release_all);
+#elif defined(DSN_USE_JEMALLOC)
+    void register_jemalloc_ctrl_command();
 #endif
 
 private:
@@ -375,6 +377,9 @@ private:
     dsn_handle_t _get_tcmalloc_status_command;
     dsn_handle_t _max_reserved_memory_percentage_command;
     dsn_handle_t _release_all_reserved_memory_command;
+#elif defined(DSN_USE_JEMALLOC)
+    dsn_handle_t _set_jemalloc_arena_dirty_decay_ms_command;
+    dsn_handle_t _set_jemalloc_arena_muzzy_decay_ms_command;
 #endif
     dsn_handle_t _max_concurrent_bulk_load_downloading_count_command;
 

--- a/src/utils/je_ctl.cpp
+++ b/src/utils/je_ctl.cpp
@@ -1,0 +1,237 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifdef DSN_USE_JEMALLOC
+
+#include "je_ctl.h"
+
+#include <cstring>
+#include <dsn/c/api_utilities.h>
+#include <dsn/dist/fmt_logging.h>
+#include <dsn/utility/ports.h>
+
+namespace dsn {
+namespace utils {
+
+static bool je_check_err(const char *action, int err, std::string *err_msg)
+{
+    std::string msg;
+    if (dsn_likely(err == 0)) {
+        msg = fmt::format("{} successfully", action);
+    } else {
+        msg = fmt::format(
+            "failed to {}: errno={}, message={}", action, err, dsn::utils::safe_strerror(err));
+    }
+
+    ddebug_f("<jemalloc> {}", msg);
+
+    if (err_msg != nullptr) {
+        *err_msg = std::move(msg);
+    }
+
+    return err == 0;
+}
+
+template <typename T>
+static inline bool je_check_set_err(const char *name, T val, int err, std::string *err_msg)
+{
+    std::string action(fmt::format("set {} to {}", name, val));
+    return je_check_err(action.c_str(), err, err_msg);
+}
+
+template <typename T>
+static inline bool je_set_num(const char *name, T val, std::string *err_msg)
+{
+    int je_ret = mallctl(name, nullptr, nullptr, &val, sizeof(val));
+    return je_check_set_err(name, val, je_ret, err_msg);
+}
+
+static inline bool je_check_get_err(const char *name, int err, std::string *err_msg)
+{
+    std::string action(fmt::format("get {}", name));
+    return je_check_err(action.c_str(), err, err_msg);
+}
+
+template <typename T>
+static inline bool je_get_num(const char *name, T &val, std::string *err_msg)
+{
+    size_t sz = sizeof(val);
+    int je_ret = mallctl(name, &val, &sz, nullptr, 0);
+    return je_check_get_err(name, je_ret, err_msg);
+}
+
+static inline bool je_get_narenas(unsigned &narenas, std::string *err_msg)
+{
+    return je_get_num("arenas.narenas", narenas, err_msg);
+}
+
+static inline std::string build_arena_name(unsigned index, const char *sub_name)
+{
+    return fmt::format("arena.{}.{}", index, sub_name);
+}
+
+#define CHECK_ARENA_INDEX_OUT_OF_RANGE(index, err_msg)                                             \
+    do {                                                                                           \
+        unsigned narenas = 0;                                                                      \
+        if (!je_get_narenas(narenas, err_msg)) {                                                   \
+            return false;                                                                          \
+        }                                                                                          \
+        if (index >= narenas) {                                                                    \
+            *err_msg = fmt::format(                                                                \
+                "<jemalloc> arena index out of range: index = {}, narenas = {}", index, narenas);  \
+            return false;                                                                          \
+        }                                                                                          \
+    } while (0)
+
+template <typename T>
+static inline bool
+je_set_arena_num(unsigned index, const char *sub_name, T val, std::string *err_msg)
+{
+    CHECK_ARENA_INDEX_OUT_OF_RANGE(index, err_msg);
+
+    std::string name(build_arena_name(index, sub_name));
+    return je_set_num(name.c_str(), val, err_msg);
+}
+
+template <typename T>
+static inline bool
+je_get_arena_num(unsigned index, const char *sub_name, T &val, std::string *err_msg)
+{
+    CHECK_ARENA_INDEX_OUT_OF_RANGE(index, err_msg);
+
+    std::string name(build_arena_name(index, sub_name));
+    return je_get_num(name.c_str(), val, err_msg);
+}
+
+template <typename T>
+static bool je_set_all_arenas_num(const char *sub_name, T val, std::string *err_msg)
+{
+    unsigned narenas = 0;
+    if (!je_get_narenas(narenas, err_msg)) {
+        return false;
+    }
+
+    for (unsigned i = 0; i < narenas; ++i) {
+        if (!je_set_arena_num(i, sub_name, val, err_msg)) {
+            return false;
+        }
+    }
+
+    *err_msg = fmt::format("set {} for all arenas successfully", sub_name);
+    return true;
+}
+
+template <typename T>
+static bool je_get_all_arenas_num(const char *sub_name, std::vector<T> &nums, std::string *err_msg)
+{
+    unsigned narenas = 0;
+    if (!je_get_narenas(narenas, err_msg)) {
+        return false;
+    }
+
+    nums.clear();
+    nums.reserve(narenas);
+    for (unsigned i = 0; i < narenas; ++i) {
+        T val;
+        if (!je_get_arena_num(i, sub_name, val, err_msg)) {
+            return false;
+        }
+        nums.push_back(val);
+    }
+
+    *err_msg = fmt::format("get {} for all arenas successfully", sub_name);
+    return true;
+}
+
+template <typename T>
+static bool je_get_arena_num_info(unsigned index, const char *sub_name, std::string *info)
+{
+    T num;
+    if (!je_get_arena_num(index, sub_name, num, info)) {
+        return false;
+    }
+
+    info->append(fmt::format("\narena[{}]: {}", index, num));
+    return true;
+}
+
+template <typename T>
+static bool je_get_all_arenas_num_info(const char *sub_name, std::string *info)
+{
+    std::vector<T> nums;
+    if (!je_get_all_arenas_num(sub_name, nums, info)) {
+        return false;
+    }
+
+    for (size_t i = 0; i < nums.size(); ++i) {
+        info->append(fmt::format("\narena[{}]: {}", i, nums[i]));
+    }
+    return true;
+}
+
+static const char *je_decay_state_to_ms_name(je_decay_state state)
+{
+    static const char *name_map[] = {
+        "dirty_decay_ms", "muzzy_decay_ms",
+    };
+
+    dassert_f(state < sizeof(name_map) / sizeof(name_map[0]), "invalid je_decay_state: {}", state);
+    return name_map[state];
+}
+
+bool je_set_arena_decay_ms(unsigned index,
+                           je_decay_state decay_state,
+                           ssize_t decay_ms,
+                           std::string *err_msg)
+{
+    return je_set_arena_num(index, je_decay_state_to_ms_name(decay_state), decay_ms, err_msg);
+}
+
+bool je_set_all_arenas_decay_ms(je_decay_state decay_state, ssize_t decay_ms, std::string *err_msg)
+{
+    return je_set_all_arenas_num(je_decay_state_to_ms_name(decay_state), decay_ms, err_msg);
+}
+
+bool je_get_arena_decay_ms(unsigned index,
+                           je_decay_state decay_state,
+                           ssize_t &decay_ms,
+                           std::string *err_msg)
+{
+    return je_get_arena_num(index, je_decay_state_to_ms_name(decay_state), decay_ms, err_msg);
+}
+
+bool je_get_all_arenas_decay_ms(je_decay_state decay_state,
+                                std::vector<ssize_t> &decay_ms_list,
+                                std::string *err_msg)
+{
+    return je_get_all_arenas_num(je_decay_state_to_ms_name(decay_state), decay_ms_list, err_msg);
+}
+
+bool je_get_arena_decay_ms_info(unsigned index, je_decay_state decay_state, std::string *info)
+{
+    return je_get_arena_num_info<ssize_t>(index, je_decay_state_to_ms_name(decay_state), info);
+}
+
+bool je_get_all_arenas_decay_ms_info(je_decay_state decay_state, std::string *info)
+{
+    return je_get_all_arenas_num_info<ssize_t>(je_decay_state_to_ms_name(decay_state), info);
+}
+
+} // namespace utils
+} // namespace dsn
+
+#endif // DSN_USE_JEMALLOC

--- a/src/utils/je_ctl.h
+++ b/src/utils/je_ctl.h
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#ifdef DSN_USE_JEMALLOC
+
+#include <cstdio>
+#include <dsn/utility/safe_strerror_posix.h>
+#include <fmt/format.h>
+#include <jemalloc/jemalloc.h>
+#include <string>
+#include <vector>
+
+namespace dsn {
+namespace utils {
+
+enum je_decay_state
+{
+    JE_DIRTY_DECAY = 0,
+    JE_MUZZY_DECAY = 1,
+};
+
+bool je_set_arena_decay_ms(unsigned index,
+                           je_decay_state decay_state,
+                           ssize_t decay_ms,
+                           std::string *err_msg);
+
+bool je_set_all_arenas_decay_ms(je_decay_state decay_state, ssize_t decay_ms, std::string *err_msg);
+
+bool je_get_arena_decay_ms(unsigned index,
+                           je_decay_state decay_state,
+                           ssize_t &decay_ms,
+                           std::string *err_msg);
+
+bool je_get_all_arenas_decay_ms(je_decay_state decay_state,
+                                std::vector<ssize_t> &decay_ms_list,
+                                std::string *err_msg);
+
+bool je_get_arena_decay_ms_info(unsigned index, je_decay_state decay_state, std::string *info);
+
+bool je_get_all_arenas_decay_ms_info(je_decay_state decay_state, std::string *info);
+
+} // namespace utils
+} // namespace dsn
+
+#endif // DSN_USE_JEMALLOC


### PR DESCRIPTION
In jemalloc, there are 2 important options for the two-phase, decay-based purging, with each option corresponding to a phase. They are:

- [dirty_decay_ms](http://jemalloc.net/jemalloc.3.html#arena.i.dirty_decay_ms) (from state `dirty` to `muzzy`)
- [muzzy_decay_ms](http://jemalloc.net/jemalloc.3.html#arena.i.muzzy_decay_ms) (from state `muzzy` to `clean`)

And this PR will provide 2 remote commands to set/get each option. The 2 commands's format are as below:
```
replica.set-jemalloc-arena-dirty-decay-ms <arena_index | ALL> [decay_ms | DEFAULT | DISABLE]
replica.set-jemalloc-arena-muzzy-decay-ms <arena_index | ALL> [decay_ms | DEFAULT | DISABLE]
```


Actually, the arguments of the 2 commands are exactly the same.

The 1st argument is a `arena_index` or `ALL`. Suppose that the number of arenas is `n`, then the range of `arena_index` is [0, n). `ALL` means setting/getting for all arenas.

The 2nd argument is a `decay_ms`, `DEFAULT`, or `DISABLE`. Just as its name implies, `decay_ms` means the numerical value of `dirty_decay_ms` or `muzzy_decay_ms`, whose unit is milliseconds. The value is valid only if it's equal or more than 0.
Or it is either of the following values:

- `DEFAULT`: for `dirty_decay_ms`, the value is 10000, namely 10 seconds; for `muzzy_decay_ms`, the value is 0, which means immediately purging once dirty/muzzy pages are created.
- `DISABLE`: for both `dirty_decay_ms` and `muzzy_decay_ms`, the value is -1, which means disabling purging.