### PR TITLE
fix: bug in learn that can't complete

### DIFF
--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -70,7 +70,8 @@ void prepare_list::truncate(decree init_decree)
 
 error_code prepare_list::prepare(mutation_ptr &mu,
                                  partition_status::type status,
-                                 bool pop_all_committed_mutations)
+                                 bool pop_all_committed_mutations,
+                                 bool secondary_sync_commit)
 {
     decree d = mu->data.header.decree;
     dcheck_gt_replica(d, last_committed_decree());
@@ -79,14 +80,27 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     error_code err;
     switch (status) {
     case partition_status::PS_PRIMARY:
-    case partition_status::PS_SECONDARY:
-    case partition_status::PS_POTENTIAL_SECONDARY:
         // pop committed mutations if buffer is full or pop_all_committed_mutations = true
         while ((d - min_decree() >= capacity() || pop_all_committed_mutations) &&
                last_committed_decree() > min_decree()) {
             pop_min();
         }
         return mutation_cache::put(mu);
+
+    case partition_status::PS_SECONDARY:
+    case partition_status::PS_POTENTIAL_SECONDARY:
+        // all mutations with lower decree must be ready
+        if (secondary_sync_commit) {
+            commit(mu->data.header.last_committed_decree, COMMIT_TO_DECREE_HARD);
+        }
+        // pop committed mutations if buffer is full or pop_all_committed_mutations = true
+        while ((d - min_decree() >= capacity() || pop_all_committed_mutations) &&
+               last_committed_decree() > min_decree()) {
+            pop_min();
+        }
+        err = mutation_cache::put(mu);
+        dassert_replica(err == ERR_OK, "mutation_cache::put failed, err = {}", err);
+        return err;
 
     //// delayed commit - only when capacity is an issue
     // case partition_status::PS_POTENTIAL_SECONDARY:

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -71,7 +71,7 @@ void prepare_list::truncate(decree init_decree)
 error_code prepare_list::prepare(mutation_ptr &mu,
                                  partition_status::type status,
                                  bool pop_all_committed_mutations,
-                                 bool secondary_sync_commit)
+                                 bool secondary_commit)
 {
     decree d = mu->data.header.decree;
     dcheck_gt_replica(d, last_committed_decree());
@@ -90,7 +90,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     case partition_status::PS_SECONDARY:
     case partition_status::PS_POTENTIAL_SECONDARY:
         // all mutations with lower decree must be ready
-        if (secondary_sync_commit) {
+        if (secondary_commit) {
             commit(mu->data.header.last_committed_decree, COMMIT_TO_DECREE_HARD);
         }
         // pop committed mutations if buffer is full or pop_all_committed_mutations = true

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -67,7 +67,8 @@ public:
     // bulk load ingestion
     error_code prepare(mutation_ptr &mu,
                        partition_status::type status,
-                       bool pop_all_committed_mutations = false); // unordered prepare
+                       bool pop_all_committed_mutations = false,
+                       bool secondary_sync_commit = true); // unordered prepare
     virtual void commit(decree decree, commit_type ct);           // ordered commit
 
     virtual ~prepare_list() = default;

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -68,8 +68,8 @@ public:
     error_code prepare(mutation_ptr &mu,
                        partition_status::type status,
                        bool pop_all_committed_mutations = false,
-                       bool secondary_sync_commit = true); // unordered prepare
-    virtual void commit(decree decree, commit_type ct);    // ordered commit
+                       bool secondary_commit = true);   // unordered prepare
+    virtual void commit(decree decree, commit_type ct); // ordered commit
 
     virtual ~prepare_list() = default;
 

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -69,7 +69,7 @@ public:
                        partition_status::type status,
                        bool pop_all_committed_mutations = false,
                        bool secondary_sync_commit = true); // unordered prepare
-    virtual void commit(decree decree, commit_type ct);           // ordered commit
+    virtual void commit(decree decree, commit_type ct);    // ordered commit
 
     virtual ~prepare_list() = default;
 

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -65,10 +65,12 @@ public:
     //
     // if pop_all_committed_mutations = true, pop all committed mutations, will only used during
     // bulk load ingestion
+    // if secondary_commit = true, and status is secondary or protential secondary, previous logs
+    // will be committed
     error_code prepare(mutation_ptr &mu,
                        partition_status::type status,
                        bool pop_all_committed_mutations = false,
-                       bool secondary_commit = true);   // unordered prepare
+                       bool secondary_commit = true);
     virtual void commit(decree decree, commit_type ct); // ordered commit
 
     virtual ~prepare_list() = default;

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -230,7 +230,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
             last_committed_decree());
 
     // local prepare
-    err = _prepare_list->prepare(mu, partition_status::PS_PRIMARY, pop_all_committed_mutations);
+    err = _prepare_list->prepare(mu, partition_status::PS_PRIMARY, pop_all_committed_mutations, false);
     if (err != ERR_OK) {
         goto ErrOut;
     }
@@ -489,7 +489,7 @@ void replica::on_prepare(dsn::message_ex *request)
         return;
     }
 
-    error_code err = _prepare_list->prepare(mu, status());
+    error_code err = _prepare_list->prepare(mu, status(), false, false);
     dassert(err == ERR_OK, "prepare mutation failed, err = %s", err.to_string());
 
     if (partition_status::PS_POTENTIAL_SECONDARY == status() ||

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -230,7 +230,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
             last_committed_decree());
 
     // local prepare
-    err = _prepare_list->prepare(mu, partition_status::PS_PRIMARY, pop_all_committed_mutations, false);
+    err = _prepare_list->prepare(mu, partition_status::PS_PRIMARY, pop_all_committed_mutations);
     if (err != ERR_OK) {
         goto ErrOut;
     }


### PR DESCRIPTION
For more details: https://github.com/XiaoMi/rdsn/pull/909

## Manual Test

### insert data into app, and we can read it successfully

```
>>> use temp
OK
>>> set a c b 
OK

app_id          : 2
partition_index : 4
decree          : 21
server          : 10.231.57.100:34802
>>> get a c 
"b"

app_id          : 2
partition_index : 4
server          : 10.231.57.100:34802
```

### insert data into app, and kill the corresponding primary replica, then we can also read it successfully.

1. insert data
```
>>> use temp
OK
>>> set a b c
OK

app_id          : 2
partition_index : 4
decree          : 29
server          : 10.231.57.100:34802
```
2. kill the corresponding primary replica server
```
➜  pegasus git:(master) ✗ ps aux | grep pegasus
mi       16833  0.3  0.1 11680324 55756 pts/0  Sl   11:42   0:01 /usr/lib/jvm/java-8-openjdk-amd64/bin/java -Dzookeeper.log.dir=. -Dzookeeper.root.logger=INFO,CONSOLE -cp /home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../build/classes:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../build/lib/*.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/slf4j-log4j12-1.6.1.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/slf4j-api-1.6.1.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/netty-3.7.0.Final.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/log4j-1.2.16.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../lib/jline-0.9.94.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../zookeeper-3.4.6.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../src/java/lib/*.jar:/home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../conf: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain /home/mi/workspace/pegasus/.zk_install/zookeeper-3.4.6/bin/../conf/zoo.cfg
mi       16874  0.1  0.1 495252 46692 pts/0    Sl   11:42   0:00 /home/mi/workspace/pegasus/onebox/meta1/pegasus_server config.ini -app_list meta
mi       16882  0.0  0.1 473700 45464 pts/0    Sl   11:42   0:00 /home/mi/workspace/pegasus/onebox/meta2/pegasus_server config.ini -app_list meta
mi       16927  0.0  0.1 473696 45164 pts/0    Sl   11:42   0:00 /home/mi/workspace/pegasus/onebox/meta3/pegasus_server config.ini -app_list meta
mi       16987  0.4  0.4 1275820 145540 pts/0  Sl   11:42   0:01 /home/mi/workspace/pegasus/onebox/replica1/pegasus_server config.ini -app_list replica
mi       17009  0.4  0.5 1268924 164424 pts/0  Sl   11:42   0:01 /home/mi/workspace/pegasus/onebox/replica2/pegasus_server config.ini -app_list replica
mi       17064  0.4  0.4 1278656 147444 pts/0  Sl   11:42   0:01 /home/mi/workspace/pegasus/onebox/replica3/pegasus_server config.ini -app_list replica
mi       18691  0.0  0.0  16176  1088 pts/0    S+   11:47   0:00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox pegasus
➜  pegasus git:(master) ✗ kill 17009
```
3. read data, and we can get the data insert before
```
>>> use temp
OK
>>> get a b 
"c"

app_id          : 2
partition_index : 4
server          : 10.231.57.100:34803
```

### run the pegasus bench, and it can works well

```
➜  pegasus git:(master) ✗ ./run.sh bench
W2021-11-10 11:49:42.704 (1636516182704076575 18872) : overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
W2021-11-10 11:49:42.704 (1636516182704110718 18872) : overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX_ACK from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
Init pegasus succeed
Hashkeys:       16 bytes each
Sortkeys:       16 bytes each
Values:         100 bytes each
Entries:        10000
FileSize:       1 MB (estimated)
WARNING: Assertions are enabled; benchmarks unnecessarily slow
------------------------------------------------
Statistics for write:  
226.477 micros/op; 4415 ops/sec; 0.441546 MB/s 
Count: 10000 Average: 226.4727  StdDev: 250.43
Min: 129  Median: 160.8906  Max: 3181
Percentiles: P50: 160.89 P75: 209.29 P99: 1726.27 P99.9: 1887.46 P99.99: 2900.00
------------------------------------------------------
(     110,     170 ]     5895  58.950%  58.950% ############
(     170,     250 ]     3268  32.680%  91.630% #######
(     250,     380 ]      330   3.300%  94.930% #
(     380,     580 ]       77   0.770%  95.700% 
(     580,     870 ]       23   0.230%  95.930% 
(     870,    1300 ]       69   0.690%  96.620% 
(    1300,    1900 ]      335   3.350%  99.970% #
(    1900,    2900 ]        2   0.020%  99.990% 
(    2900,    4400 ]        1   0.010% 100.000% 

Statistics for read:  
53.7388 micros/op; 18608 ops/sec; 1.86085 MB/s (10000 of 10000 found)
Count: 10000 Average: 53.7361  StdDev: 7.68
Min: 40  Median: 54.5797  Max: 225
Percentiles: P50: 54.58 P75: 65.77 P99: 94.93 P99.9: 110.00 P99.99: 210.00
------------------------------------------------------
(      34,      51 ]     4200  42.000%  42.000% ########
(      51,      76 ]     5587  55.870%  97.870% ###########
(      76,     110 ]      203   2.030%  99.900% 
(     110,     170 ]        8   0.080%  99.980% 
(     170,     250 ]        2   0.020% 100.000% 

Statistics for delete:  
190.473 micros/op; 5250 ops/sec; 
Count: 10000 Average: 190.4700  StdDev: 88.66
Min: 131  Median: 164.5852  Max: 4330
Percentiles: P50: 164.59 P75: 214.89 P99: 546.67 P99.9: 870.00 P99.99: 2900.00
------------------------------------------------------
(     110,     170 ]     5496  54.960%  54.960% ###########
(     170,     250 ]     3571  35.710%  90.670% #######
(     250,     380 ]      643   6.430%  97.100% #
(     380,     580 ]      228   2.280%  99.380% 
(     580,     870 ]       52   0.520%  99.900% 
(     870,    1300 ]        7   0.070%  99.970% 
(    1300,    1900 ]        1   0.010%  99.980% 
(    1900,    2900 ]        1   0.010%  99.990% 
(    2900,    4400 ]        1   0.010% 100.000% 
```