### PR TITLE
fix: partitions are unbalanced after the table is created

### DIFF
--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -658,7 +658,8 @@ void partition_guardian::finish_cure_proposal(meta_view &view,
             np->newly_remove_primary(gpid.get_app_id(), false);
         } else if (act.type == config_type::CT_UPGRADE_TO_PRIMARY) {
             np->newly_remove_primary(gpid.get_app_id(), true);
-        } else if (act.type == config_type::CT_UPGRADE_TO_SECONDARY) {
+        } else if (act.type == config_type::CT_UPGRADE_TO_SECONDARY ||
+                   act.type == config_type::CT_ADD_SECONDARY) {
             np->newly_remove_partition(gpid.get_app_id());
         }
     }


### PR DESCRIPTION
What problem does this PR solve?
partitions are unbalanced after the table is created
For details, see apache/incubator-pegasus#832


Check List
Tests

Manual test (add detailed scripts or steps below)
1. start a onebox with 5 repicaserver: ./run start_onebox -r 5
2. create an app with 100 partitions : create test100 -p 100
3. to view the balancer of the test100 app: app test100 -d