### PR TITLE
feat: support single replica

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -128,8 +128,8 @@ dsn::error_code replication_ddl_client::create_app(const std::string &app_name,
         return ERR_INVALID_PARAMETERS;
     }
 
-    if (replica_count < 2) {
-        std::cout << "create app " << app_name << " failed: replica_count should >= 2" << std::endl;
+    if (replica_count < 1) {
+        std::cout << "create app " << app_name << " failed: replica_count should >= 1" << std::endl;
         return ERR_INVALID_PARAMETERS;
     }
 

--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -34,8 +34,18 @@
  */
 #include "meta_options.h"
 
+#include <dsn/utility/flags.h>
+
 namespace dsn {
 namespace replication {
+
+DSN_DEFINE_uint64("meta_server",
+                  min_live_node_count_for_unfreeze,
+                  3,
+                  "minimum live node count without which the state is freezed");
+DSN_TAG_VARIABLE(min_live_node_count_for_unfreeze, FT_MUTABLE);
+DSN_DEFINE_validator(min_live_node_count_for_unfreeze,
+                     [](uint64_t min_live_node_count) -> bool { return min_live_node_count > 0; });
 
 std::string meta_options::concat_path_unix_style(const std::string &prefix,
                                                  const std::string &postfix)
@@ -72,11 +82,7 @@ void meta_options::initialize()
         "if live_node_count * 100 < total_node_count * node_live_percentage_threshold_for_update, "
         "then freeze the cluster; default is 65");
 
-    min_live_node_count_for_unfreeze =
-        dsn_config_get_value_uint64("meta_server",
-                                    "min_live_node_count_for_unfreeze",
-                                    3,
-                                    "minimum live node count without which the state is freezed");
+    min_live_node_count_for_unfreeze = FLAGS_min_live_node_count_for_unfreeze;
 
     meta_function_level_on_start = meta_function_level::fl_invalid;
     const char *level_str = dsn_config_get_value_string(


### PR DESCRIPTION
As is well known, it's not reliable enough for most replication protocols that a table has only one replica, or just two replicas. However, considering the cost, some of our customers choose to set single replica, or double replicas for a table.

In fact, [PacificA Protocol](https://www.microsoft.com/en-us/research/wp-content/uploads/2008/02/tr-2008-25.pdf) can support single replica or double replicas well. Therefore, to support single replica, we can just eliminate the restriction while creating a table.

On the other hand, as described in https://github.com/apache/incubator-pegasus/issues/820, now `greedy_load_balancer` cannot support single replica or double replicas well, since if a cluster has only one replica server, or two replica servers, meta server will core dump. By this PR,  meta server will run normally when a cluster a cluster has one or two replica servers, especially when `min_live_node_count_for_unfreeze` is set to 1.