### PR TITLE
feat(bulk_load): async create connection with remote file provider

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -408,12 +408,12 @@ void replica_bulk_loader::download_files(const std::string &provider_name,
     dist::block_service::block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
 
+    // download metadata file synchronously
+    uint64_t file_size = 0;
+    error_code err = _stub->_block_service_manager.download_file(
+        remote_dir, local_dir, bulk_load_constant::BULK_LOAD_METADATA, fs, file_size);
     {
         zauto_write_lock l(_lock);
-        // download metadata file synchronously
-        uint64_t file_size = 0;
-        error_code err = _stub->_block_service_manager.download_file(
-            remote_dir, local_dir, bulk_load_constant::BULK_LOAD_METADATA, fs, file_size);
         if (err != ERR_OK && err != ERR_PATH_ALREADY_EXIST) {
             try_decrease_bulk_load_download_count();
             _download_status.store(err);

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -408,27 +408,29 @@ void replica_bulk_loader::download_files(const std::string &provider_name,
     dist::block_service::block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
 
-    zauto_write_lock l(_lock);
-    // download metadata file synchronously
-    uint64_t file_size = 0;
-    error_code err = _stub->_block_service_manager.download_file(
-        remote_dir, local_dir, bulk_load_constant::BULK_LOAD_METADATA, fs, file_size);
-    if (err != ERR_OK && err != ERR_PATH_ALREADY_EXIST) {
-        try_decrease_bulk_load_download_count();
-        _download_status.store(err);
-        derror_replica("download bulk load metadata file failed, error = {}", err.to_string());
-        return;
-    }
+    {
+        zauto_write_lock l(_lock);
+        // download metadata file synchronously
+        uint64_t file_size = 0;
+        error_code err = _stub->_block_service_manager.download_file(
+            remote_dir, local_dir, bulk_load_constant::BULK_LOAD_METADATA, fs, file_size);
+        if (err != ERR_OK && err != ERR_PATH_ALREADY_EXIST) {
+            try_decrease_bulk_load_download_count();
+            _download_status.store(err);
+            derror_replica("download bulk load metadata file failed, error = {}", err.to_string());
+            return;
+        }
 
-    // parse metadata
-    const std::string &local_metadata_file_name =
-        utils::filesystem::path_combine(local_dir, bulk_load_constant::BULK_LOAD_METADATA);
-    err = parse_bulk_load_metadata(local_metadata_file_name);
-    if (err != ERR_OK) {
-        try_decrease_bulk_load_download_count();
-        _download_status.store(err);
-        derror_replica("parse bulk load metadata failed, error = {}", err.to_string());
-        return;
+        // parse metadata
+        const std::string &local_metadata_file_name =
+            utils::filesystem::path_combine(local_dir, bulk_load_constant::BULK_LOAD_METADATA);
+        err = parse_bulk_load_metadata(local_metadata_file_name);
+        if (err != ERR_OK) {
+            try_decrease_bulk_load_download_count();
+            _download_status.store(err);
+            derror_replica("parse bulk load metadata failed, error = {}", err.to_string());
+            return;
+        }
     }
 
     // download sst files asynchronously

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -186,6 +186,7 @@ void replica_bulk_loader::on_group_bulk_load(const group_bulk_load_request &requ
     report_bulk_load_states_to_primary(request.meta_bulk_load_status, response);
 }
 
+// ThreadPool: THREAD_POOL_REPLICATION
 void replica_bulk_loader::on_group_bulk_load_reply(error_code err,
                                                    const group_bulk_load_request &req,
                                                    const group_bulk_load_response &resp)
@@ -373,23 +374,6 @@ error_code replica_bulk_loader::start_download(const std::string &remote_dir,
     _bulk_load_start_time_ms = dsn_now_ms();
     _stub->_counter_bulk_load_downloading_count->increment();
 
-    // start download
-    _is_downloading.store(true);
-    ddebug_replica("start to download sst files");
-    error_code err = download_sst_files(remote_dir, provider_name);
-    if (err != ERR_OK) {
-        try_decrease_bulk_load_download_count();
-    }
-    return err;
-}
-
-// ThreadPool: THREAD_POOL_REPLICATION
-error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir,
-                                                   const std::string &provider_name)
-{
-    FAIL_POINT_INJECT_F("replica_bulk_loader_download_sst_files",
-                        [](string_view) -> error_code { return ERR_OK; });
-
     // create local bulk load dir
     if (!utils::filesystem::directory_exists(_replica->_dir)) {
         derror_replica("_dir({}) is not existed", _replica->_dir);
@@ -403,16 +387,37 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
         return ERR_FILE_OPERATION_FAILED;
     }
 
+    // start download
+    _is_downloading.store(true);
+    _download_task = tasking::enqueue(
+        LPC_BACKGROUND_BULK_LOAD,
+        tracker(),
+        std::bind(
+            &replica_bulk_loader::download_files, this, provider_name, remote_dir, local_dir));
+    return ERR_OK;
+}
+
+// ThreadPool: THREAD_POOL_DEFAULT
+void replica_bulk_loader::download_files(const std::string &provider_name,
+                                         const std::string &remote_dir,
+                                         const std::string &local_dir)
+{
+    FAIL_POINT_INJECT_F("replica_bulk_loader_download_files", [](string_view) {});
+
+    ddebug_replica("start to download files");
     dist::block_service::block_filesystem *fs =
         _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
 
+    zauto_write_lock l(_lock);
     // download metadata file synchronously
     uint64_t file_size = 0;
     error_code err = _stub->_block_service_manager.download_file(
         remote_dir, local_dir, bulk_load_constant::BULK_LOAD_METADATA, fs, file_size);
     if (err != ERR_OK && err != ERR_PATH_ALREADY_EXIST) {
+        try_decrease_bulk_load_download_count();
+        _download_status.store(err);
         derror_replica("download bulk load metadata file failed, error = {}", err.to_string());
-        return err;
+        return;
     }
 
     // parse metadata
@@ -420,63 +425,74 @@ error_code replica_bulk_loader::download_sst_files(const std::string &remote_dir
         utils::filesystem::path_combine(local_dir, bulk_load_constant::BULK_LOAD_METADATA);
     err = parse_bulk_load_metadata(local_metadata_file_name);
     if (err != ERR_OK) {
+        try_decrease_bulk_load_download_count();
+        _download_status.store(err);
         derror_replica("parse bulk load metadata failed, error = {}", err.to_string());
-        return err;
+        return;
     }
 
     // download sst files asynchronously
     for (const auto &f_meta : _metadata.files) {
-        auto bulk_load_download_task = tasking::enqueue(
-            LPC_BACKGROUND_BULK_LOAD, tracker(), [this, remote_dir, local_dir, f_meta, fs]() {
-                uint64_t f_size = 0;
-                error_code ec = _stub->_block_service_manager.download_file(
-                    remote_dir, local_dir, f_meta.name, fs, f_size);
-                const std::string &file_name =
-                    utils::filesystem::path_combine(local_dir, f_meta.name);
-                bool verified = false;
-                if (ec == ERR_PATH_ALREADY_EXIST) {
-                    if (utils::filesystem::verify_file(file_name, f_meta.md5, f_meta.size)) {
-                        // local file exist and is verified
-                        ec = ERR_OK;
-                        f_size = f_meta.size;
-                        verified = true;
-                    } else {
-                        derror_replica(
-                            "file({}) exists, but not verified, try to remove local file "
-                            "and redownload it",
-                            file_name);
-                        if (!utils::filesystem::remove_path(file_name)) {
-                            derror_replica("failed to remove file({})", file_name);
-                            ec = ERR_FILE_OPERATION_FAILED;
-                        } else {
-                            ec = _stub->_block_service_manager.download_file(
-                                remote_dir, local_dir, f_meta.name, fs, f_size);
-                        }
-                    }
-                }
-                if (ec == ERR_OK && !verified &&
-                    !utils::filesystem::verify_file(file_name, f_meta.md5, f_meta.size)) {
-                    ec = ERR_CORRUPTION;
-                }
-                if (ec != ERR_OK) {
-                    try_decrease_bulk_load_download_count();
-                    _download_status.store(ec);
-                    derror_replica(
-                        "failed to download file({}), error = {}", f_meta.name, ec.to_string());
-                    _stub->_counter_bulk_load_download_file_fail_count->increment();
-                    return;
-                }
-                // download file succeed, update progress
-                update_bulk_load_download_progress(f_size, f_meta.name);
-                _stub->_counter_bulk_load_download_file_succ_count->increment();
-                _stub->_counter_bulk_load_download_file_size->add(f_size);
-            });
-        _download_task[f_meta.name] = bulk_load_download_task;
+        _download_files_task[f_meta.name] = tasking::enqueue(
+            LPC_BACKGROUND_BULK_LOAD,
+            tracker(),
+            std::bind(
+                &replica_bulk_loader::download_sst_file, this, remote_dir, local_dir, f_meta, fs));
     }
-    return err;
 }
 
-// ThreadPool: THREAD_POOL_REPLICATION
+// ThreadPool: THREAD_POOL_DEFAULT
+void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
+                                            const std::string &local_dir,
+                                            const file_meta &f_meta,
+                                            dist::block_service::block_filesystem *fs)
+{
+    uint64_t f_size = 0;
+    error_code ec =
+        _stub->_block_service_manager.download_file(remote_dir, local_dir, f_meta.name, fs, f_size);
+    const std::string &file_name = utils::filesystem::path_combine(local_dir, f_meta.name);
+    bool verified = false;
+    if (ec == ERR_PATH_ALREADY_EXIST) {
+        if (utils::filesystem::verify_file(file_name, f_meta.md5, f_meta.size)) {
+            // local file exist and is verified
+            ec = ERR_OK;
+            f_size = f_meta.size;
+            verified = true;
+        } else {
+            derror_replica("file({}) exists, but not verified, try to remove local file "
+                           "and redownload it",
+                           file_name);
+            if (!utils::filesystem::remove_path(file_name)) {
+                derror_replica("failed to remove file({})", file_name);
+                ec = ERR_FILE_OPERATION_FAILED;
+            } else {
+                ec = _stub->_block_service_manager.download_file(
+                    remote_dir, local_dir, f_meta.name, fs, f_size);
+            }
+        }
+    }
+    if (ec == ERR_OK && !verified &&
+        !utils::filesystem::verify_file(file_name, f_meta.md5, f_meta.size)) {
+        ec = ERR_CORRUPTION;
+    }
+    if (ec != ERR_OK) {
+        {
+            zauto_write_lock l(_lock);
+            try_decrease_bulk_load_download_count();
+            _download_status.store(ec);
+        }
+        derror_replica("failed to download file({}), error = {}", f_meta.name, ec.to_string());
+        _stub->_counter_bulk_load_download_file_fail_count->increment();
+        return;
+    }
+    // download file succeed, update progress
+    update_bulk_load_download_progress(f_size, f_meta.name);
+    _stub->_counter_bulk_load_download_file_succ_count->increment();
+    _stub->_counter_bulk_load_download_file_size->add(f_size);
+}
+
+// ThreadPool: THREAD_POOL_DEFAULT
+// need to acquire write lock while calling it
 error_code replica_bulk_loader::parse_bulk_load_metadata(const std::string &fname)
 {
     std::string buf;
@@ -505,25 +521,28 @@ error_code replica_bulk_loader::parse_bulk_load_metadata(const std::string &fnam
 void replica_bulk_loader::update_bulk_load_download_progress(uint64_t file_size,
                                                              const std::string &file_name)
 {
-    if (_metadata.file_total_size <= 0) {
-        derror_replica("update downloading file({}) progress failed, metadata has invalid "
-                       "file_total_size({}), current status = {}",
-                       file_name,
-                       _metadata.file_total_size,
-                       enum_to_string(_status));
-        return;
-    }
+    {
+        zauto_write_lock l(_lock);
+        if (_metadata.file_total_size <= 0) {
+            derror_replica("update downloading file({}) progress failed, metadata has invalid "
+                           "file_total_size({}), current status = {}",
+                           file_name,
+                           _metadata.file_total_size,
+                           enum_to_string(_status));
+            return;
+        }
 
-    ddebug_replica("update progress after downloading file({})", file_name);
-    _cur_downloaded_size.fetch_add(file_size);
-    auto total_size = static_cast<double>(_metadata.file_total_size);
-    auto cur_downloaded_size = static_cast<double>(_cur_downloaded_size.load());
-    auto cur_progress = static_cast<int32_t>((cur_downloaded_size / total_size) * 100);
-    _download_progress.store(cur_progress);
-    ddebug_replica("total_size = {}, cur_downloaded_size = {}, progress = {}",
-                   total_size,
-                   cur_downloaded_size,
-                   cur_progress);
+        ddebug_replica("update progress after downloading file({})", file_name);
+        _cur_downloaded_size.fetch_add(file_size);
+        auto total_size = static_cast<double>(_metadata.file_total_size);
+        auto cur_downloaded_size = static_cast<double>(_cur_downloaded_size.load());
+        auto cur_progress = static_cast<int32_t>((cur_downloaded_size / total_size) * 100);
+        _download_progress.store(cur_progress);
+        ddebug_replica("total_size = {}, cur_downloaded_size = {}, progress = {}",
+                       total_size,
+                       cur_downloaded_size,
+                       cur_progress);
+    }
 
     tasking::enqueue(LPC_REPLICATION_COMMON,
                      tracker(),
@@ -532,6 +551,7 @@ void replica_bulk_loader::update_bulk_load_download_progress(uint64_t file_size,
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION, THREAD_POOL_DEFAULT
+// need to acquire write lock while calling it
 void replica_bulk_loader::try_decrease_bulk_load_download_count()
 {
     if (!_is_downloading.load()) {
@@ -551,8 +571,11 @@ void replica_bulk_loader::check_download_finish()
         _status == bulk_load_status::BLS_DOWNLOADING) {
         ddebug_replica("download all files succeed");
         _status = bulk_load_status::BLS_DOWNLOADED;
-        try_decrease_bulk_load_download_count();
-        cleanup_download_task();
+        {
+            zauto_write_lock l(_lock);
+            try_decrease_bulk_load_download_count();
+            cleanup_download_tasks();
+        }
     }
 }
 
@@ -647,17 +670,20 @@ void replica_bulk_loader::remove_local_bulk_load_dir(const std::string &bulk_loa
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica_bulk_loader::cleanup_download_task()
+// need to acquire write lock while calling it
+void replica_bulk_loader::cleanup_download_tasks()
 {
-    for (auto &kv : _download_task) {
-        if (kv.second != nullptr) {
-            bool finished = false;
-            kv.second->cancel(false, &finished);
-            if (finished) {
-                kv.second = nullptr;
-            }
-        }
+    for (auto &kv : _download_files_task) {
+        cleanup_download_task(kv.second);
     }
+    cleanup_download_task(_download_task);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+bool replica_bulk_loader::cleanup_download_task(task_ptr task_)
+{
+    CLEANUP_TASK(task_, false)
+    return true;
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
@@ -667,13 +693,17 @@ void replica_bulk_loader::clear_bulk_load_states()
         try_decrease_bulk_load_download_count();
     }
 
-    cleanup_download_task();
-    _download_task.clear();
-    _metadata.files.clear();
-    _metadata.file_total_size = 0;
-    _cur_downloaded_size.store(0);
-    _download_progress.store(0);
-    _download_status.store(ERR_OK);
+    {
+        zauto_write_lock l(_lock);
+        cleanup_download_tasks();
+        _download_files_task.clear();
+        _download_task = nullptr;
+        _metadata.files.clear();
+        _metadata.file_total_size = 0;
+        _cur_downloaded_size.store(0);
+        _download_progress.store(0);
+        _download_status.store(ERR_OK);
+    }
 
     _replica->_is_bulk_load_ingestion = false;
     _replica->_app->set_ingestion_status(ingestion_status::IS_INVALID);
@@ -690,11 +720,15 @@ bool replica_bulk_loader::is_cleaned_up()
     if (_status != bulk_load_status::BLS_INVALID) {
         return false;
     }
-    // download context not cleaned up
-    if (_cur_downloaded_size.load() != 0 || _download_progress.load() != 0 ||
-        _download_status.load() != ERR_OK || _download_task.size() != 0 ||
-        _metadata.files.size() != 0 || _metadata.file_total_size != 0) {
-        return false;
+    {
+        // download context not cleaned up
+        zauto_read_lock l(_lock);
+        if (_cur_downloaded_size.load() != 0 || _download_progress.load() != 0 ||
+            _download_status.load() != ERR_OK || _download_files_task.size() != 0 ||
+            _download_task != nullptr || _metadata.files.size() != 0 ||
+            _metadata.file_total_size != 0) {
+            return false;
+        }
     }
     // ingestion context not cleaned up
     if (_replica->_is_bulk_load_ingestion ||
@@ -712,7 +746,8 @@ void replica_bulk_loader::pause_bulk_load()
         return;
     }
     if (_status == bulk_load_status::BLS_DOWNLOADING) {
-        cleanup_download_task();
+        zauto_write_lock l(_lock);
+        cleanup_download_tasks();
         try_decrease_bulk_load_download_count();
     }
     _status = bulk_load_status::BLS_PAUSED;
@@ -729,8 +764,11 @@ void replica_bulk_loader::report_bulk_load_states_to_meta(bulk_load_status::type
         return;
     }
 
-    if (report_metadata && !_metadata.files.empty()) {
-        response.__set_metadata(_metadata);
+    if (report_metadata) {
+        zauto_read_lock l(_lock);
+        if (!_metadata.files.empty()) {
+            response.__set_metadata(_metadata);
+        }
     }
 
     switch (remote_status) {
@@ -768,8 +806,11 @@ void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_respo
     }
 
     partition_bulk_load_state primary_state;
-    primary_state.__set_download_progress(_download_progress.load());
-    primary_state.__set_download_status(_download_status.load());
+    {
+        zauto_read_lock l(_lock);
+        primary_state.__set_download_progress(_download_progress.load());
+        primary_state.__set_download_status(_download_status.load());
+    }
     response.group_bulk_load_state[_replica->_primary_states.membership.primary] = primary_state;
     ddebug_replica("primary = {}, download progress = {}%, status = {}",
                    _replica->_primary_states.membership.primary.to_string(),
@@ -925,10 +966,11 @@ void replica_bulk_loader::report_bulk_load_states_to_primary(
     auto local_status = _status;
     switch (remote_status) {
     case bulk_load_status::BLS_DOWNLOADING:
-    case bulk_load_status::BLS_DOWNLOADED:
+    case bulk_load_status::BLS_DOWNLOADED: {
+        zauto_read_lock l(_lock);
         bulk_load_state.__set_download_progress(_download_progress.load());
         bulk_load_state.__set_download_status(_download_status.load());
-        break;
+    } break;
     case bulk_load_status::BLS_INGESTING:
         bulk_load_state.__set_ingest_status(_replica->_app->get_ingestion_status());
         break;

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -56,23 +56,30 @@ private:
 
     // replica start or restart download sst files from remote provider
     // \return ERR_BUSY if node has already had enough replica executing downloading
-    // \return download errors by function `download_sst_files`
+    // \return ERR_FILE_OPERATION_FAILED: create local bulk load dir failed
     error_code start_download(const std::string &remote_dir, const std::string &provider_name);
 
-    // download metadata and sst files from remote provider
+    // download metadata file and create sst download tasks
     // metadata and sst files will be downloaded in {_dir}/.bulk_load directory
-    // \return ERR_FILE_OPERATION_FAILED: create local bulk load dir failed
-    // \return download metadata file error, see function `do_download`
-    // \return parse metadata file error, see function `parse_bulk_load_metadata`
-    error_code download_sst_files(const std::string &remote_dir, const std::string &provider_name);
+    void download_files(const std::string &provider_name,
+                        const std::string &remote_dir,
+                        const std::string &local_dir);
+
+    // download sst files from remote provider
+    void download_sst_file(const std::string &remote_dir,
+                           const std::string &local_dir,
+                           const file_meta &f_meta,
+                           dist::block_service::block_filesystem *fs);
 
     // \return ERR_FILE_OPERATION_FAILED: file not exist, get size failed, open file failed
     // \return ERR_CORRUPTION: parse failed
+    // need to acquire write lock while calling it
     error_code parse_bulk_load_metadata(const std::string &fname);
 
     // update download progress after downloading sst files succeed
     void update_bulk_load_download_progress(uint64_t file_size, const std::string &file_name);
 
+    // need to acquire write lock while calling it
     void try_decrease_bulk_load_download_count();
     void check_download_finish();
     void start_ingestion();
@@ -83,7 +90,9 @@ private:
     void pause_bulk_load();
 
     void remove_local_bulk_load_dir(const std::string &bulk_load_dir);
-    void cleanup_download_task();
+    // need to acquire write lock while calling it
+    void cleanup_download_tasks();
+    bool cleanup_download_task(task_ptr task_);
     void clear_bulk_load_states();
     bool is_cleaned_up();
 
@@ -150,6 +159,7 @@ private:
     friend class replica_stub;
     friend class replica_bulk_loader_test;
 
+    zrwlock_nr _lock; // bulk load states lock
     bulk_load_status::type _status{bulk_load_status::BLS_INVALID};
     bulk_load_metadata _metadata;
     std::atomic<bool> _is_downloading{false};
@@ -157,8 +167,10 @@ private:
     std::atomic<int32_t> _download_progress{0};
     std::atomic<error_code> _download_status{ERR_OK};
     // file_name -> downloading task
-    std::map<std::string, task_ptr> _download_task;
+    std::map<std::string, task_ptr> _download_files_task;
 
+    // download metadata and create download file tasks
+    task_ptr _download_task;
     // Used for perf-counter
     uint64_t _bulk_load_start_time_ms{0};
 };

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <dsn/tool-api/zlocks.h>
+
 #include "replica/replica.h"
 #include "replica/replica_context.h"
 #include "replica/replica_stub.h"

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -161,16 +161,17 @@ private:
     friend class replica_stub;
     friend class replica_bulk_loader_test;
 
-    zrwlock_nr _lock; // bulk load states lock
+    // bulk load states lock
+    zrwlock_nr _lock; // {
     bulk_load_status::type _status{bulk_load_status::BLS_INVALID};
     bulk_load_metadata _metadata;
     std::atomic<bool> _is_downloading{false};
     std::atomic<uint64_t> _cur_downloaded_size{0};
     std::atomic<int32_t> _download_progress{0};
     std::atomic<error_code> _download_status{ERR_OK};
+    // }
     // file_name -> downloading task
     std::map<std::string, task_ptr> _download_files_task;
-
     // download metadata and create download file tasks
     task_ptr _download_task;
     // Used for perf-counter

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -495,12 +495,11 @@ TEST_F(replica_bulk_loader_test, start_downloading_test)
                ERR_BUSY,
                bulk_load_status::BLS_INVALID,
                MAX_DOWNLOADING_COUNT},
-              {false, 1, ERR_CORRUPTION, bulk_load_status::BLS_DOWNLOADING, 1},
               {true, 1, ERR_OK, bulk_load_status::BLS_DOWNLOADING, 2}};
 
     for (auto test : tests) {
         if (test.mock_function) {
-            fail::cfg("replica_bulk_loader_download_sst_files", "return()");
+            fail::cfg("replica_bulk_loader_download_files", "return()");
         }
         mock_group_progress(bulk_load_status::BLS_INVALID);
         create_bulk_load_request(bulk_load_status::BLS_DOWNLOADING, test.downloading_count);
@@ -514,7 +513,7 @@ TEST_F(replica_bulk_loader_test, start_downloading_test)
 // start_downloading unit tests
 TEST_F(replica_bulk_loader_test, rollback_to_downloading_test)
 {
-    fail::cfg("replica_bulk_loader_download_sst_files", "return()");
+    fail::cfg("replica_bulk_loader_download_files", "return()");
     struct test_struct
     {
         bulk_load_status::type status;

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -485,22 +485,15 @@ TEST_F(replica_bulk_loader_test, start_downloading_test)
     // - downloading succeed
     struct test_struct
     {
-        bool mock_function;
         int32_t downloading_count;
         error_code expected_err;
         bulk_load_status::type expected_status;
         int32_t expected_downloading_count;
-    } tests[]{{false,
-               MAX_DOWNLOADING_COUNT,
-               ERR_BUSY,
-               bulk_load_status::BLS_INVALID,
-               MAX_DOWNLOADING_COUNT},
-              {true, 1, ERR_OK, bulk_load_status::BLS_DOWNLOADING, 2}};
-
+    } tests[]{
+        {MAX_DOWNLOADING_COUNT, ERR_BUSY, bulk_load_status::BLS_INVALID, MAX_DOWNLOADING_COUNT},
+        {1, ERR_OK, bulk_load_status::BLS_DOWNLOADING, 2}};
+    fail::cfg("replica_bulk_loader_download_files", "return()");
     for (auto test : tests) {
-        if (test.mock_function) {
-            fail::cfg("replica_bulk_loader_download_files", "return()");
-        }
         mock_group_progress(bulk_load_status::BLS_INVALID);
         create_bulk_load_request(bulk_load_status::BLS_DOWNLOADING, test.downloading_count);
 

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -20,6 +20,7 @@
 
 #include <fstream>
 
+#include <dsn/tool-api/zlocks.h>
 #include <dsn/utility/fail_point.h>
 #include <gtest/gtest.h>
 
@@ -59,7 +60,9 @@ public:
     {
         const std::string remote_dir = _bulk_loader->get_remote_bulk_load_dir(
             APP_NAME, CLUSTER, ROOT_PATH, PID.get_partition_index());
-        return _bulk_loader->start_download(remote_dir, PROVIDER);
+        auto err = _bulk_loader->start_download(remote_dir, PROVIDER);
+        _bulk_loader->tracker()->wait_outstanding_tasks();
+        return err;
     }
 
     void test_rollback_to_downloading(bulk_load_status::type cur_status)

--- a/src/replica/storage/simple_kv/test/case-212.ini
+++ b/src/replica/storage/simple_kv/test/case-212.ini
@@ -138,7 +138,6 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 15
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false

--- a/src/replica/storage/simple_kv/test/case-212.ini
+++ b/src/replica/storage/simple_kv/test/case-212.ini
@@ -138,7 +138,7 @@ prepare_timeout_ms_for_potential_secondaries = 3000
 
 batch_write_disabled = true
 staleness_for_commit = 5
-max_mutation_count_in_prepare_list = 10
+max_mutation_count_in_prepare_list = 15
 mutation_2pc_min_replica_count = 2
 
 group_check_disabled = false


### PR DESCRIPTION
When bulk load started, replica server will firstly connect to the remote file provider and download metadata file synchronously. However, creating connection may cost seconds in production environment, will sometimes affect performance.

This pull request does following update:
- create connection with remote file provider asynchronously
- download metadata file asynchronously
- use default threadpool rather than replication threadpool
- add lock for the related varieties