### PR TITLE
feat: add alive nodes perf-counter

### DIFF
--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -77,6 +77,8 @@ meta_service::meta_service()
         "replica server disconnect count in the recent period");
     _unalive_nodes_count.init_app_counter(
         "eon.meta_service", "unalive_nodes", COUNTER_TYPE_NUMBER, "current count of unalive nodes");
+    _alive_nodes_count.init_app_counter(
+        "eon.meta_service", "alive_nodes", COUNTER_TYPE_NUMBER, "current count of alive nodes");
 
     _access_controller = security::create_meta_access_controller();
 }
@@ -233,6 +235,7 @@ void meta_service::set_node_state(const std::vector<rpc_address> &nodes, bool is
 
     _recent_disconnect_count->add(is_alive ? 0 : nodes.size());
     _unalive_nodes_count->set(_dead_set.size());
+    _alive_nodes_count->set(_alive_set.size());
 
     if (!_started) {
         return;
@@ -305,6 +308,8 @@ void meta_service::start_service()
         if (_dead_set.find(kv.first) == _dead_set.end())
             _alive_set.insert(kv.first);
     }
+
+    _alive_nodes_count->set(_alive_set.size());
 
     for (const dsn::rpc_address &node : _alive_set) {
         // sync alive set and the failure_detector

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -280,6 +280,7 @@ private:
 
     perf_counter_wrapper _recent_disconnect_count;
     perf_counter_wrapper _unalive_nodes_count;
+    perf_counter_wrapper _alive_nodes_count;
 
     dsn::task_tracker _tracker;
 


### PR DESCRIPTION
Currently we've counted unalive nodes which can be used to warn that some node is dead. Since we've managed lots of clusters, one of the first things that we tend to learn is how many replica servers this cluster has. However, now we cannot read this from a graph. We have to connect to the cluster and check it by commands.

Therefore, I added a counter for alive nodes. Then, taking Prometheus for example,  we can read the number of alive nodes by `meta_eon_meta_service_alive_nodes`, and also the total number of replica servers by `meta_eon_meta_service_alive_nodes + meta_eon_meta_service_unalive_nodes`.

The name and type of the counter is listed as below:
```
meta*eon.meta_service*alive_nodes - NUMBER
```