### PR TITLE
feat(bulk_load): remove bulk load request short interval avoid unnecessary timeout

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -664,7 +664,6 @@ const std::string replica_envs::BACKUP_REQUEST_QPS_THROTTLING("replica.backup_re
 
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;
-const int32_t bulk_load_constant::BULK_LOAD_REQUEST_SHORT_INTERVAL = 5;
 const std::string bulk_load_constant::BULK_LOAD_METADATA("bulk_load_metadata");
 const std::string bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR("bulk_load");
 const int32_t bulk_load_constant::PROGRESS_FINISHED = 100;

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -171,7 +171,6 @@ class bulk_load_constant
 public:
     static const std::string BULK_LOAD_INFO;
     static const int32_t BULK_LOAD_REQUEST_INTERVAL;
-    static const int32_t BULK_LOAD_REQUEST_SHORT_INTERVAL;
     static const std::string BULK_LOAD_METADATA;
     static const std::string BULK_LOAD_LOCAL_ROOT_DIR;
     static const int32_t PROGRESS_FINISHED;

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -460,8 +460,7 @@ void bulk_load_service::on_partition_bulk_load_reply(error_code err,
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
-void bulk_load_service::try_resend_bulk_load_request(const std::string &app_name,
-                                                     const gpid &pid)
+void bulk_load_service::try_resend_bulk_load_request(const std::string &app_name, const gpid &pid)
 {
     FAIL_POINT_INJECT_F("meta_bulk_load_resend_request", [](dsn::string_view) {});
     zauto_read_lock l(_lock);

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -148,8 +148,7 @@ private:
 
     // if app is still in bulk load, resend bulk_load_request to primary after interval seconds
     void try_resend_bulk_load_request(const std::string &app_name,
-                                      const gpid &pid,
-                                      const int32_t interval);
+                                      const gpid &pid);
 
     void handle_app_downloading(const bulk_load_response &response,
                                 const rpc_address &primary_addr);

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -147,8 +147,7 @@ private:
                                       const bulk_load_response &response);
 
     // if app is still in bulk load, resend bulk_load_request to primary after interval seconds
-    void try_resend_bulk_load_request(const std::string &app_name,
-                                      const gpid &pid);
+    void try_resend_bulk_load_request(const std::string &app_name, const gpid &pid);
 
     void handle_app_downloading(const bulk_load_response &response,
                                 const rpc_address &primary_addr);


### PR DESCRIPTION
Server will reject user write requests during bulk load ingestion stage, so bulk_load_request used to send more frequently during ingestion. However, it sometimes leads unnecessary timeout when server has heavy load. This pull request remove short interval, all requests will be sent in fixed interval.