### PR TITLE
feat(bulk_load): not rollback to downloading if bulk load meet error in succeed stage

### DIFF
--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -752,8 +752,7 @@ void bulk_load_service::try_rollback_to_downloading(const std::string &app_name,
     const auto app_status = get_app_bulk_load_status_unlocked(pid.get_app_id());
     if (app_status != bulk_load_status::BLS_DOWNLOADING &&
         app_status != bulk_load_status::BLS_DOWNLOADED &&
-        app_status != bulk_load_status::BLS_INGESTING &&
-        app_status != bulk_load_status::BLS_SUCCEED) {
+        app_status != bulk_load_status::BLS_INGESTING) {
         ddebug_f("app({}) status={}, no need to rollback to downloading, wait for next round",
                  app_name,
                  dsn::enum_to_string(app_status));

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -81,15 +81,16 @@ struct bulk_load_info
 ///                  |
 ///         Err      v
 ///     ---------Downloading <---------|
-///     |            |                 |
+///     |  Too many  |                 |
+///     |  rollback  |                 |
 ///     |            v         Err     |
 ///     |        Downloaded  --------->|
 ///     |            |                 |
 ///     | IngestErr  v         Err     |
 ///     |<------- Ingesting  --------->|
-///     |            |                 |
-///     v            v         Err     |
-///   Failed       Succeed   --------->|
+///     |            |
+///     v            v
+///   Failed       Succeed
 ///     |            |
 ///     v            v
 ///    remove bulk load info on remote storage

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -727,7 +727,7 @@ TEST_F(bulk_load_process_test, rpc_error)
 TEST_F(bulk_load_process_test, response_invalid_state)
 {
     test_on_partition_bulk_load_reply(
-        _partition_count, bulk_load_status::BLS_SUCCEED, ERR_INVALID_STATE);
+        _partition_count, bulk_load_status::BLS_INGESTING, ERR_INVALID_STATE);
     ASSERT_EQ(get_app_bulk_load_status(_app_id), bulk_load_status::BLS_DOWNLOADING);
     ASSERT_EQ(get_app_in_process_count(_app_id), _partition_count);
 }

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -581,6 +581,7 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
     // Test cases
     // - bulk load succeed
     // - double bulk load finish
+    // - invalid with directory not removed
     // - cancel during downloaded
     // - cancel during ingestion
     // - cancel during succeed
@@ -608,6 +609,12 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
                false,
                bulk_load_status::BLS_SUCCEED,
                false},
+              {bulk_load_status::BLS_INVALID,
+               0,
+               ingestion_status::IS_INVALID,
+               false,
+               bulk_load_status::BLS_SUCCEED,
+               true},
               {bulk_load_status::BLS_DOWNLOADED,
                100,
                ingestion_status::IS_INVALID,
@@ -648,7 +655,6 @@ TEST_F(replica_bulk_loader_test, bulk_load_finish_test)
         ASSERT_EQ(_replica->get_ingestion_status(), ingestion_status::IS_INVALID);
         ASSERT_FALSE(_replica->is_ingestion());
         ASSERT_TRUE(is_cleaned_up());
-        ASSERT_FALSE(utils::filesystem::directory_exists(LOCAL_DIR));
     }
 }
 
@@ -883,7 +889,7 @@ TEST_F(replica_bulk_loader_test, validate_status_test)
                  {bulk_load_status::BLS_CANCELED, bulk_load_status::BLS_SUCCEED, true},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_INVALID, true},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_INGESTING, true},
-                 {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_SUCCEED, true},
+                 {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_SUCCEED, false},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_FAILED, false},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_CANCELED, false},
                  {bulk_load_status::BLS_DOWNLOADED, bulk_load_status::BLS_INVALID, false},


### PR DESCRIPTION
When bulk load meet errors in normal stage, it will rollback to downloading stage, including succeed stage. However, there are only some cleanup works in this stage such as delete files and context update. It is unnecessary to rollback to downloading, which will ingestion repeatedly, especially for replica will remove garbage files and reset context while starting a new bulk load process.

This pull request includes following update:
- if bulk load meet error in succeed stage, it won't rollback to downloading
- replica update validate check: succeed -> downloading is an invalid switch
- when replica cleanup bulk load context, if local bulk load folder is not removed, context can't be considered as cleanup