### PR TITLE
refactor: remove class cluster_balance_type which is duplicated

### DIFF
--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -49,6 +49,7 @@ enum class balance_type
 ENUM_BEGIN(balance_type, balance_type::INVALID)
 ENUM_REG(balance_type::COPY_PRIMARY)
 ENUM_REG(balance_type::COPY_SECONDARY)
+ENUM_REG(balance_type::MOVE_PRIMARY)
 ENUM_END(balance_type)
 
 uint32_t get_partition_count(const node_state &ns, balance_type type, int32_t app_id);

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -39,26 +39,19 @@
 
 namespace dsn {
 namespace replication {
-enum class cluster_balance_type
+enum class balance_type
 {
     COPY_PRIMARY = 0,
     COPY_SECONDARY,
+    MOVE_PRIMARY,
     INVALID,
 };
-ENUM_BEGIN(cluster_balance_type, cluster_balance_type::INVALID)
-ENUM_REG(cluster_balance_type::COPY_PRIMARY)
-ENUM_REG(cluster_balance_type::COPY_SECONDARY)
-ENUM_END(cluster_balance_type)
+ENUM_BEGIN(balance_type, balance_type::INVALID)
+ENUM_REG(balance_type::COPY_PRIMARY)
+ENUM_REG(balance_type::COPY_SECONDARY)
+ENUM_END(balance_type)
 
-// TODO: combine with cluster_balance_type
-enum class balance_type
-{
-    move_primary,
-    copy_primary,
-    copy_secondary
-};
-
-uint32_t get_partition_count(const node_state &ns, cluster_balance_type type, int32_t app_id);
+uint32_t get_partition_count(const node_state &ns, balance_type type, int32_t app_id);
 uint32_t get_skew(const std::map<rpc_address, uint32_t> &count_map);
 void get_min_max_set(const std::map<rpc_address, uint32_t> &node_count_map,
                      /*out*/ std::set<rpc_address> &min_set,
@@ -270,11 +263,11 @@ private:
     void balance_cluster();
 
     bool cluster_replica_balance(const meta_view *global_view,
-                                 const cluster_balance_type type,
+                                 const balance_type type,
                                  /*out*/ migration_list &list);
 
     bool do_cluster_replica_balance(const meta_view *global_view,
-                                    const cluster_balance_type type,
+                                    const balance_type type,
                                     /*out*/ migration_list &list);
 
     struct app_migration_info
@@ -322,7 +315,7 @@ private:
 
     struct cluster_migration_info
     {
-        cluster_balance_type type;
+        balance_type type;
         std::map<int32_t, uint32_t> apps_skew;
         std::map<int32_t, app_migration_info> apps_info;
         std::map<rpc_address, node_migration_info> nodes_info;
@@ -339,12 +332,12 @@ private:
     };
 
     bool get_cluster_migration_info(const meta_view *global_view,
-                                    const cluster_balance_type type,
+                                    const balance_type type,
                                     /*out*/ cluster_migration_info &cluster_info);
 
     bool get_app_migration_info(std::shared_ptr<app_state> app,
                                 const node_mapper &nodes,
-                                const cluster_balance_type type,
+                                const balance_type type,
                                 /*out*/ app_migration_info &info);
 
     void get_node_migration_info(const node_state &ns,

--- a/src/meta/test/copy_replica_operation_test.cpp
+++ b/src/meta/test/copy_replica_operation_test.cpp
@@ -262,7 +262,7 @@ TEST(copy_secondary_operation, misc)
     /**
      * Test copy_secondary_operation::get_balance_type
      */
-    ASSERT_EQ(op.get_balance_type(), balance_type::copy_secondary);
+    ASSERT_EQ(op.get_balance_type(), balance_type::COPY_SECONDARY);
 
     /**
      * Test copy_secondary_operation::only_copy_primary

--- a/src/meta/test/greedy_load_balancer_test.cpp
+++ b/src/meta/test/greedy_load_balancer_test.cpp
@@ -72,9 +72,7 @@ TEST(greedy_load_balancer, node_migration_info)
 TEST(greedy_load_balancer, get_skew)
 {
     std::map<rpc_address, uint32_t> count_map = {
-        {rpc_address(1, 10086), 1},
-        {rpc_address(2, 10086), 3},
-        {rpc_address(3, 10086), 5},
+        {rpc_address(1, 10086), 1}, {rpc_address(2, 10086), 3}, {rpc_address(3, 10086), 5},
     };
 
     ASSERT_EQ(get_skew(count_map), count_map.rbegin()->second - count_map.begin()->second);

--- a/src/meta/test/greedy_load_balancer_test.cpp
+++ b/src/meta/test/greedy_load_balancer_test.cpp
@@ -72,7 +72,9 @@ TEST(greedy_load_balancer, node_migration_info)
 TEST(greedy_load_balancer, get_skew)
 {
     std::map<rpc_address, uint32_t> count_map = {
-        {rpc_address(1, 10086), 1}, {rpc_address(2, 10086), 3}, {rpc_address(3, 10086), 5},
+        {rpc_address(1, 10086), 1},
+        {rpc_address(2, 10086), 3},
+        {rpc_address(3, 10086), 5},
     };
 
     ASSERT_EQ(get_skew(count_map), count_map.rbegin()->second - count_map.begin()->second);
@@ -87,8 +89,8 @@ TEST(greedy_load_balancer, get_partition_count)
     ns.put_partition(gpid(apid, 2), false);
     ns.put_partition(gpid(apid, 3), false);
 
-    ASSERT_EQ(get_partition_count(ns, cluster_balance_type::COPY_PRIMARY, apid), 1);
-    ASSERT_EQ(get_partition_count(ns, cluster_balance_type::COPY_SECONDARY, apid), 3);
+    ASSERT_EQ(get_partition_count(ns, balance_type::COPY_PRIMARY, apid), 1);
+    ASSERT_EQ(get_partition_count(ns, balance_type::COPY_SECONDARY, apid), 3);
 }
 
 TEST(greedy_load_balancer, get_app_migration_info)
@@ -114,15 +116,15 @@ TEST(greedy_load_balancer, get_app_migration_info)
     greedy_load_balancer::app_migration_info migration_info;
     {
         app->partitions[0].max_replica_count = 100;
-        auto res = balancer.get_app_migration_info(
-            app, nodes, cluster_balance_type::COPY_PRIMARY, migration_info);
+        auto res =
+            balancer.get_app_migration_info(app, nodes, balance_type::COPY_PRIMARY, migration_info);
         ASSERT_FALSE(res);
     }
 
     {
         app->partitions[0].max_replica_count = 1;
-        auto res = balancer.get_app_migration_info(
-            app, nodes, cluster_balance_type::COPY_PRIMARY, migration_info);
+        auto res =
+            balancer.get_app_migration_info(app, nodes, balance_type::COPY_PRIMARY, migration_info);
         ASSERT_TRUE(res);
         ASSERT_EQ(migration_info.app_id, appid);
         ASSERT_EQ(migration_info.app_name, appname);
@@ -216,7 +218,7 @@ TEST(greedy_load_balancer, get_disk_partitions_map)
     node_info.partitions[disk_tag] = partitions;
     cluster_info.nodes_info[addr] = node_info;
 
-    cluster_info.type = cluster_balance_type::COPY_SECONDARY;
+    cluster_info.type = balance_type::COPY_SECONDARY;
     disk_partitions = balancer.get_disk_partitions_map(cluster_info, addr, app_id);
     ASSERT_EQ(disk_partitions.size(), 1);
     ASSERT_EQ(disk_partitions.count(disk_tag), 1);
@@ -227,7 +229,7 @@ TEST(greedy_load_balancer, get_disk_partitions_map)
 TEST(greedy_load_balancer, get_max_load_disk)
 {
     greedy_load_balancer::cluster_migration_info cluster_info;
-    cluster_info.type = cluster_balance_type::COPY_SECONDARY;
+    cluster_info.type = balance_type::COPY_SECONDARY;
 
     rpc_address addr(1, 10086);
     int32_t app_id = 1;
@@ -273,7 +275,7 @@ TEST(greedy_load_balancer, apply_move)
     minfo.source_disk_tag = disk_tag;
     rpc_address target_node(2, 10086);
     minfo.target_node = target_node;
-    minfo.type = balance_type::move_primary;
+    minfo.type = balance_type::MOVE_PRIMARY;
 
     node_mapper nodes;
     app_mapper apps;
@@ -284,7 +286,7 @@ TEST(greedy_load_balancer, apply_move)
     greedy_load_balancer balancer(nullptr);
     balancer.t_global_view = &view;
     greedy_load_balancer::cluster_migration_info cluster_info;
-    cluster_info.type = cluster_balance_type::COPY_SECONDARY;
+    cluster_info.type = balance_type::COPY_SECONDARY;
     partition_set selected_pids;
     migration_list list;
     balancer.t_migration_result = &list;


### PR DESCRIPTION
### Manual Test

***cluster load balancer***

1. start onebox with 5 replica servers
```
./run.sh start_onebox -r 5
```
2. create serveral tables with 4 partitions
3. the cluster is not balanced now.
```
>>> nodes -d
[details]
address              status    replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                38             12               26
10.231.57.100:34802  ALIVE                35             12               23
10.231.57.100:34803  ALIVE                34             12               22
10.231.57.100:34804  ALIVE                34             12               22
10.231.57.100:34805  ALIVE                39             12               27

[summary]
total_node_count    : 5
alive_node_count    : 5
unalive_node_count  : 0
``` 
4. enable cluster load balancer
```
http://127.0.0.1:34601/updateConfig?balance_cluster=true
``` 
5. enable load balancer
```
>>> set_meta_level lively
control meta level ok, the old level is fl_steady
```
6. the cluster is balanced now.
```
>>> nodes -d
[details]
address              status    replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                36             12               24
10.231.57.100:34802  ALIVE                36             12               24
10.231.57.100:34803  ALIVE                36             12               24
10.231.57.100:34804  ALIVE                36             12               24
10.231.57.100:34805  ALIVE                36             12               24

[summary]
total_node_count    : 5
alive_node_count    : 5
unalive_node_count  : 0
```

***app load balance***

1. start onebox with 4 replica servers
```
./run.sh start_onebox -r 4
```
2.  create serveral tables with 4 partitions
3. kill one replica server
```
➜  pegasus git:(master) ✗ ps aux | grep pegasus
mi       14073  0.3  0.1 11680324 57904 pts/0  Sl   11:07   0:01 /usr/lib/jvm/java-8-openjdk-amd64/bin/java -Dzookeeper.log.dir=. -Dzookeeper.root.logger=INFO,CONSOLE -cp /home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../build/classes:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../build/lib/*.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/slf4j-log4j12-1.6.1.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/slf4j-api-1.6.1.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/netty-3.7.0.Final.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/log4j-1.2.16.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/jline-0.9.94.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../zookeeper-3.4.6.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../src/java/lib/*.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../conf: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain /home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../conf/zoo.cfg
mi       14118  0.1  0.1 495056 47356 pts/0    Sl   11:07   0:00 /home/mi/workspace/pegasus/onebox/meta1/pegasus_server config.ini -app_list meta
mi       14128  0.0  0.1 473508 45260 pts/0    Sl   11:07   0:00 /home/mi/workspace/pegasus/onebox/meta2/pegasus_server config.ini -app_list meta
mi       14168  0.0  0.1 473508 45032 pts/0    Sl   11:07   0:00 /home/mi/workspace/pegasus/onebox/meta3/pegasus_server config.ini -app_list meta
mi       14213  0.9  1.1 2210128 368404 pts/0  Sl   11:07   0:03 /home/mi/workspace/pegasus/onebox/replica1/pegasus_server config.ini -app_list replica
mi       14262  0.9  1.0 2197400 358116 pts/0  Sl   11:07   0:03 /home/mi/workspace/pegasus/onebox/replica2/pegasus_server config.ini -app_list replica
mi       14316  0.9  1.1 2201164 368700 pts/0  Sl   11:07   0:03 /home/mi/workspace/pegasus/onebox/replica3/pegasus_server config.ini -app_list replica
mi       14377  0.9  1.1 2196924 363380 pts/0  Sl   11:07   0:03 /home/mi/workspace/pegasus/onebox/replica4/pegasus_server config.ini -app_list replica
mi       17713  0.0  0.0  16176  1076 pts/0    R+   11:13   0:00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox pegasus
➜  pegasus git:(master) ✗ kill 14377
```
4. wait cluster to be healthy
```
>>> nodes -d
[details]
address              status     replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                 39             18               21
10.231.57.100:34802  ALIVE                 39             16               23
10.231.57.100:34803  ALIVE                 39             18               21
10.231.57.100:34804  UNALIVE                0              0                0
```
5. start the replica server killed before
```
./run.sh start_instance -r 4
```
6. set meta level to lively, to start load balance
```
>>> set_meta_level lively
```
7. the cluster is balanced now.
```
>>> nodes -d
[details]
address              status    replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                39             13               26
10.231.57.100:34802  ALIVE                39             13               26
10.231.57.100:34803  ALIVE                39             13               26
10.231.57.100:34804  ALIVE                39             13               26

[summary]
total_node_count    : 4
alive_node_count    : 4
unalive_node_count  : 0
```