### PR TITLE
refactor: implement app balance policy

### DIFF
--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -11,13 +11,8 @@ namespace replication {
 
 void app_balance_policy::balance(bool checker, const meta_view *global_view, migration_list *list)
 {
-    const node_mapper &nodes = *_global_view->nodes;
+    init(global_view, list);
     const app_mapper &apps = *_global_view->apps;
-    _global_view = global_view;
-    _migration_result = list;
-    _alive_nodes = nodes.size();
-    number_nodes(nodes);
-
     if (!execute_balance(apps,
                          checker,
                          _balancer_in_turn,

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -1,6 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Created by mi on 2021/11/2.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include <dsn/tool-api/command_manager.h>
 #include <dsn/dist/fmt_logging.h>

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -10,7 +10,11 @@
 namespace dsn {
 namespace replication {
 
-app_balance_policy::app_balance_policy(meta_service *svc) : load_balance_policy(svc)
+app_balance_policy::app_balance_policy(meta_service *svc)
+    : load_balance_policy(svc),
+      _ctrl_balancer_in_turn(nullptr),
+      _ctrl_only_primary_balancer(nullptr),
+      _ctrl_only_move_primary(nullptr)
 {
     if (_svc != nullptr) {
         _balancer_in_turn = _svc->get_meta_options()._lb_opts.balancer_in_turn;

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -117,7 +117,7 @@ void app_balance_policy::unregister_ctrl_commands()
 bool app_balance_policy::need_balance_secondaries(bool balance_checker)
 {
     if (!balance_checker && !_migration_result->empty()) {
-        ddebug("stop to do secondary balance coz we already has actions to do");
+        ddebug("stop to do secondary balance coz we already have actions to do");
         return false;
     }
     if (_only_primary_balancer) {

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -1,0 +1,179 @@
+//
+// Created by mi on 2021/11/2.
+//
+
+#include <dsn/tool-api/command_manager.h>
+#include <dsn/dist/fmt_logging.h>
+#include "app_balance_policy.h"
+
+namespace dsn {
+namespace replication {
+
+void app_balance_policy::balance(bool checker, const meta_view *global_view, migration_list *list)
+{
+    const node_mapper &nodes = *_global_view->nodes;
+    const app_mapper &apps = *_global_view->apps;
+    _global_view = global_view;
+    _migration_result = list;
+    _alive_nodes = nodes.size();
+    number_nodes(nodes);
+
+    if (!execute_balance(apps,
+                         checker,
+                         _balancer_in_turn,
+                         _only_move_primary,
+                         std::bind(&app_balance_policy::primary_balance,
+                                   this,
+                                   std::placeholders::_1,
+                                   std::placeholders::_2))) {
+        return;
+    }
+
+    if (!need_balance_secondaries(checker)) {
+        return;
+    }
+
+    // we seperate the primary/secondary balancer for 2 reasons:
+    // 1. globally primary balancer may make secondary unbalanced
+    // 2. in one-by-one mode, a secondary balance decision for an app may be prior than
+    // another app's primary balancer if not seperated.
+    execute_balance(apps,
+                    checker,
+                    _balancer_in_turn,
+                    _only_move_primary,
+                    std::bind(&app_balance_policy::copy_secondary,
+                              this,
+                              std::placeholders::_1,
+                              std::placeholders::_2));
+}
+
+void app_balance_policy::register_ctrl_commands()
+{
+    load_balance_policy::register_ctrl_commands();
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        _ctrl_balancer_in_turn = dsn::command_manager::instance().register_command(
+            {"meta.lb.balancer_in_turn"},
+            "meta.lb.balancer_in_turn <true|false>",
+            "control whether do app balancer in turn",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(_balancer_in_turn, "lb.balancer_in_turn", args);
+            });
+
+        _ctrl_only_primary_balancer = dsn::command_manager::instance().register_command(
+            {"meta.lb.only_primary_balancer"},
+            "meta.lb.only_primary_balancer <true|false>",
+            "control whether do only primary balancer",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(
+                    _only_primary_balancer, "lb.only_primary_balancer", args);
+            });
+
+        _ctrl_only_move_primary = dsn::command_manager::instance().register_command(
+            {"meta.lb.only_move_primary"},
+            "meta.lb.only_move_primary <true|false>",
+            "control whether only move primary in balancer",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_set_bool_flag(
+                    _only_move_primary, "lb.only_move_primary", args);
+            });
+    });
+}
+
+void app_balance_policy::unregister_ctrl_commands()
+{
+    load_balance_policy::unregister_ctrl_commands();
+    UNREGISTER_VALID_HANDLER(_ctrl_balancer_in_turn);
+    UNREGISTER_VALID_HANDLER(_ctrl_only_primary_balancer);
+    UNREGISTER_VALID_HANDLER(_ctrl_only_move_primary);
+}
+
+bool app_balance_policy::need_balance_secondaries(bool balance_checker)
+{
+    if (!balance_checker && !_migration_result->empty()) {
+        ddebug("stop to do secondary balance coz we already has actions to do");
+        return false;
+    }
+    if (_only_primary_balancer) {
+        ddebug("stop to do secondary balancer coz it is not allowed");
+        return false;
+    }
+    return true;
+}
+
+bool app_balance_policy::copy_secondary(const std::shared_ptr<app_state> &app, bool place_holder)
+{
+    node_mapper &nodes = *(_global_view->nodes);
+    const app_mapper &apps = *_global_view->apps;
+    int replicas_low = app->partition_count / _alive_nodes;
+
+    std::unique_ptr<copy_replica_operation> operation = dsn::make_unique<copy_secondary_operation>(
+        app, apps, nodes, address_vec, address_id, replicas_low);
+    return operation->start(_migration_result);
+}
+
+copy_secondary_operation::copy_secondary_operation(
+    const std::shared_ptr<app_state> app,
+    const app_mapper &apps,
+    node_mapper &nodes,
+    const std::vector<dsn::rpc_address> &address_vec,
+    const std::unordered_map<dsn::rpc_address, int> &address_id,
+    int replicas_low)
+    : copy_replica_operation(app, apps, nodes, address_vec, address_id), _replicas_low(replicas_low)
+{
+}
+
+bool copy_secondary_operation::can_continue()
+{
+    int id_min = *_ordered_address_ids.begin();
+    int id_max = *_ordered_address_ids.rbegin();
+    if (_partition_counts[id_max] <= _replicas_low ||
+        _partition_counts[id_max] - _partition_counts[id_min] <= 1) {
+        ddebug_f("{}: stop copy secondary coz it will be balanced later", _app->get_logname());
+        return false;
+    }
+    return true;
+}
+
+int copy_secondary_operation::get_partition_count(const node_state &ns) const
+{
+    return ns.partition_count(_app->app_id);
+}
+
+bool copy_secondary_operation::can_select(gpid pid, migration_list *result)
+{
+    int id_max = *_ordered_address_ids.rbegin();
+    const node_state &max_ns = _nodes.at(_address_vec[id_max]);
+    if (max_ns.served_as(pid) == partition_status::PS_PRIMARY) {
+        dinfo_f("{}: skip gpid({}.{}) coz it is primary",
+                _app->get_logname(),
+                pid.get_app_id(),
+                pid.get_partition_index());
+        return false;
+    }
+
+    // if the pid have been used
+    if (result->find(pid) != result->end()) {
+        dinfo_f("{}: skip gpid({}.{}) coz it is already copyed",
+                _app->get_logname(),
+                pid.get_app_id(),
+                pid.get_partition_index());
+        return false;
+    }
+
+    int id_min = *_ordered_address_ids.begin();
+    const node_state &min_ns = _nodes.at(_address_vec[id_min]);
+    if (min_ns.served_as(pid) != partition_status::PS_INACTIVE) {
+        dinfo_f("{}: skip gpid({}.{}) coz it is already a member on the target node",
+                _app->get_logname(),
+                pid.get_app_id(),
+                pid.get_partition_index());
+        return false;
+    }
+    return true;
+}
+
+balance_type copy_secondary_operation::get_balance_type() { return balance_type::COPY_SECONDARY; }
+
+} // namespace replication
+} // namespace dsn

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -5,9 +5,23 @@
 #include <dsn/tool-api/command_manager.h>
 #include <dsn/dist/fmt_logging.h>
 #include "app_balance_policy.h"
+#include "meta_service.h"
 
 namespace dsn {
 namespace replication {
+
+app_balance_policy::app_balance_policy(meta_service *svc) : load_balance_policy(svc)
+{
+    if (_svc != nullptr) {
+        _balancer_in_turn = _svc->get_meta_options()._lb_opts.balancer_in_turn;
+        _only_primary_balancer = _svc->get_meta_options()._lb_opts.only_primary_balancer;
+        _only_move_primary = _svc->get_meta_options()._lb_opts.only_move_primary;
+    } else {
+        _balancer_in_turn = false;
+        _only_primary_balancer = false;
+        _only_move_primary = false;
+    }
+}
 
 void app_balance_policy::balance(bool checker, const meta_view *global_view, migration_list *list)
 {

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -38,7 +38,10 @@ app_balance_policy::app_balance_policy(meta_service *svc)
         _only_primary_balancer = false;
         _only_move_primary = false;
     }
+    register_ctrl_commands();
 }
+
+app_balance_policy::~app_balance_policy() { unregister_ctrl_commands(); }
 
 void app_balance_policy::balance(bool checker, const meta_view *global_view, migration_list *list)
 {
@@ -75,7 +78,6 @@ void app_balance_policy::balance(bool checker, const meta_view *global_view, mig
 
 void app_balance_policy::register_ctrl_commands()
 {
-    load_balance_policy::register_ctrl_commands();
     static std::once_flag flag;
     std::call_once(flag, [&]() {
         _ctrl_balancer_in_turn = dsn::command_manager::instance().register_command(
@@ -108,7 +110,6 @@ void app_balance_policy::register_ctrl_commands()
 
 void app_balance_policy::unregister_ctrl_commands()
 {
-    load_balance_policy::unregister_ctrl_commands();
     UNREGISTER_VALID_HANDLER(_ctrl_balancer_in_turn);
     UNREGISTER_VALID_HANDLER(_ctrl_only_primary_balancer);
     UNREGISTER_VALID_HANDLER(_ctrl_only_move_primary);

--- a/src/meta/app_balance_policy.h
+++ b/src/meta/app_balance_policy.h
@@ -24,7 +24,7 @@ namespace replication {
 class app_balance_policy : public load_balance_policy
 {
 public:
-    app_balance_policy() = default;
+    app_balance_policy(meta_service *svc);
 
     void balance(bool checker, const meta_view *global_view, migration_list *list);
     void register_ctrl_commands();

--- a/src/meta/app_balance_policy.h
+++ b/src/meta/app_balance_policy.h
@@ -25,6 +25,7 @@ class app_balance_policy : public load_balance_policy
 {
 public:
     app_balance_policy(meta_service *svc);
+    ~app_balance_policy() = default;
 
     void balance(bool checker, const meta_view *global_view, migration_list *list);
     void register_ctrl_commands();

--- a/src/meta/app_balance_policy.h
+++ b/src/meta/app_balance_policy.h
@@ -25,15 +25,16 @@ class app_balance_policy : public load_balance_policy
 {
 public:
     app_balance_policy(meta_service *svc);
-    ~app_balance_policy() = default;
+    ~app_balance_policy();
 
     void balance(bool checker, const meta_view *global_view, migration_list *list);
-    void register_ctrl_commands();
-    void unregister_ctrl_commands();
 
 private:
     bool need_balance_secondaries(bool balance_checker);
     bool copy_secondary(const std::shared_ptr<app_state> &app, bool place_holder);
+
+    void register_ctrl_commands();
+    void unregister_ctrl_commands();
 
     dsn_handle_t _ctrl_balancer_in_turn;
     dsn_handle_t _ctrl_only_primary_balancer;

--- a/src/meta/app_balance_policy.h
+++ b/src/meta/app_balance_policy.h
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "load_balance_policy.h"
+
+namespace dsn {
+namespace replication {
+class app_balance_policy : public load_balance_policy
+{
+public:
+    app_balance_policy() = default;
+
+    void balance(bool checker, const meta_view *global_view, migration_list *list);
+    void register_ctrl_commands();
+    void unregister_ctrl_commands();
+
+private:
+    bool need_balance_secondaries(bool balance_checker);
+    bool copy_secondary(const std::shared_ptr<app_state> &app, bool place_holder);
+
+    dsn_handle_t _ctrl_balancer_in_turn;
+    dsn_handle_t _ctrl_only_primary_balancer;
+    dsn_handle_t _ctrl_only_move_primary;
+
+    // options
+    bool _balancer_in_turn;
+    bool _only_primary_balancer;
+    bool _only_move_primary;
+};
+
+class copy_secondary_operation : public copy_replica_operation
+{
+public:
+    copy_secondary_operation(const std::shared_ptr<app_state> app,
+                             const app_mapper &apps,
+                             node_mapper &nodes,
+                             const std::vector<dsn::rpc_address> &address_vec,
+                             const std::unordered_map<dsn::rpc_address, int> &address_id,
+                             int replicas_low);
+    ~copy_secondary_operation() = default;
+
+private:
+    bool can_continue();
+    int get_partition_count(const node_state &ns) const;
+    bool can_select(gpid pid, migration_list *result);
+    balance_type get_balance_type();
+    bool only_copy_primary() { return false; }
+
+    int _replicas_low;
+
+    FRIEND_TEST(copy_secondary_operation, misc);
+};
+} // namespace replication
+} // namespace dsn

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -104,23 +104,9 @@ void get_min_max_set(const std::map<rpc_address, uint32_t> &node_count_map,
 }
 
 greedy_load_balancer::greedy_load_balancer(meta_service *_svc)
-    : server_load_balancer(_svc),
-      _ctrl_balancer_ignored_apps(nullptr),
-      _ctrl_balancer_in_turn(nullptr),
-      _ctrl_only_primary_balancer(nullptr),
-      _ctrl_only_move_primary(nullptr),
-      _get_balance_operation_count(nullptr)
+    : server_load_balancer(_svc), _get_balance_operation_count(nullptr)
 {
-    if (_svc != nullptr) {
-        _balancer_in_turn = _svc->get_meta_options()._lb_opts.balancer_in_turn;
-        _only_primary_balancer = _svc->get_meta_options()._lb_opts.only_primary_balancer;
-        _only_move_primary = _svc->get_meta_options()._lb_opts.only_move_primary;
-    } else {
-        _balancer_in_turn = false;
-        _only_primary_balancer = false;
-        _only_move_primary = false;
-    }
-    _app_balance_policy = dsn::make_unique<app_balance_policy>();
+    _app_balance_policy = dsn::make_unique<app_balance_policy>(_svc);
 
     ::memset(t_operation_counters, 0, sizeof(t_operation_counters));
 

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -35,6 +35,7 @@
 #include "greedy_load_balancer.h"
 #include "meta_data.h"
 #include "meta_admin_types.h"
+#include "app_balance_policy.h"
 
 namespace dsn {
 namespace replication {
@@ -102,131 +103,6 @@ void get_min_max_set(const std::map<rpc_address, uint32_t> &node_count_map,
     }
 }
 
-const std::string &get_disk_tag(const app_mapper &apps, const rpc_address &node, const gpid &pid)
-{
-    const config_context &cc = *get_config_context(apps, pid);
-    auto iter = cc.find_from_serving(node);
-    dassert(iter != cc.serving.end(),
-            "can't find disk tag of gpid(%d.%d) for %s",
-            pid.get_app_id(),
-            pid.get_partition_index(),
-            node.to_string());
-    return iter->disk_tag;
-}
-
-std::shared_ptr<configuration_balancer_request>
-generate_balancer_request(const app_mapper &apps,
-                          const partition_configuration &pc,
-                          const balance_type &type,
-                          const rpc_address &from,
-                          const rpc_address &to)
-{
-    FAIL_POINT_INJECT_F("generate_balancer_request", [](string_view name) { return nullptr; });
-
-    configuration_balancer_request result;
-    result.gpid = pc.pid;
-
-    std::string ans;
-    switch (type) {
-    case balance_type::MOVE_PRIMARY:
-        ans = "move_primary";
-        result.balance_type = balancer_request_type::move_primary;
-        result.action_list.emplace_back(
-            new_proposal_action(from, from, config_type::CT_DOWNGRADE_TO_SECONDARY));
-        result.action_list.emplace_back(
-            new_proposal_action(to, to, config_type::CT_UPGRADE_TO_PRIMARY));
-        break;
-    case balance_type::COPY_PRIMARY:
-        ans = "copy_primary";
-        result.balance_type = balancer_request_type::copy_primary;
-        result.action_list.emplace_back(
-            new_proposal_action(from, to, config_type::CT_ADD_SECONDARY_FOR_LB));
-        result.action_list.emplace_back(
-            new_proposal_action(from, from, config_type::CT_DOWNGRADE_TO_SECONDARY));
-        result.action_list.emplace_back(
-            new_proposal_action(to, to, config_type::CT_UPGRADE_TO_PRIMARY));
-        result.action_list.emplace_back(new_proposal_action(to, from, config_type::CT_REMOVE));
-        break;
-    case balance_type::COPY_SECONDARY:
-        ans = "copy_secondary";
-        result.balance_type = balancer_request_type::copy_secondary;
-        result.action_list.emplace_back(
-            new_proposal_action(pc.primary, to, config_type::CT_ADD_SECONDARY_FOR_LB));
-        result.action_list.emplace_back(
-            new_proposal_action(pc.primary, from, config_type::CT_REMOVE));
-        break;
-    default:
-        dassert(false, "");
-    }
-    ddebug("generate balancer: %d.%d %s from %s of disk_tag(%s) to %s",
-           pc.pid.get_app_id(),
-           pc.pid.get_partition_index(),
-           ans.c_str(),
-           from.to_string(),
-           get_disk_tag(apps, from, pc.pid).c_str(),
-           to.to_string());
-    return std::make_shared<configuration_balancer_request>(std::move(result));
-}
-
-void dump_disk_load(app_id id, const rpc_address &node, bool only_primary, const disk_load &load)
-{
-    std::ostringstream load_string;
-    load_string << std::endl << "<<<<<<<<<<" << std::endl;
-    load_string << "load for " << node.to_string() << ", "
-                << "app id: " << id;
-    if (only_primary) {
-        load_string << ", only for primary";
-    }
-    load_string << std::endl;
-
-    for (const auto &kv : load) {
-        load_string << kv.first << ": " << kv.second << std::endl;
-    }
-    load_string << ">>>>>>>>>>";
-    dinfo("%s", load_string.str().c_str());
-}
-
-bool calc_disk_load(node_mapper &nodes,
-                    const app_mapper &apps,
-                    app_id id,
-                    const rpc_address &node,
-                    bool only_primary,
-                    /*out*/ disk_load &load)
-{
-    load.clear();
-    const node_state *ns = get_node_state(nodes, node, false);
-    dassert(ns != nullptr, "can't find node(%s) from node_state", node.to_string());
-
-    auto add_one_replica_to_disk_load = [&](const gpid &pid) {
-        dinfo("add gpid(%d.%d) to node(%s) disk load",
-              pid.get_app_id(),
-              pid.get_partition_index(),
-              node.to_string());
-        const config_context &cc = *get_config_context(apps, pid);
-        auto iter = cc.find_from_serving(node);
-        if (iter == cc.serving.end()) {
-            dwarn("can't collect gpid(%d.%d)'s info from %s, which should be primary",
-                  pid.get_app_id(),
-                  pid.get_partition_index(),
-                  node.to_string());
-            return false;
-        } else {
-            load[iter->disk_tag]++;
-            return true;
-        }
-    };
-
-    if (only_primary) {
-        bool result = ns->for_each_primary(id, add_one_replica_to_disk_load);
-        dump_disk_load(id, node, only_primary, load);
-        return result;
-    } else {
-        bool result = ns->for_each_partition(id, add_one_replica_to_disk_load);
-        dump_disk_load(id, node, only_primary, load);
-        return result;
-    }
-}
-
 greedy_load_balancer::greedy_load_balancer(meta_service *_svc)
     : server_load_balancer(_svc),
       _ctrl_balancer_ignored_apps(nullptr),
@@ -244,6 +120,7 @@ greedy_load_balancer::greedy_load_balancer(meta_service *_svc)
         _only_primary_balancer = false;
         _only_move_primary = false;
     }
+    _app_balance_policy = dsn::make_unique<app_balance_policy>();
 
     ::memset(t_operation_counters, 0, sizeof(t_operation_counters));
 
@@ -269,64 +146,22 @@ greedy_load_balancer::greedy_load_balancer(meta_service *_svc)
         "copy secondary count by balancer in the recent period");
 }
 
-greedy_load_balancer::~greedy_load_balancer()
-{
-    UNREGISTER_VALID_HANDLER(_ctrl_balancer_in_turn);
-    UNREGISTER_VALID_HANDLER(_ctrl_only_primary_balancer);
-    UNREGISTER_VALID_HANDLER(_ctrl_only_move_primary);
-    UNREGISTER_VALID_HANDLER(_get_balance_operation_count);
-    UNREGISTER_VALID_HANDLER(_ctrl_balancer_ignored_apps);
-}
+greedy_load_balancer::~greedy_load_balancer() { unregister_ctrl_commands(); }
 
 void greedy_load_balancer::register_ctrl_commands()
 {
-    _ctrl_balancer_in_turn = dsn::command_manager::instance().register_command(
-        {"meta.lb.balancer_in_turn"},
-        "meta.lb.balancer_in_turn <true|false>",
-        "control whether do app balancer in turn",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_balancer_in_turn, "lb.balancer_in_turn", args);
-        });
-
-    _ctrl_only_primary_balancer = dsn::command_manager::instance().register_command(
-        {"meta.lb.only_primary_balancer"},
-        "meta.lb.only_primary_balancer <true|false>",
-        "control whether do only primary balancer",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(
-                _only_primary_balancer, "lb.only_primary_balancer", args);
-        });
-
-    _ctrl_only_move_primary = dsn::command_manager::instance().register_command(
-        {"meta.lb.only_move_primary"},
-        "meta.lb.only_move_primary <true|false>",
-        "control whether only move primary in balancer",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_only_move_primary, "lb.only_move_primary", args);
-        });
-
     _get_balance_operation_count = dsn::command_manager::instance().register_command(
         {"meta.lb.get_balance_operation_count"},
         "meta.lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]",
         "get balance operation count",
         [this](const std::vector<std::string> &args) { return get_balance_operation_count(args); });
-
-    _ctrl_balancer_ignored_apps = dsn::command_manager::instance().register_command(
-        {"meta.lb.ignored_app_list"},
-        "meta.lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]",
-        "get, set and clear balancer ignored_app_list",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_balancer_ignored_app_ids(args);
-        });
+    _app_balance_policy->register_ctrl_commands();
 }
 
 void greedy_load_balancer::unregister_ctrl_commands()
 {
-    UNREGISTER_VALID_HANDLER(_ctrl_balancer_in_turn);
-    UNREGISTER_VALID_HANDLER(_ctrl_only_primary_balancer);
-    UNREGISTER_VALID_HANDLER(_ctrl_only_move_primary);
     UNREGISTER_VALID_HANDLER(_get_balance_operation_count);
-    UNREGISTER_VALID_HANDLER(_ctrl_balancer_ignored_apps);
+    _app_balance_policy->unregister_ctrl_commands();
 }
 
 std::string greedy_load_balancer::get_balance_operation_count(const std::vector<std::string> &args)
@@ -406,17 +241,6 @@ bool greedy_load_balancer::copy_primary(const std::shared_ptr<app_state> &app,
     return operation->start(t_migration_result);
 }
 
-bool greedy_load_balancer::copy_secondary(const std::shared_ptr<app_state> &app, bool place_holder)
-{
-    node_mapper &nodes = *(t_global_view->nodes);
-    const app_mapper &apps = *t_global_view->apps;
-    int replicas_low = app->partition_count / t_alive_nodes;
-
-    std::unique_ptr<copy_replica_operation> operation = dsn::make_unique<copy_secondary_operation>(
-        app, apps, nodes, address_vec, address_id, replicas_low);
-    return operation->start(t_migration_result);
-}
-
 void greedy_load_balancer::number_nodes(const node_mapper &nodes)
 {
     int current_id = 1;
@@ -430,140 +254,6 @@ void greedy_load_balancer::number_nodes(const node_mapper &nodes)
         address_id[iter->first] = current_id;
         address_vec[current_id] = iter->first;
         ++current_id;
-    }
-}
-
-ford_fulkerson::ford_fulkerson(const std::shared_ptr<app_state> &app,
-                               const node_mapper &nodes,
-                               const std::unordered_map<dsn::rpc_address, int> &address_id,
-                               uint32_t higher_count,
-                               uint32_t lower_count,
-                               int replicas_low)
-    : _app(app),
-      _nodes(nodes),
-      _address_id(address_id),
-      _higher_count(higher_count),
-      _lower_count(lower_count),
-      _replicas_low(replicas_low)
-{
-    make_graph();
-}
-
-// using dijstra to find shortest path
-std::unique_ptr<flow_path> ford_fulkerson::find_shortest_path()
-{
-    std::vector<bool> visit(_graph_nodes, false);
-    std::vector<int> flow(_graph_nodes, 0);
-    std::vector<int> prev(_graph_nodes, -1);
-    flow[0] = INT_MAX;
-    while (!visit.back()) {
-        auto pos = select_node(visit, flow);
-        if (pos == -1) {
-            break;
-        }
-        update_flow(pos, visit, _network, flow, prev);
-    }
-
-    if (visit.back() && flow.back() != 0) {
-        return dsn::make_unique<struct flow_path>(_app, std::move(flow), std::move(prev));
-    } else {
-        return nullptr;
-    }
-}
-
-void ford_fulkerson::make_graph()
-{
-    _graph_nodes = _nodes.size() + 2;
-    _network.resize(_graph_nodes, std::vector<int>(_graph_nodes, 0));
-    for (const auto &node : _nodes) {
-        int node_id = _address_id.at(node.first);
-        add_edge(node_id, node.second);
-        update_decree(node_id, node.second);
-    }
-    handle_corner_case();
-}
-
-void ford_fulkerson::add_edge(int node_id, const node_state &ns)
-{
-    int primary_count = ns.primary_count(_app->app_id);
-    if (primary_count > _replicas_low) {
-        _network[0][node_id] = primary_count - _replicas_low;
-    } else {
-        _network[node_id].back() = _replicas_low - primary_count;
-    }
-}
-
-void ford_fulkerson::update_decree(int node_id, const node_state &ns)
-{
-    ns.for_each_primary(_app->app_id, [&, this](const gpid &pid) {
-        const partition_configuration &pc = _app->partitions[pid.get_partition_index()];
-        for (const auto &secondary : pc.secondaries) {
-            auto i = _address_id.find(secondary);
-            dassert_f(i != _address_id.end(),
-                      "invalid secondary address, address = {}",
-                      secondary.to_string());
-            _network[node_id][i->second]++;
-        }
-        return true;
-    });
-}
-
-void ford_fulkerson::handle_corner_case()
-{
-    // Suppose you have an 8-shard app in a cluster with 3 nodes(which name are node1, node2,
-    // node3). The distribution of primaries among these nodes is as follow:
-    // node1 : [0, 1, 2, 3]
-    // node2 : [4, 5]
-    // node2 : [6, 7]
-    // This is obviously unbalanced.
-    // But if we don't handle this corner case, primary migration will not be triggered
-    if (_higher_count > 0 && _lower_count == 0) {
-        for (int i = 0; i != _graph_nodes; ++i) {
-            if (_network[0][i] > 0)
-                --_network[0][i];
-            else
-                ++_network[i][_graph_nodes - 1];
-        }
-    }
-}
-
-int ford_fulkerson::select_node(std::vector<bool> &visit, const std::vector<int> &flow)
-{
-    auto pos = max_value_pos(visit, flow);
-    if (pos != -1) {
-        visit[pos] = true;
-    }
-    return pos;
-}
-
-int ford_fulkerson::max_value_pos(const std::vector<bool> &visit, const std::vector<int> &flow)
-{
-    int pos = -1, max_value = 0;
-    for (auto i = 0; i != _graph_nodes; ++i) {
-        if (!visit[i] && flow[i] > max_value) {
-            pos = i;
-            max_value = flow[i];
-        }
-    }
-    return pos;
-}
-
-void ford_fulkerson::update_flow(int pos,
-                                 const std::vector<bool> &visit,
-                                 const std::vector<std::vector<int>> &network,
-                                 std::vector<int> &flow,
-                                 std::vector<int> &prev)
-{
-    for (auto i = 0; i != _graph_nodes; ++i) {
-        if (visit[i]) {
-            continue;
-        }
-
-        auto min = std::min(flow[pos], network[pos][i]);
-        if (min > flow[i]) {
-            flow[i] = min;
-            prev[i] = pos;
-        }
     }
 }
 
@@ -737,58 +427,13 @@ void greedy_load_balancer::greedy_balancer(const bool balance_checker)
     }
 
     if (!FLAGS_balance_cluster) {
-        app_balancer(balance_checker);
+        _app_balance_policy->balance(balance_checker, t_global_view, t_migration_result);
         return;
     }
 
     if (!balance_checker) {
         balance_cluster();
     }
-}
-
-void greedy_load_balancer::app_balancer(bool balance_checker)
-{
-    const app_mapper &apps = *t_global_view->apps;
-    if (!execute_balance(apps,
-                         balance_checker,
-                         _balancer_in_turn,
-                         _only_move_primary,
-                         std::bind(&greedy_load_balancer::primary_balance,
-                                   this,
-                                   std::placeholders::_1,
-                                   std::placeholders::_2))) {
-        return;
-    }
-
-    if (!need_balance_secondaries(balance_checker)) {
-        return;
-    }
-
-    // we seperate the primary/secondary balancer for 2 reasons:
-    // 1. globally primary balancer may make secondary unbalanced
-    // 2. in one-by-one mode, a secondary balance decision for an app may be prior than
-    // another app's primary balancer if not seperated.
-    execute_balance(apps,
-                    balance_checker,
-                    _balancer_in_turn,
-                    _only_move_primary,
-                    std::bind(&greedy_load_balancer::copy_secondary,
-                              this,
-                              std::placeholders::_1,
-                              std::placeholders::_2));
-}
-
-bool greedy_load_balancer::need_balance_secondaries(bool balance_checker)
-{
-    if (!balance_checker && !t_migration_result->empty()) {
-        ddebug("stop to do secondary balance coz we already has actions to do");
-        return false;
-    }
-    if (_only_primary_balancer) {
-        ddebug("stop to do secondary balancer coz it is not allowed");
-        return false;
-    }
-    return true;
 }
 
 bool greedy_load_balancer::execute_balance(
@@ -1407,147 +1052,6 @@ bool greedy_load_balancer::is_ignored_app(app_id app_id)
     return _balancer_ignored_apps.find(app_id) != _balancer_ignored_apps.end();
 }
 
-std::unordered_map<dsn::rpc_address, disk_load>
-get_node_loads(const std::shared_ptr<app_state> &app,
-               const app_mapper &apps,
-               node_mapper &nodes,
-               bool only_primary)
-{
-    std::unordered_map<dsn::rpc_address, disk_load> node_loads;
-    for (auto iter = nodes.begin(); iter != nodes.end(); ++iter) {
-        if (!calc_disk_load(
-                nodes, apps, app->app_id, iter->first, only_primary, node_loads[iter->first])) {
-            dwarn_f("stop the balancer as some replica infos aren't collected, node({}), app({})",
-                    iter->first.to_string(),
-                    app->get_logname());
-            return node_loads;
-        }
-    }
-    return node_loads;
-}
-
-copy_replica_operation::copy_replica_operation(
-    const std::shared_ptr<app_state> app,
-    const app_mapper &apps,
-    node_mapper &nodes,
-    const std::vector<dsn::rpc_address> &address_vec,
-    const std::unordered_map<dsn::rpc_address, int> &address_id)
-    : _app(app), _apps(apps), _nodes(nodes), _address_vec(address_vec), _address_id(address_id)
-{
-}
-
-bool copy_replica_operation::start(migration_list *result)
-{
-    init_ordered_address_ids();
-    _node_loads = get_node_loads(_app, _apps, _nodes, only_copy_primary());
-    if (_node_loads.size() != _nodes.size()) {
-        return false;
-    }
-
-    while (true) {
-        if (!can_continue()) {
-            break;
-        }
-
-        gpid selected_pid = select_partition(result);
-        if (selected_pid.get_app_id() != -1) {
-            copy_once(selected_pid, result);
-            update_ordered_address_ids();
-        } else {
-            _ordered_address_ids.erase(--_ordered_address_ids.end());
-        }
-    }
-    return true;
-}
-
-const partition_set *copy_replica_operation::get_all_partitions()
-{
-    int id_max = *_ordered_address_ids.rbegin();
-    const node_state &ns = _nodes.find(_address_vec[id_max])->second;
-    const partition_set *partitions = ns.partitions(_app->app_id, only_copy_primary());
-    return partitions;
-}
-
-gpid copy_replica_operation::select_max_load_gpid(const partition_set *partitions,
-                                                  migration_list *result)
-{
-    int id_max = *_ordered_address_ids.rbegin();
-    const disk_load &load_on_max = _node_loads.at(_address_vec[id_max]);
-
-    gpid selected_pid(-1, -1);
-    int max_load = -1;
-    for (const gpid &pid : *partitions) {
-        if (!can_select(pid, result)) {
-            continue;
-        }
-
-        const std::string &disk_tag = get_disk_tag(_apps, _address_vec[id_max], pid);
-        auto load = load_on_max.at(disk_tag);
-        if (load > max_load) {
-            selected_pid = pid;
-            max_load = load;
-        }
-    }
-    return selected_pid;
-}
-
-void copy_replica_operation::copy_once(gpid selected_pid, migration_list *result)
-{
-    auto from = _address_vec[*_ordered_address_ids.rbegin()];
-    auto to = _address_vec[*_ordered_address_ids.begin()];
-
-    auto pc = _app->partitions[selected_pid.get_partition_index()];
-    auto request = generate_balancer_request(_apps, pc, get_balance_type(), from, to);
-    result->emplace(selected_pid, request);
-}
-
-void copy_replica_operation::update_ordered_address_ids()
-{
-    int id_min = *_ordered_address_ids.begin();
-    int id_max = *_ordered_address_ids.rbegin();
-    --_partition_counts[id_max];
-    ++_partition_counts[id_min];
-
-    _ordered_address_ids.erase(_ordered_address_ids.begin());
-    _ordered_address_ids.erase(--_ordered_address_ids.end());
-
-    _ordered_address_ids.insert(id_max);
-    _ordered_address_ids.insert(id_min);
-}
-
-void copy_replica_operation::init_ordered_address_ids()
-{
-    _partition_counts.resize(_address_vec.size(), 0);
-    for (const auto &iter : _nodes) {
-        auto id = _address_id.at(iter.first);
-        _partition_counts[id] = get_partition_count(iter.second);
-    }
-
-    std::set<int, std::function<bool(int a, int b)>> ordered_queue([this](int a, int b) {
-        return _partition_counts[a] != _partition_counts[b]
-                   ? _partition_counts[a] < _partition_counts[b]
-                   : a < b;
-    });
-    for (const auto &iter : _nodes) {
-        auto id = _address_id.at(iter.first);
-        ordered_queue.insert(id);
-    }
-    _ordered_address_ids.swap(ordered_queue);
-}
-
-gpid copy_replica_operation::select_partition(migration_list *result)
-{
-    const partition_set *partitions = get_all_partitions();
-
-    int id_max = *_ordered_address_ids.rbegin();
-    const node_state &ns = _nodes.find(_address_vec[id_max])->second;
-    dassert_f(partitions != nullptr && !partitions->empty(),
-              "max load({}) shouldn't empty",
-              ns.addr().to_string());
-
-    return select_max_load_gpid(partitions, result);
-}
-
 copy_primary_operation::copy_primary_operation(
     const std::shared_ptr<app_state> app,
     const app_mapper &apps,
@@ -1591,71 +1095,5 @@ bool copy_primary_operation::can_continue()
 }
 
 enum balance_type copy_primary_operation::get_balance_type() { return balance_type::COPY_PRIMARY; }
-
-copy_secondary_operation::copy_secondary_operation(
-    const std::shared_ptr<app_state> app,
-    const app_mapper &apps,
-    node_mapper &nodes,
-    const std::vector<dsn::rpc_address> &address_vec,
-    const std::unordered_map<dsn::rpc_address, int> &address_id,
-    int replicas_low)
-    : copy_replica_operation(app, apps, nodes, address_vec, address_id), _replicas_low(replicas_low)
-{
-}
-
-bool copy_secondary_operation::can_continue()
-{
-    int id_min = *_ordered_address_ids.begin();
-    int id_max = *_ordered_address_ids.rbegin();
-    if (_partition_counts[id_max] <= _replicas_low ||
-        _partition_counts[id_max] - _partition_counts[id_min] <= 1) {
-        ddebug_f("{}: stop copy secondary coz it will be balanced later", _app->get_logname());
-        return false;
-    }
-    return true;
-}
-
-int copy_secondary_operation::get_partition_count(const node_state &ns) const
-{
-    return ns.partition_count(_app->app_id);
-}
-
-bool copy_secondary_operation::can_select(gpid pid, migration_list *result)
-{
-    int id_max = *_ordered_address_ids.rbegin();
-    const node_state &max_ns = _nodes.at(_address_vec[id_max]);
-    if (max_ns.served_as(pid) == partition_status::PS_PRIMARY) {
-        dinfo_f("{}: skip gpid({}.{}) coz it is primary",
-                _app->get_logname(),
-                pid.get_app_id(),
-                pid.get_partition_index());
-        return false;
-    }
-
-    // if the pid have been used
-    if (result->find(pid) != result->end()) {
-        dinfo_f("{}: skip gpid({}.{}) coz it is already copyed",
-                _app->get_logname(),
-                pid.get_app_id(),
-                pid.get_partition_index());
-        return false;
-    }
-
-    int id_min = *_ordered_address_ids.begin();
-    const node_state &min_ns = _nodes.at(_address_vec[id_min]);
-    if (min_ns.served_as(pid) != partition_status::PS_INACTIVE) {
-        dinfo_f("{}: skip gpid({}.{}) coz it is already a member on the target node",
-                _app->get_logname(),
-                pid.get_app_id(),
-                pid.get_partition_index());
-        return false;
-    }
-    return true;
-}
-
-enum balance_type copy_secondary_operation::get_balance_type()
-{
-    return balance_type::COPY_SECONDARY;
-}
 } // namespace replication
 } // namespace dsn

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -141,17 +141,11 @@ void greedy_load_balancer::register_ctrl_commands()
         "meta.lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]",
         "get balance operation count",
         [this](const std::vector<std::string> &args) { return get_balance_operation_count(args); });
-    if (_app_balance_policy != nullptr) {
-        _app_balance_policy->register_ctrl_commands();
-    }
 }
 
 void greedy_load_balancer::unregister_ctrl_commands()
 {
     UNREGISTER_VALID_HANDLER(_get_balance_operation_count);
-    if (_app_balance_policy != nullptr) {
-        _app_balance_policy->unregister_ctrl_commands();
-    }
 }
 
 std::string greedy_load_balancer::get_balance_operation_count(const std::vector<std::string> &args)
@@ -965,75 +959,6 @@ void greedy_load_balancer::report(const dsn::replication::migration_list &list,
         _recent_balance_copy_primary_count->add(counters[COPY_PRI_COUNT]);
         _recent_balance_copy_secondary_count->add(counters[COPY_SEC_COUNT]);
     }
-}
-
-std::string
-greedy_load_balancer::remote_command_balancer_ignored_app_ids(const std::vector<std::string> &args)
-{
-    static const std::string invalid_arguments("invalid arguments");
-    if (args.empty()) {
-        return invalid_arguments;
-    }
-    if (args[0] == "set") {
-        return set_balancer_ignored_app_ids(args);
-    }
-    if (args[0] == "get") {
-        return get_balancer_ignored_app_ids();
-    }
-    if (args[0] == "clear") {
-        return clear_balancer_ignored_app_ids();
-    }
-    return invalid_arguments;
-}
-
-std::string greedy_load_balancer::set_balancer_ignored_app_ids(const std::vector<std::string> &args)
-{
-    static const std::string invalid_arguments("invalid arguments");
-    if (args.size() != 2) {
-        return invalid_arguments;
-    }
-
-    std::vector<std::string> app_ids;
-    dsn::utils::split_args(args[1].c_str(), app_ids, ',');
-    if (app_ids.empty()) {
-        return invalid_arguments;
-    }
-
-    std::set<app_id> app_list;
-    for (const std::string &app_id_str : app_ids) {
-        app_id app;
-        if (!dsn::buf2int32(app_id_str, app)) {
-            return invalid_arguments;
-        }
-        app_list.insert(app);
-    }
-
-    dsn::zauto_write_lock l(_balancer_ignored_apps_lock);
-    _balancer_ignored_apps = std::move(app_list);
-    return "set ok";
-}
-
-std::string greedy_load_balancer::get_balancer_ignored_app_ids()
-{
-    std::stringstream oss;
-    dsn::zauto_read_lock l(_balancer_ignored_apps_lock);
-    if (_balancer_ignored_apps.empty()) {
-        return "no ignored apps";
-    }
-    oss << "ignored_app_id_list: ";
-    std::copy(_balancer_ignored_apps.begin(),
-              _balancer_ignored_apps.end(),
-              std::ostream_iterator<app_id>(oss, ","));
-    std::string app_ids = oss.str();
-    app_ids[app_ids.size() - 1] = '\0';
-    return app_ids;
-}
-
-std::string greedy_load_balancer::clear_balancer_ignored_app_ids()
-{
-    dsn::zauto_write_lock l(_balancer_ignored_apps_lock);
-    _balancer_ignored_apps.clear();
-    return "clear ok";
 }
 
 bool greedy_load_balancer::is_ignored_app(app_id app_id)

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -141,13 +141,17 @@ void greedy_load_balancer::register_ctrl_commands()
         "meta.lb.get_balance_operation_count [total | move_pri | copy_pri | copy_sec | detail]",
         "get balance operation count",
         [this](const std::vector<std::string> &args) { return get_balance_operation_count(args); });
-    _app_balance_policy->register_ctrl_commands();
+    if (_app_balance_policy != nullptr) {
+        _app_balance_policy->register_ctrl_commands();
+    }
 }
 
 void greedy_load_balancer::unregister_ctrl_commands()
 {
     UNREGISTER_VALID_HANDLER(_get_balance_operation_count);
-    _app_balance_policy->unregister_ctrl_commands();
+    if (_app_balance_policy != nullptr) {
+        _app_balance_policy->unregister_ctrl_commands();
+    }
 }
 
 std::string greedy_load_balancer::get_balance_operation_count(const std::vector<std::string> &args)

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -254,11 +254,6 @@ private:
 
     bool all_replica_infos_collected(const node_state &ns);
 
-    std::string remote_command_balancer_ignored_app_ids(const std::vector<std::string> &args);
-    std::string set_balancer_ignored_app_ids(const std::vector<std::string> &args);
-    std::string get_balancer_ignored_app_ids();
-    std::string clear_balancer_ignored_app_ids();
-
     bool is_ignored_app(app_id app_id);
 
     FRIEND_TEST(greedy_load_balancer, app_migration_info);

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -86,19 +86,10 @@ private:
 
     std::unique_ptr<load_balance_policy> _app_balance_policy;
 
-    // options
-    bool _balancer_in_turn;
-    bool _only_primary_balancer;
-    bool _only_move_primary;
-
     // the app set which won't be re-balanced
     std::set<app_id> _balancer_ignored_apps;
     dsn::zrwlock_nr _balancer_ignored_apps_lock;
 
-    dsn_handle_t _ctrl_balancer_ignored_apps;
-    dsn_handle_t _ctrl_balancer_in_turn;
-    dsn_handle_t _ctrl_only_primary_balancer;
-    dsn_handle_t _ctrl_only_move_primary;
     dsn_handle_t _get_balance_operation_count;
 
     // perf counters

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -169,6 +169,15 @@ generate_balancer_request(const app_mapper &apps,
     return std::make_shared<configuration_balancer_request>(std::move(result));
 }
 
+void load_balance_policy::init(const meta_view *global_view, migration_list *list)
+{
+    _global_view = global_view;
+    _migration_result = list;
+    const node_mapper &nodes = *_global_view->nodes;
+    _alive_nodes = nodes.size();
+    number_nodes(nodes);
+}
+
 bool load_balance_policy::primary_balance(const std::shared_ptr<app_state> &app,
                                           bool only_move_primary)
 {

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -169,6 +169,8 @@ generate_balancer_request(const app_mapper &apps,
     return std::make_shared<configuration_balancer_request>(std::move(result));
 }
 
+load_balance_policy::load_balance_policy(meta_service *svc) : _svc(svc) {}
+
 void load_balance_policy::init(const meta_view *global_view, migration_list *list)
 {
     _global_view = global_view;

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -172,9 +172,10 @@ generate_balancer_request(const app_mapper &apps,
 load_balance_policy::load_balance_policy(meta_service *svc)
     : _svc(svc), _ctrl_balancer_ignored_apps(nullptr)
 {
+    register_ctrl_commands();
 }
 
-load_balance_policy::~load_balance_policy() = default;
+load_balance_policy::~load_balance_policy() { unregister_ctrl_commands(); }
 
 void load_balance_policy::init(const meta_view *global_view, migration_list *list)
 {

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -174,6 +174,8 @@ load_balance_policy::load_balance_policy(meta_service *svc)
 {
 }
 
+load_balance_policy::~load_balance_policy() = default;
+
 void load_balance_policy::init(const meta_view *global_view, migration_list *list)
 {
     _global_view = global_view;

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -713,11 +713,12 @@ void copy_replica_operation::init_ordered_address_ids()
         _partition_counts[id] = get_partition_count(iter.second);
     }
 
-    std::set<int, std::function<bool(int a, int b)>> ordered_queue([this](int a, int b) {
-        return _partition_counts[a] != _partition_counts[b]
-                   ? _partition_counts[a] < _partition_counts[b]
-                   : a < b;
-    });
+    std::set<int, std::function<bool(int left, int right)>> ordered_queue(
+        [this](int left, int right) {
+            return _partition_counts[left] != _partition_counts[right]
+                       ? _partition_counts[left] < _partition_counts[right]
+                       : left < right;
+        });
     for (const auto &iter : _nodes) {
         auto id = _address_id.at(iter.first);
         ordered_queue.insert(id);

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -1,0 +1,726 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "load_balance_policy.h"
+#include "greedy_load_balancer.h"
+
+#include <dsn/tool-api/command_manager.h>
+#include <dsn/dist/fmt_logging.h>
+#include <dsn/utility/fail_point.h>
+
+namespace dsn {
+namespace replication {
+
+void dump_disk_load(app_id id, const rpc_address &node, bool only_primary, const disk_load &load)
+{
+    std::ostringstream load_string;
+    load_string << std::endl << "<<<<<<<<<<" << std::endl;
+    load_string << "load for " << node.to_string() << ", "
+                << "app id: " << id;
+    if (only_primary) {
+        load_string << ", only for primary";
+    }
+    load_string << std::endl;
+
+    for (const auto &kv : load) {
+        load_string << kv.first << ": " << kv.second << std::endl;
+    }
+    load_string << ">>>>>>>>>>";
+    dinfo("%s", load_string.str().c_str());
+}
+
+bool calc_disk_load(node_mapper &nodes,
+                    const app_mapper &apps,
+                    app_id id,
+                    const rpc_address &node,
+                    bool only_primary,
+                    /*out*/ disk_load &load)
+{
+    load.clear();
+    const node_state *ns = get_node_state(nodes, node, false);
+    dassert(ns != nullptr, "can't find node(%s) from node_state", node.to_string());
+
+    auto add_one_replica_to_disk_load = [&](const gpid &pid) {
+        dinfo("add gpid(%d.%d) to node(%s) disk load",
+              pid.get_app_id(),
+              pid.get_partition_index(),
+              node.to_string());
+        const config_context &cc = *get_config_context(apps, pid);
+        auto iter = cc.find_from_serving(node);
+        if (iter == cc.serving.end()) {
+            dwarn("can't collect gpid(%d.%d)'s info from %s, which should be primary",
+                  pid.get_app_id(),
+                  pid.get_partition_index(),
+                  node.to_string());
+            return false;
+        } else {
+            load[iter->disk_tag]++;
+            return true;
+        }
+    };
+
+    if (only_primary) {
+        bool result = ns->for_each_primary(id, add_one_replica_to_disk_load);
+        dump_disk_load(id, node, only_primary, load);
+        return result;
+    } else {
+        bool result = ns->for_each_partition(id, add_one_replica_to_disk_load);
+        dump_disk_load(id, node, only_primary, load);
+        return result;
+    }
+}
+
+std::unordered_map<dsn::rpc_address, disk_load>
+get_node_loads(const std::shared_ptr<app_state> &app,
+               const app_mapper &apps,
+               node_mapper &nodes,
+               bool only_primary)
+{
+    std::unordered_map<dsn::rpc_address, disk_load> node_loads;
+    for (auto iter = nodes.begin(); iter != nodes.end(); ++iter) {
+        if (!calc_disk_load(
+                nodes, apps, app->app_id, iter->first, only_primary, node_loads[iter->first])) {
+            dwarn_f("stop the balancer as some replica infos aren't collected, node({}), app({})",
+                    iter->first.to_string(),
+                    app->get_logname());
+            return node_loads;
+        }
+    }
+    return node_loads;
+}
+
+const std::string &get_disk_tag(const app_mapper &apps, const rpc_address &node, const gpid &pid)
+{
+    const config_context &cc = *get_config_context(apps, pid);
+    auto iter = cc.find_from_serving(node);
+    dassert(iter != cc.serving.end(),
+            "can't find disk tag of gpid(%d.%d) for %s",
+            pid.get_app_id(),
+            pid.get_partition_index(),
+            node.to_string());
+    return iter->disk_tag;
+}
+
+std::shared_ptr<configuration_balancer_request>
+generate_balancer_request(const app_mapper &apps,
+                          const partition_configuration &pc,
+                          const balance_type &type,
+                          const rpc_address &from,
+                          const rpc_address &to)
+{
+    FAIL_POINT_INJECT_F("generate_balancer_request", [](string_view name) { return nullptr; });
+
+    configuration_balancer_request result;
+    result.gpid = pc.pid;
+
+    std::string ans;
+    switch (type) {
+    case balance_type::MOVE_PRIMARY:
+        ans = "move_primary";
+        result.balance_type = balancer_request_type::move_primary;
+        result.action_list.emplace_back(
+            new_proposal_action(from, from, config_type::CT_DOWNGRADE_TO_SECONDARY));
+        result.action_list.emplace_back(
+            new_proposal_action(to, to, config_type::CT_UPGRADE_TO_PRIMARY));
+        break;
+    case balance_type::COPY_PRIMARY:
+        ans = "copy_primary";
+        result.balance_type = balancer_request_type::copy_primary;
+        result.action_list.emplace_back(
+            new_proposal_action(from, to, config_type::CT_ADD_SECONDARY_FOR_LB));
+        result.action_list.emplace_back(
+            new_proposal_action(from, from, config_type::CT_DOWNGRADE_TO_SECONDARY));
+        result.action_list.emplace_back(
+            new_proposal_action(to, to, config_type::CT_UPGRADE_TO_PRIMARY));
+        result.action_list.emplace_back(new_proposal_action(to, from, config_type::CT_REMOVE));
+        break;
+    case balance_type::COPY_SECONDARY:
+        ans = "copy_secondary";
+        result.balance_type = balancer_request_type::copy_secondary;
+        result.action_list.emplace_back(
+            new_proposal_action(pc.primary, to, config_type::CT_ADD_SECONDARY_FOR_LB));
+        result.action_list.emplace_back(
+            new_proposal_action(pc.primary, from, config_type::CT_REMOVE));
+        break;
+    default:
+        dassert(false, "");
+    }
+    ddebug("generate balancer: %d.%d %s from %s of disk_tag(%s) to %s",
+           pc.pid.get_app_id(),
+           pc.pid.get_partition_index(),
+           ans.c_str(),
+           from.to_string(),
+           get_disk_tag(apps, from, pc.pid).c_str(),
+           to.to_string());
+    return std::make_shared<configuration_balancer_request>(std::move(result));
+}
+
+bool load_balance_policy::primary_balance(const std::shared_ptr<app_state> &app,
+                                          bool only_move_primary)
+{
+    dassert(_alive_nodes > 2, "too few alive nodes will lead to freeze");
+    ddebug_f("primary balancer for app({}:{})", app->app_name, app->app_id);
+
+    auto graph = ford_fulkerson::builder(app, *_global_view->nodes, address_id).build();
+    if (nullptr == graph) {
+        dinfo_f("the primaries are balanced for app({}:{})", app->app_name, app->app_id);
+        return true;
+    }
+
+    auto path = graph->find_shortest_path();
+    if (path != nullptr) {
+        dinfo_f("{} primaries are flew", path->_flow.back());
+        return move_primary(std::move(path));
+    } else {
+        ddebug_f("we can't make the server load more balanced by moving primaries to secondaries");
+        if (!only_move_primary) {
+            return copy_primary(app, graph->have_less_than_average());
+        } else {
+            ddebug_f("stop to copy primary for app({}) coz it is disabled", app->get_logname());
+            return true;
+        }
+    }
+}
+
+bool load_balance_policy::copy_primary(const std::shared_ptr<app_state> &app,
+                                       bool still_have_less_than_average)
+{
+    node_mapper &nodes = *(_global_view->nodes);
+    const app_mapper &apps = *_global_view->apps;
+    int replicas_low = app->partition_count / _alive_nodes;
+
+    std::unique_ptr<copy_replica_operation> operation = dsn::make_unique<copy_primary_operation>(
+        app, apps, nodes, address_vec, address_id, still_have_less_than_average, replicas_low);
+    return operation->start(_migration_result);
+}
+
+bool load_balance_policy::move_primary(std::unique_ptr<flow_path> path)
+{
+    // used to calculate the primary disk loads of each server.
+    // disk_load[disk_tag] means how many primaies on this "disk_tag".
+    // IF disk_load.find(disk_tag) == disk_load.end(), means 0
+    disk_load loads[2];
+    disk_load *prev_load = &loads[0];
+    disk_load *current_load = &loads[1];
+    node_mapper &nodes = *(_global_view->nodes);
+    const app_mapper &apps = *(_global_view->apps);
+
+    int current = path->_prev.back();
+    if (!calc_disk_load(
+            nodes, apps, path->_app->app_id, address_vec[current], true, *current_load)) {
+        dwarn_f("stop move primary as some replica infos aren't collected, node({}), app({})",
+                address_vec[current].to_string(),
+                path->_app->get_logname());
+        return false;
+    }
+
+    int plan_moving = path->_flow.back();
+    while (path->_prev[current] != 0) {
+        rpc_address from = address_vec[path->_prev[current]];
+        rpc_address to = address_vec[current];
+        if (!calc_disk_load(nodes, apps, path->_app->app_id, from, true, *prev_load)) {
+            dwarn_f("stop move primary as some replica infos aren't collected, node({}), app({})",
+                    from.to_string(),
+                    path->_app->get_logname());
+            return false;
+        }
+
+        start_moving_primary(path->_app, from, to, plan_moving, prev_load, current_load);
+
+        current = path->_prev[current];
+        std::swap(current_load, prev_load);
+    }
+    return true;
+}
+
+void load_balance_policy::start_moving_primary(const std::shared_ptr<app_state> &app,
+                                               const rpc_address &from,
+                                               const rpc_address &to,
+                                               int plan_moving,
+                                               disk_load *prev_load,
+                                               disk_load *current_load)
+{
+    std::list<dsn::gpid> potential_moving = calc_potential_moving(app, from, to);
+    auto potential_moving_size = potential_moving.size();
+    dassert_f(plan_moving <= potential_moving_size,
+              "from({}) to({}) plan({}), can_move({})",
+              from.to_string(),
+              to.to_string(),
+              plan_moving,
+              potential_moving_size);
+
+    while (plan_moving-- > 0) {
+        dsn::gpid selected = select_moving(potential_moving, prev_load, current_load, from, to);
+
+        const partition_configuration &pc = app->partitions[selected.get_partition_index()];
+        auto balancer_result = _migration_result->emplace(
+            selected,
+            generate_balancer_request(
+                *_global_view->apps, pc, balance_type::MOVE_PRIMARY, from, to));
+        dassert_f(balancer_result.second, "gpid({}) already inserted as an action", selected);
+
+        --(*prev_load)[get_disk_tag(*_global_view->apps, from, selected)];
+        ++(*current_load)[get_disk_tag(*_global_view->apps, to, selected)];
+    }
+}
+
+std::list<dsn::gpid> load_balance_policy::calc_potential_moving(
+    const std::shared_ptr<app_state> &app, const rpc_address &from, const rpc_address &to)
+{
+    std::list<dsn::gpid> potential_moving;
+    const node_state &ns = _global_view->nodes->find(from)->second;
+    ns.for_each_primary(app->app_id, [&](const gpid &pid) {
+        const partition_configuration &pc = app->partitions[pid.get_partition_index()];
+        if (is_secondary(pc, to)) {
+            potential_moving.push_back(pid);
+        }
+        return true;
+    });
+    return potential_moving;
+}
+
+dsn::gpid load_balance_policy::select_moving(std::list<dsn::gpid> &potential_moving,
+                                             disk_load *prev_load,
+                                             disk_load *current_load,
+                                             rpc_address from,
+                                             rpc_address to)
+{
+    std::list<dsn::gpid>::iterator selected = potential_moving.end();
+    int max = std::numeric_limits<int>::min();
+
+    for (auto it = potential_moving.begin(); it != potential_moving.end(); ++it) {
+        int load_difference = (*prev_load)[get_disk_tag(*_global_view->apps, from, *it)] -
+                              (*current_load)[get_disk_tag(*_global_view->apps, to, *it)];
+        if (load_difference > max) {
+            max = load_difference;
+            selected = it;
+        }
+    }
+
+    dassert_f(selected != potential_moving.end(),
+              "can't find gpid to move from({}) to({})",
+              from.to_string(),
+              to.to_string());
+    auto res = *selected;
+    potential_moving.erase(selected);
+    return res;
+}
+
+bool load_balance_policy::execute_balance(
+    const app_mapper &apps,
+    bool balance_checker,
+    bool balance_in_turn,
+    bool only_move_primary,
+    const std::function<bool(const std::shared_ptr<app_state> &, bool)> &balance_operation)
+{
+    for (const auto &kv : apps) {
+        const std::shared_ptr<app_state> &app = kv.second;
+        if (is_ignored_app(kv.first)) {
+            ddebug_f("skip to do balance for the ignored app[{}]", app->get_logname());
+            continue;
+        }
+        if (app->status != app_status::AS_AVAILABLE || app->is_bulk_loading || app->splitting())
+            continue;
+
+        bool enough_information = balance_operation(app, only_move_primary);
+        if (!enough_information) {
+            // Even if we don't have enough info for current app,
+            // the decisions made by previous apps are kept.
+            // t_migration_result->empty();
+            return false;
+        }
+        if (!balance_checker) {
+            if (!_migration_result->empty()) {
+                if (balance_in_turn) {
+                    ddebug("stop to handle more apps after we found some actions for %s",
+                           app->get_logname());
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+void load_balance_policy::register_ctrl_commands()
+{
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        _ctrl_balancer_ignored_apps = dsn::command_manager::instance().register_command(
+            {"meta.lb.ignored_app_list"},
+            "meta.lb.ignored_app_list <get|set|clear> [app_id1,app_id2..]",
+            "get, set and clear balancer ignored_app_list",
+            [this](const std::vector<std::string> &args) {
+                return remote_command_balancer_ignored_app_ids(args);
+            });
+    });
+}
+
+void load_balance_policy::unregister_ctrl_commands()
+{
+    UNREGISTER_VALID_HANDLER(_ctrl_balancer_ignored_apps);
+}
+
+std::string
+load_balance_policy::remote_command_balancer_ignored_app_ids(const std::vector<std::string> &args)
+{
+    static const std::string invalid_arguments("invalid arguments");
+    if (args.empty()) {
+        return invalid_arguments;
+    }
+    if (args[0] == "set") {
+        return set_balancer_ignored_app_ids(args);
+    }
+    if (args[0] == "get") {
+        return get_balancer_ignored_app_ids();
+    }
+    if (args[0] == "clear") {
+        return clear_balancer_ignored_app_ids();
+    }
+    return invalid_arguments;
+}
+
+std::string load_balance_policy::set_balancer_ignored_app_ids(const std::vector<std::string> &args)
+{
+    static const std::string invalid_arguments("invalid arguments");
+    if (args.size() != 2) {
+        return invalid_arguments;
+    }
+
+    std::vector<std::string> app_ids;
+    dsn::utils::split_args(args[1].c_str(), app_ids, ',');
+    if (app_ids.empty()) {
+        return invalid_arguments;
+    }
+
+    std::set<app_id> app_list;
+    for (const std::string &app_id_str : app_ids) {
+        app_id app;
+        if (!dsn::buf2int32(app_id_str, app)) {
+            return invalid_arguments;
+        }
+        app_list.insert(app);
+    }
+
+    dsn::zauto_write_lock l(_balancer_ignored_apps_lock);
+    _balancer_ignored_apps = std::move(app_list);
+    return "set ok";
+}
+
+std::string load_balance_policy::get_balancer_ignored_app_ids()
+{
+    std::stringstream oss;
+    dsn::zauto_read_lock l(_balancer_ignored_apps_lock);
+    if (_balancer_ignored_apps.empty()) {
+        return "no ignored apps";
+    }
+    oss << "ignored_app_id_list: ";
+    std::copy(_balancer_ignored_apps.begin(),
+              _balancer_ignored_apps.end(),
+              std::ostream_iterator<app_id>(oss, ","));
+    std::string app_ids = oss.str();
+    app_ids[app_ids.size() - 1] = '\0';
+    return app_ids;
+}
+
+std::string load_balance_policy::clear_balancer_ignored_app_ids()
+{
+    dsn::zauto_write_lock l(_balancer_ignored_apps_lock);
+    _balancer_ignored_apps.clear();
+    return "clear ok";
+}
+
+bool load_balance_policy::is_ignored_app(app_id app_id)
+{
+    dsn::zauto_read_lock l(_balancer_ignored_apps_lock);
+    return _balancer_ignored_apps.find(app_id) != _balancer_ignored_apps.end();
+}
+
+void load_balance_policy::number_nodes(const node_mapper &nodes)
+{
+    int current_id = 1;
+
+    address_id.clear();
+    address_vec.resize(_alive_nodes + 2);
+    for (auto iter = nodes.begin(); iter != nodes.end(); ++iter) {
+        dassert(!iter->first.is_invalid() && !iter->second.addr().is_invalid(), "invalid address");
+        dassert(iter->second.alive(), "dead node");
+
+        address_id[iter->first] = current_id;
+        address_vec[current_id] = iter->first;
+        ++current_id;
+    }
+}
+
+ford_fulkerson::ford_fulkerson(const std::shared_ptr<app_state> &app,
+                               const node_mapper &nodes,
+                               const std::unordered_map<dsn::rpc_address, int> &address_id,
+                               uint32_t higher_count,
+                               uint32_t lower_count,
+                               int replicas_low)
+    : _app(app),
+      _nodes(nodes),
+      _address_id(address_id),
+      _higher_count(higher_count),
+      _lower_count(lower_count),
+      _replicas_low(replicas_low)
+{
+    make_graph();
+}
+
+// using dijstra to find shortest path
+std::unique_ptr<flow_path> ford_fulkerson::find_shortest_path()
+{
+    std::vector<bool> visit(_graph_nodes, false);
+    std::vector<int> flow(_graph_nodes, 0);
+    std::vector<int> prev(_graph_nodes, -1);
+    flow[0] = INT_MAX;
+    while (!visit.back()) {
+        auto pos = select_node(visit, flow);
+        if (pos == -1) {
+            break;
+        }
+        update_flow(pos, visit, _network, flow, prev);
+    }
+
+    if (visit.back() && flow.back() != 0) {
+        return dsn::make_unique<struct flow_path>(_app, std::move(flow), std::move(prev));
+    } else {
+        return nullptr;
+    }
+}
+
+void ford_fulkerson::make_graph()
+{
+    _graph_nodes = _nodes.size() + 2;
+    _network.resize(_graph_nodes, std::vector<int>(_graph_nodes, 0));
+    for (const auto &node : _nodes) {
+        int node_id = _address_id.at(node.first);
+        add_edge(node_id, node.second);
+        update_decree(node_id, node.second);
+    }
+    handle_corner_case();
+}
+
+void ford_fulkerson::add_edge(int node_id, const node_state &ns)
+{
+    int primary_count = ns.primary_count(_app->app_id);
+    if (primary_count > _replicas_low) {
+        _network[0][node_id] = primary_count - _replicas_low;
+    } else {
+        _network[node_id].back() = _replicas_low - primary_count;
+    }
+}
+
+void ford_fulkerson::update_decree(int node_id, const node_state &ns)
+{
+    ns.for_each_primary(_app->app_id, [&, this](const gpid &pid) {
+        const partition_configuration &pc = _app->partitions[pid.get_partition_index()];
+        for (const auto &secondary : pc.secondaries) {
+            auto i = _address_id.find(secondary);
+            dassert_f(i != _address_id.end(),
+                      "invalid secondary address, address = {}",
+                      secondary.to_string());
+            _network[node_id][i->second]++;
+        }
+        return true;
+    });
+}
+
+void ford_fulkerson::handle_corner_case()
+{
+    // Suppose you have an 8-shard app in a cluster with 3 nodes(which name are node1, node2,
+    // node3). The distribution of primaries among these nodes is as follow:
+    // node1 : [0, 1, 2, 3]
+    // node2 : [4, 5]
+    // node2 : [6, 7]
+    // This is obviously unbalanced.
+    // But if we don't handle this corner case, primary migration will not be triggered
+    if (_higher_count > 0 && _lower_count == 0) {
+        for (int i = 0; i != _graph_nodes; ++i) {
+            if (_network[0][i] > 0)
+                --_network[0][i];
+            else
+                ++_network[i][_graph_nodes - 1];
+        }
+    }
+}
+
+int ford_fulkerson::select_node(std::vector<bool> &visit, const std::vector<int> &flow)
+{
+    auto pos = max_value_pos(visit, flow);
+    if (pos != -1) {
+        visit[pos] = true;
+    }
+    return pos;
+}
+
+int ford_fulkerson::max_value_pos(const std::vector<bool> &visit, const std::vector<int> &flow)
+{
+    int pos = -1, max_value = 0;
+    for (auto i = 0; i != _graph_nodes; ++i) {
+        if (!visit[i] && flow[i] > max_value) {
+            pos = i;
+            max_value = flow[i];
+        }
+    }
+    return pos;
+}
+
+void ford_fulkerson::update_flow(int pos,
+                                 const std::vector<bool> &visit,
+                                 const std::vector<std::vector<int>> &network,
+                                 std::vector<int> &flow,
+                                 std::vector<int> &prev)
+{
+    for (auto i = 0; i != _graph_nodes; ++i) {
+        if (visit[i]) {
+            continue;
+        }
+
+        auto min = std::min(flow[pos], network[pos][i]);
+        if (min > flow[i]) {
+            flow[i] = min;
+            prev[i] = pos;
+        }
+    }
+}
+
+copy_replica_operation::copy_replica_operation(
+    const std::shared_ptr<app_state> app,
+    const app_mapper &apps,
+    node_mapper &nodes,
+    const std::vector<dsn::rpc_address> &address_vec,
+    const std::unordered_map<dsn::rpc_address, int> &address_id)
+    : _app(app), _apps(apps), _nodes(nodes), _address_vec(address_vec), _address_id(address_id)
+{
+}
+
+bool copy_replica_operation::start(migration_list *result)
+{
+    init_ordered_address_ids();
+    _node_loads = get_node_loads(_app, _apps, _nodes, only_copy_primary());
+    if (_node_loads.size() != _nodes.size()) {
+        return false;
+    }
+
+    while (true) {
+        if (!can_continue()) {
+            break;
+        }
+
+        gpid selected_pid = select_partition(result);
+        if (selected_pid.get_app_id() != -1) {
+            copy_once(selected_pid, result);
+            update_ordered_address_ids();
+        } else {
+            _ordered_address_ids.erase(--_ordered_address_ids.end());
+        }
+    }
+    return true;
+}
+
+const partition_set *copy_replica_operation::get_all_partitions()
+{
+    int id_max = *_ordered_address_ids.rbegin();
+    const node_state &ns = _nodes.find(_address_vec[id_max])->second;
+    const partition_set *partitions = ns.partitions(_app->app_id, only_copy_primary());
+    return partitions;
+}
+
+gpid copy_replica_operation::select_max_load_gpid(const partition_set *partitions,
+                                                  migration_list *result)
+{
+    int id_max = *_ordered_address_ids.rbegin();
+    const disk_load &load_on_max = _node_loads.at(_address_vec[id_max]);
+
+    gpid selected_pid(-1, -1);
+    int max_load = -1;
+    for (const gpid &pid : *partitions) {
+        if (!can_select(pid, result)) {
+            continue;
+        }
+
+        const std::string &disk_tag = get_disk_tag(_apps, _address_vec[id_max], pid);
+        auto load = load_on_max.at(disk_tag);
+        if (load > max_load) {
+            selected_pid = pid;
+            max_load = load;
+        }
+    }
+    return selected_pid;
+}
+
+void copy_replica_operation::copy_once(gpid selected_pid, migration_list *result)
+{
+    auto from = _address_vec[*_ordered_address_ids.rbegin()];
+    auto to = _address_vec[*_ordered_address_ids.begin()];
+
+    auto pc = _app->partitions[selected_pid.get_partition_index()];
+    auto request = generate_balancer_request(_apps, pc, get_balance_type(), from, to);
+    result->emplace(selected_pid, request);
+}
+
+void copy_replica_operation::update_ordered_address_ids()
+{
+    int id_min = *_ordered_address_ids.begin();
+    int id_max = *_ordered_address_ids.rbegin();
+    --_partition_counts[id_max];
+    ++_partition_counts[id_min];
+
+    _ordered_address_ids.erase(_ordered_address_ids.begin());
+    _ordered_address_ids.erase(--_ordered_address_ids.end());
+
+    _ordered_address_ids.insert(id_max);
+    _ordered_address_ids.insert(id_min);
+}
+
+void copy_replica_operation::init_ordered_address_ids()
+{
+    _partition_counts.resize(_address_vec.size(), 0);
+    for (const auto &iter : _nodes) {
+        auto id = _address_id.at(iter.first);
+        _partition_counts[id] = get_partition_count(iter.second);
+    }
+
+    std::set<int, std::function<bool(int a, int b)>> ordered_queue([this](int a, int b) {
+        return _partition_counts[a] != _partition_counts[b]
+                   ? _partition_counts[a] < _partition_counts[b]
+                   : a < b;
+    });
+    for (const auto &iter : _nodes) {
+        auto id = _address_id.at(iter.first);
+        ordered_queue.insert(id);
+    }
+    _ordered_address_ids.swap(ordered_queue);
+}
+
+gpid copy_replica_operation::select_partition(migration_list *result)
+{
+    const partition_set *partitions = get_all_partitions();
+
+    int id_max = *_ordered_address_ids.rbegin();
+    const node_state &ns = _nodes.find(_address_vec[id_max])->second;
+    dassert_f(partitions != nullptr && !partitions->empty(),
+              "max load({}) shouldn't empty",
+              ns.addr().to_string());
+
+    return select_max_load_gpid(partitions, result);
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -169,7 +169,10 @@ generate_balancer_request(const app_mapper &apps,
     return std::make_shared<configuration_balancer_request>(std::move(result));
 }
 
-load_balance_policy::load_balance_policy(meta_service *svc) : _svc(svc) {}
+load_balance_policy::load_balance_policy(meta_service *svc)
+    : _svc(svc), _ctrl_balancer_ignored_apps(nullptr)
+{
+}
 
 void load_balance_policy::init(const meta_view *global_view, migration_list *list)
 {

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -21,7 +21,7 @@
 
 namespace dsn {
 namespace replication {
-// disk_tag -> targets(primaries/partitions)_on_this_disk
+// disk_tag->primary_count/total_count_on_this_disk
 typedef std::map<std::string, int> disk_load;
 
 enum class balance_type
@@ -238,7 +238,7 @@ protected:
     virtual bool can_continue() = 0;
     virtual balance_type get_balance_type() = 0;
 
-    std::set<int, std::function<bool(int a, int b)>> _ordered_address_ids;
+    std::set<int, std::function<bool(int left, int right)>> _ordered_address_ids;
     const std::shared_ptr<app_state> _app;
     const app_mapper &_apps;
     node_mapper &_nodes;

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -52,10 +52,11 @@ generate_balancer_request(const app_mapper &apps,
                           const rpc_address &to);
 
 struct flow_path;
+class meta_service;
 class load_balance_policy
 {
 public:
-    load_balance_policy() = default;
+    load_balance_policy(meta_service *svc);
 
     virtual void balance(bool checker, const meta_view *global_view, migration_list *list) = 0;
     virtual void register_ctrl_commands();
@@ -94,6 +95,7 @@ protected:
     std::string get_balancer_ignored_app_ids();
     std::string clear_balancer_ignored_app_ids();
 
+    meta_service *_svc;
     const meta_view *_global_view;
     migration_list *_migration_result;
     int _alive_nodes;

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -62,6 +62,7 @@ public:
     virtual void unregister_ctrl_commands();
 
 protected:
+    void init(const meta_view *global_view, migration_list *list);
     bool execute_balance(
         const app_mapper &apps,
         bool balance_checker,

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -249,6 +249,5 @@ protected:
     FRIEND_TEST(copy_primary_operation, misc);
     FRIEND_TEST(copy_replica_operation, get_all_partitions);
 };
-
 } // namespace replication
 } // namespace dsn

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -57,6 +57,7 @@ class load_balance_policy
 {
 public:
     load_balance_policy(meta_service *svc);
+    virtual ~load_balance_policy() = 0;
 
     virtual void balance(bool checker, const meta_view *global_view, migration_list *list) = 0;
     virtual void register_ctrl_commands();

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "meta_data.h"
+
+namespace dsn {
+namespace replication {
+// disk_tag -> targets(primaries/partitions)_on_this_disk
+typedef std::map<std::string, int> disk_load;
+
+enum class balance_type
+{
+    COPY_PRIMARY = 0,
+    COPY_SECONDARY,
+    MOVE_PRIMARY,
+    INVALID,
+};
+ENUM_BEGIN(balance_type, balance_type::INVALID)
+ENUM_REG(balance_type::COPY_PRIMARY)
+ENUM_REG(balance_type::COPY_SECONDARY)
+ENUM_REG(balance_type::MOVE_PRIMARY)
+ENUM_END(balance_type)
+
+bool calc_disk_load(node_mapper &nodes,
+                    const app_mapper &apps,
+                    app_id id,
+                    const rpc_address &node,
+                    bool only_primary,
+                    /*out*/ disk_load &load);
+const std::string &get_disk_tag(const app_mapper &apps, const rpc_address &node, const gpid &pid);
+std::shared_ptr<configuration_balancer_request>
+generate_balancer_request(const app_mapper &apps,
+                          const partition_configuration &pc,
+                          const balance_type &type,
+                          const rpc_address &from,
+                          const rpc_address &to);
+
+struct flow_path;
+class load_balance_policy
+{
+public:
+    load_balance_policy() = default;
+
+    virtual void balance(bool checker, const meta_view *global_view, migration_list *list) = 0;
+    virtual void register_ctrl_commands();
+    virtual void unregister_ctrl_commands();
+
+protected:
+    bool execute_balance(
+        const app_mapper &apps,
+        bool balance_checker,
+        bool balance_in_turn,
+        bool only_move_primary,
+        const std::function<bool(const std::shared_ptr<app_state> &, bool)> &balance_operation);
+    bool is_ignored_app(app_id app_id);
+    bool primary_balance(const std::shared_ptr<app_state> &app, bool only_move_primary);
+    bool move_primary(std::unique_ptr<flow_path> path);
+    bool copy_primary(const std::shared_ptr<app_state> &app, bool still_have_less_than_average);
+    void start_moving_primary(const std::shared_ptr<app_state> &app,
+                              const rpc_address &from,
+                              const rpc_address &to,
+                              int plan_moving,
+                              disk_load *prev_load,
+                              disk_load *current_load);
+    std::list<dsn::gpid> calc_potential_moving(const std::shared_ptr<app_state> &app,
+                                               const rpc_address &from,
+                                               const rpc_address &to);
+    dsn::gpid select_moving(std::list<dsn::gpid> &potential_moving,
+                            disk_load *prev_load,
+                            disk_load *current_load,
+                            rpc_address from,
+                            rpc_address to);
+    void number_nodes(const node_mapper &nodes);
+
+    std::string remote_command_balancer_ignored_app_ids(const std::vector<std::string> &args);
+    std::string set_balancer_ignored_app_ids(const std::vector<std::string> &args);
+    std::string get_balancer_ignored_app_ids();
+    std::string clear_balancer_ignored_app_ids();
+
+    const meta_view *_global_view;
+    migration_list *_migration_result;
+    int _alive_nodes;
+    // this is used to assign an integer id for every node
+    // and these are generated from the above data, which are tempory too
+    std::unordered_map<dsn::rpc_address, int> address_id;
+    std::vector<dsn::rpc_address> address_vec;
+
+    // the app set which won't be re-balanced
+    dsn::zrwlock_nr _balancer_ignored_apps_lock; // {
+    std::set<app_id> _balancer_ignored_apps;
+    // }
+
+    dsn_handle_t _ctrl_balancer_ignored_apps;
+};
+
+struct flow_path
+{
+    flow_path(const std::shared_ptr<app_state> &app,
+              std::vector<int> &&flow,
+              std::vector<int> &&prev)
+        : _app(app), _flow(std::move(flow)), _prev(std::move(prev))
+    {
+    }
+
+    const std::shared_ptr<app_state> &_app;
+    std::vector<int> _flow, _prev;
+};
+
+// Ford Fulkerson is used for primary balance.
+// For more details: https://levy5307.github.io/blog/pegasus-balancer/
+class ford_fulkerson
+{
+public:
+    ford_fulkerson() = delete;
+    ford_fulkerson(const std::shared_ptr<app_state> &app,
+                   const node_mapper &nodes,
+                   const std::unordered_map<dsn::rpc_address, int> &address_id,
+                   uint32_t higher_count,
+                   uint32_t lower_count,
+                   int replicas_low);
+
+    // using dijstra to find shortest path
+    std::unique_ptr<flow_path> find_shortest_path();
+    bool have_less_than_average() const { return _lower_count != 0; }
+
+    class builder
+    {
+    public:
+        builder(const std::shared_ptr<app_state> &app,
+                const node_mapper &nodes,
+                const std::unordered_map<dsn::rpc_address, int> &address_id)
+            : _app(app), _nodes(nodes), _address_id(address_id)
+        {
+        }
+
+        std::unique_ptr<ford_fulkerson> build()
+        {
+            auto nodes_count = _nodes.size();
+            int replicas_low = _app->partition_count / nodes_count;
+            int replicas_high = (_app->partition_count + nodes_count - 1) / nodes_count;
+
+            uint32_t higher_count = 0, lower_count = 0;
+            for (const auto &node : _nodes) {
+                int primary_count = node.second.primary_count(_app->app_id);
+                if (primary_count > replicas_high) {
+                    higher_count++;
+                } else if (primary_count < replicas_low) {
+                    lower_count++;
+                }
+            }
+
+            if (0 == higher_count && 0 == lower_count) {
+                return nullptr;
+            }
+            return dsn::make_unique<ford_fulkerson>(
+                _app, _nodes, _address_id, higher_count, lower_count, replicas_low);
+        }
+
+    private:
+        const std::shared_ptr<app_state> &_app;
+        const node_mapper &_nodes;
+        const std::unordered_map<dsn::rpc_address, int> &_address_id;
+    };
+
+private:
+    void make_graph();
+    void add_edge(int node_id, const node_state &ns);
+    void update_decree(int node_id, const node_state &ns);
+    void handle_corner_case();
+
+    int select_node(std::vector<bool> &visit, const std::vector<int> &flow);
+    int max_value_pos(const std::vector<bool> &visit, const std::vector<int> &flow);
+    void update_flow(int pos,
+                     const std::vector<bool> &visit,
+                     const std::vector<std::vector<int>> &network,
+                     std::vector<int> &flow,
+                     std::vector<int> &prev);
+
+    const std::shared_ptr<app_state> &_app;
+    const node_mapper &_nodes;
+    const std::unordered_map<dsn::rpc_address, int> &_address_id;
+    uint32_t _higher_count;
+    uint32_t _lower_count;
+    int _replicas_low;
+    size_t _graph_nodes;
+    std::vector<std::vector<int>> _network;
+
+    FRIEND_TEST(ford_fulkerson, add_edge);
+    FRIEND_TEST(ford_fulkerson, update_decree);
+    FRIEND_TEST(ford_fulkerson, find_shortest_path);
+    FRIEND_TEST(ford_fulkerson, max_value_pos);
+    FRIEND_TEST(ford_fulkerson, select_node);
+};
+
+class copy_replica_operation
+{
+public:
+    copy_replica_operation(const std::shared_ptr<app_state> app,
+                           const app_mapper &apps,
+                           node_mapper &nodes,
+                           const std::vector<dsn::rpc_address> &address_vec,
+                           const std::unordered_map<dsn::rpc_address, int> &address_id);
+    virtual ~copy_replica_operation() = default;
+
+    bool start(migration_list *result);
+
+protected:
+    void init_ordered_address_ids();
+    virtual int get_partition_count(const node_state &ns) const = 0;
+
+    gpid select_partition(migration_list *result);
+    const partition_set *get_all_partitions();
+    gpid select_max_load_gpid(const partition_set *partitions, migration_list *result);
+    void copy_once(gpid selected_pid, migration_list *result);
+    void update_ordered_address_ids();
+    virtual bool only_copy_primary() = 0;
+    virtual bool can_select(gpid pid, migration_list *result) = 0;
+    virtual bool can_continue() = 0;
+    virtual balance_type get_balance_type() = 0;
+
+    std::set<int, std::function<bool(int a, int b)>> _ordered_address_ids;
+    const std::shared_ptr<app_state> _app;
+    const app_mapper &_apps;
+    node_mapper &_nodes;
+    const std::vector<dsn::rpc_address> &_address_vec;
+    const std::unordered_map<dsn::rpc_address, int> &_address_id;
+    std::unordered_map<dsn::rpc_address, disk_load> _node_loads;
+    std::vector<int> _partition_counts;
+
+    FRIEND_TEST(copy_primary_operation, misc);
+    FRIEND_TEST(copy_replica_operation, get_all_partitions);
+};
+
+} // namespace replication
+} // namespace dsn

--- a/src/meta/test/copy_replica_operation_test.cpp
+++ b/src/meta/test/copy_replica_operation_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <dsn/utility/fail_point.h>
+#include "meta/app_balance_policy.h"
 #include "meta/greedy_load_balancer.h"
 
 namespace dsn {


### PR DESCRIPTION
move code about app balancer from `greedy_load_balancer` to clss `app_balance_policy`

### Manual Test

***App Balance Test***

1. start onebox with 4 replica servers
```
./run.sh start_onebox -r 4
```
2. kill one replica server
```
➜  pegasus git:(master) ✗ ps aux | grep pegasus 
mi        8155  1.7  0.1 11680324 55080 pts/0  Sl   09:50   0:00 /usr/lib/jvm/java-8-openjdk-amd64/bin/java -Dzookeeper.log.dir=. -Dzookeeper.root.logger=INFO,CONSOLE -cp /home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../build/classes:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../build/lib/*.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/slf4j-log4j12-1.6.1.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/slf4j-api-1.6.1.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/netty-3.7.0.Final.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/log4j-1.2.16.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/jline-0.9.94.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../zookeeper-3.4.6.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../src/java/lib/*.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../conf: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain /home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../conf/zoo.cfg
mi        8198  0.2  0.1 495148 46792 pts/0    Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/meta1/pegasus_server config.ini -app_list meta
mi        8208  0.1  0.1 473592 45072 pts/0    Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/meta2/pegasus_server config.ini -app_list meta
mi        8270  0.1  0.1 473596 44832 pts/0    Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/meta3/pegasus_server config.ini -app_list meta
mi        8314  0.5  0.3 1075460 117176 pts/0  Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/replica1/pegasus_server config.ini -app_list replica
mi        8353  0.5  0.3 1092264 125348 pts/0  Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/replica2/pegasus_server config.ini -app_list replica
mi        8402  0.5  0.3 1075456 119664 pts/0  Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/replica3/pegasus_server config.ini -app_list replica
mi        8463  0.5  0.3 1025868 109620 pts/0  Sl   09:50   0:00 /home/mi/workspace/pegasus/onebox/replica4/pegasus_server config.ini -app_list replica
mi        9398  0.0  0.0  16176  1032 pts/0    R+   09:51   0:00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox pegasus
➜  pegasus git:(master) ✗ kill 8463
```
3. create serveral apps
4. nodes -d
```
>>> nodes -d
[details]
address              status     replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                 49             18               31
10.231.57.100:34802  ALIVE                 50             17               33
10.231.57.100:34803  ALIVE                 49             17               32
10.231.57.100:34804  UNALIVE                0              0                0

[summary]
total_node_count    : 4
alive_node_count    : 3
unalive_node_count  : 1
```
5. restart the killed replica server
```
./run.sh start_onebox_instance -r 4
```
6. set meta level to lively
```
>>> set_meta_level lively
control meta level ok, the old level is fl_steady
```
7. after serverl minutes, the cluster becomes balanced
```
>>> nodes -d
[details]
address              status    replica_count  primary_count  secondary_count
10.231.57.100:34801  ALIVE                39             13               26
10.231.57.100:34802  ALIVE                39             13               26
10.231.57.100:34803  ALIVE                39             13               26
10.231.57.100:34804  ALIVE                39             13               26

[summary]
total_node_count    : 4
alive_node_count    : 4
unalive_node_count  : 0
```

***Remote Command Test***

- meta.lb.balancer_in_turn
```
>>> remote_command -t meta-server meta.lb.balancer_in_turn true
COMMAND: meta.lb.balancer_in_turn true

CALL [meta-server] [127.0.0.1:34601] succeed: OK
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.balancer_in_turn'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.balancer_in_turn'

Succeed count: 3
Failed count: 0
```
- meta.lb.only_primary_balancer
```
>>> remote_command -t meta-server meta.lb.only_primary_balancer true
COMMAND: meta.lb.only_primary_balancer true

CALL [meta-server] [127.0.0.1:34601] succeed: OK
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.only_primary_balancer'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.only_primary_balancer'

Succeed count: 3
Failed count: 0
```
- meta.lb.only_move_primary
```
>>> remote_command -t meta-server meta.lb.only_move_primary true
COMMAND: meta.lb.only_move_primary true

CALL [meta-server] [127.0.0.1:34601] succeed: OK
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.only_move_primary'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.only_move_primary'

Succeed count: 3
Failed count: 0
```
- meta.lb.ignored_app_list

1. set ignored app list
```
>>> remote_command -t meta-server meta.lb.ignored_app_list set 1,2,3
COMMAND: meta.lb.ignored_app_list set 1,2,3

CALL [meta-server] [127.0.0.1:34601] succeed: set ok
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.ignored_app_list'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.ignored_app_list'

Succeed count: 3
Failed count: 0
```
2. get ignores app list
```
>>> remote_command -t meta-server meta.lb.ignored_app_list get
COMMAND: meta.lb.ignored_app_list get

CALL [meta-server] [127.0.0.1:34601] succeed: ignored_app_id_list: 1,2,3
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.ignored_app_list'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.ignored_app_list'

Succeed count: 3
Failed count: 0
```
3. clear ignored app list
```
>>> remote_command -t meta-server meta.lb.ignored_app_list clear
COMMAND: meta.lb.ignored_app_list clear

CALL [meta-server] [127.0.0.1:34601] succeed: clear ok
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.ignored_app_list'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.ignored_app_list'

Succeed count: 3
Failed count: 0
>>> remote_command -t meta-server meta.lb.ignored_app_list get
COMMAND: meta.lb.ignored_app_list get

CALL [meta-server] [127.0.0.1:34601] succeed: no ignored apps
CALL [meta-server] [127.0.0.1:34602] succeed: unknown command 'meta.lb.ignored_app_list'
CALL [meta-server] [127.0.0.1:34603] succeed: unknown command 'meta.lb.ignored_app_list'

Succeed count: 3
Failed count: 0
```