### PR TITLE
feat: implement grouped flag validators

### DIFF
--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -87,6 +87,9 @@ struct hash<flag_tag>
     static const dsn::flag_validator FLAGS_VALIDATOR_##name(                                       \
         #name, []() -> bool { return FLAGS_VALIDATOR_FN_##name(FLAGS_##name); })
 
+#define DSN_DEFINE_group_validator(name, validator)                                                \
+    static const dsn::group_flag_validator FLAGS_GROUP_VALIDATOR_##name(#name, validator)
+
 #define DSN_TAG_VARIABLE(name, tag)                                                                \
     COMPILE_ASSERT(sizeof(decltype(FLAGS_##name)), exist_##name##_##tag);                          \
     static dsn::flag_tagger FLAGS_TAGGER_##name##_##tag(#name, flag_tag::tag)
@@ -112,6 +115,14 @@ class flag_validator
 {
 public:
     flag_validator(const char *name, validator_fn);
+};
+
+using group_validator_fn = std::function<bool(std::string &)>;
+
+class group_flag_validator
+{
+public:
+    group_flag_validator(const char *name, group_validator_fn);
 };
 
 class flag_tagger

--- a/include/dsn/utility/flags.h
+++ b/include/dsn/utility/flags.h
@@ -87,6 +87,33 @@ struct hash<flag_tag>
     static const dsn::flag_validator FLAGS_VALIDATOR_##name(                                       \
         #name, []() -> bool { return FLAGS_VALIDATOR_FN_##name(FLAGS_##name); })
 
+// There are scenarios where inconsistency should be detected and avoided between 2 or more flags.
+//
+// For example, FLAGS_a and FLAGS_b are mutually exclusive: they cannot both be true.
+// Therefore, a validator may be something like:
+// bool validate() {
+//     return !FLAGS_a || !FLAGS_b;
+// }
+//
+// Another example is that FLAGS_c must be less than FLAGS_d. As for this example,
+// a validator can be implemented as:
+// bool validate() {
+//     return FLAGS_c < FLAGS_d;
+// }
+//
+// Unfortunately, `flag_validator` is used to validate the value of individual
+// flag without involving others. Once another flag is used in `flag_validator`,
+// perhaps the validation is ineffective since that flag may not have been loaded
+// from the configuration file.
+//
+// We use grouped flag validator to detect the inconsistency between 2 or more flags.
+// In contrast with `flag_validator` for individual flag, `group_flag_validator` has a guarantee
+// that it will be run after all flags have been loaded from the configuration file.
+//
+// This is the convenient macro for the registration of a grouped flag validator.
+// `validator` must be a std::function<bool(std::string &)>. It does not receive any input
+// argument, but return true if the validation passed otherwise false, with a hint message
+// set as the output argument `std::string &`, if any.
 #define DSN_DEFINE_group_validator(name, validator)                                                \
     static const dsn::group_flag_validator FLAGS_GROUP_VALIDATOR_##name(#name, validator)
 
@@ -117,8 +144,8 @@ public:
     flag_validator(const char *name, validator_fn);
 };
 
+// An utility class that registers a grouped validator upon initialization.
 using group_validator_fn = std::function<bool(std::string &)>;
-
 class group_flag_validator
 {
 public:

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -65,7 +65,6 @@ public:
         }                                                                                          \
         break
 
-// we should run all group validators to find potential invalidation
 #define FLAG_DATA_UPDATE_CASE(type, type_enum, suffix)                                             \
     case type_enum: {                                                                              \
         type old_val = value<type>(), tmpval_##type_enum;                                          \
@@ -246,6 +245,7 @@ public:
 
     void add_flag(const char *name, flag_data flag)
     {
+        // We should run all group validators to find the potential inconsistency
         auto group_validators_runner = std::bind<bool (flag_registry::*)(std::string *)>(
             &flag_registry::run_group_validators, this, std::placeholders::_1);
         flag.on_update_value.put_native(group_validators_runner);

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -222,25 +222,25 @@ public:
     {
         std::map<std::string, std::string> validate_messages;
         bool valid = run_group_validators(validate_messages);
-        if (valid || total_message == nullptr) {
-            return true;
+
+        if (!valid && total_message != nullptr) {
+            std::vector<std::string> messages;
+            std::transform(validate_messages.begin(),
+                           validate_messages.end(),
+                           std::back_inserter(messages),
+                           [](const std::pair<std::string, std::string> &message) {
+                               std::string base(
+                                   fmt::format("group validator \"{}\" failed", message.first));
+                               if (message.second.empty()) {
+                                   return base;
+                               }
+                               return fmt::format("{}: \"{}\"", base, message.second);
+                           });
+
+            *total_message = boost::join(messages, "; ");
         }
 
-        std::vector<std::string> messages;
-        std::transform(validate_messages.begin(),
-                       validate_messages.end(),
-                       std::back_inserter(messages),
-                       [](const std::pair<std::string, std::string> &message) {
-                           std::string base(
-                               fmt::format("group validator \"{}\" failed", message.first));
-                           if (message.second.empty()) {
-                               return base;
-                           }
-                           return fmt::format("{}: \"{}\"", base, message.second);
-                       });
-
-        *total_message = boost::join(messages, "; ");
-        return false;
+        return valid;
     }
 
     void add_flag(const char *name, flag_data flag)

--- a/src/utils/test/flag_test.cpp
+++ b/src/utils/test/flag_test.cpp
@@ -51,28 +51,83 @@ DSN_DEFINE_validator(test_validator, [](int32_t test_validator) -> bool {
     return true;
 });
 
-DSN_DEFINE_int32("flag_test", small_value, 0, "");
-DSN_TAG_VARIABLE(small_value, FT_MUTABLE);
+DSN_DEFINE_bool("flag_test", condition_a, false, "");
+DSN_TAG_VARIABLE(condition_a, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", medium_value, 10, "");
-DSN_TAG_VARIABLE(medium_value, FT_MUTABLE);
+DSN_DEFINE_bool("flag_test", condition_b, false, "");
+DSN_TAG_VARIABLE(condition_b, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", large_value, 100, "");
-DSN_TAG_VARIABLE(large_value, FT_MUTABLE);
+DSN_DEFINE_group_validator(inconsistent_conditions, [](std::string &message) -> bool {
+    return !FLAGS_condition_a || !FLAGS_condition_b;
+});
 
-DSN_DEFINE_group_validator(small_medium, [](std::string &message) -> bool {
-    if (FLAGS_small_value >= FLAGS_medium_value) {
-        message = fmt::format("{} should be < {}", FLAGS_small_value, FLAGS_medium_value);
+DSN_DEFINE_int32("flag_test", min_value, 1, "");
+DSN_TAG_VARIABLE(min_value, FT_MUTABLE);
+DSN_DEFINE_validator(min_value, [](int32_t value) -> bool { return value > 0; });
+
+DSN_DEFINE_int32("flag_test", max_value, 5, "");
+DSN_TAG_VARIABLE(max_value, FT_MUTABLE);
+DSN_DEFINE_validator(max_value, [](int32_t value) -> bool { return value <= 10; });
+
+DSN_DEFINE_group_validator(min_max, [](std::string &message) -> bool {
+    if (FLAGS_min_value > FLAGS_max_value) {
+        message = fmt::format("min({}) should be <= max({})", FLAGS_min_value, FLAGS_max_value);
         return false;
     }
     return true;
 });
 
-DSN_DEFINE_group_validator(medium_large, [](std::string &message) -> bool {
-    if (FLAGS_medium_value >= FLAGS_large_value) {
-        message = fmt::format("{} should be < {}", FLAGS_medium_value, FLAGS_large_value);
+DSN_DEFINE_int32("flag_test", small_value, 0, "");
+DSN_TAG_VARIABLE(small_value, FT_MUTABLE);
+
+DSN_DEFINE_int32("flag_test", medium_value, 5, "");
+DSN_TAG_VARIABLE(medium_value, FT_MUTABLE);
+
+DSN_DEFINE_int32("flag_test", large_value, 10, "");
+DSN_TAG_VARIABLE(large_value, FT_MUTABLE);
+
+DSN_DEFINE_group_validator(small_medium_large, [](std::string &message) -> bool {
+    if (FLAGS_small_value >= FLAGS_medium_value) {
+        message =
+            fmt::format("small({}) should be < medium({})", FLAGS_small_value, FLAGS_medium_value);
         return false;
     }
+
+    if (FLAGS_medium_value >= FLAGS_large_value) {
+        message =
+            fmt::format("medium({}) should be < large({})", FLAGS_medium_value, FLAGS_large_value);
+        return false;
+    }
+
+    return true;
+});
+
+DSN_DEFINE_int32("flag_test", lesser, 0, "");
+DSN_TAG_VARIABLE(lesser, FT_MUTABLE);
+
+DSN_DEFINE_int32("flag_test", greater_0, 5, "");
+DSN_TAG_VARIABLE(greater_0, FT_MUTABLE);
+
+DSN_DEFINE_int32("flag_test", greater_1, 10, "");
+DSN_TAG_VARIABLE(greater_1, FT_MUTABLE);
+
+DSN_DEFINE_group_validator(lesser_greater_0, [](std::string &message) -> bool {
+    if (FLAGS_lesser >= FLAGS_greater_0) {
+        message =
+            fmt::format("lesser({}) should be < greater_0({})", FLAGS_lesser, FLAGS_greater_0);
+        return false;
+    }
+
+    return true;
+});
+
+DSN_DEFINE_group_validator(lesser_greater_1, [](std::string &message) -> bool {
+    if (FLAGS_lesser >= FLAGS_greater_1) {
+        message =
+            fmt::format("lesser({}) should be < greater_1({})", FLAGS_lesser, FLAGS_greater_1);
+        return false;
+    }
+
     return true;
 });
 
@@ -126,13 +181,67 @@ TEST(flag_test, update_config)
     ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
     ASSERT_EQ(FLAGS_test_validator, 5);
 
-    res = update_flag("medium_value", "20");
+    // successful detection with consistent conditions
+    res = update_flag("condition_a", "true");
     ASSERT_TRUE(res.is_ok());
-    ASSERT_EQ(FLAGS_medium_value, 20);
+    ASSERT_EQ(FLAGS_condition_a, true);
 
-    res = update_flag("medium_value", "-1");
+    // failed detection with mutually exclusive conditions
+    res = update_flag("condition_b", "true");
     ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
-    ASSERT_EQ(FLAGS_medium_value, 20);
+    ASSERT_EQ(FLAGS_condition_b, false);
+    std::cout << res.description() << std::endl;
+
+    // successful detection between 2 flags
+    res = update_flag("max_value", "6");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_max_value, 6);
+
+    // failed detection between 2 flags with each individual validation
+    res = update_flag("min_value", "0");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_min_value, 1);
+    std::cout << res.description() << std::endl;
+
+    // failed detection between 2 flags within a grouped validator
+    res = update_flag("min_value", "7");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_min_value, 1);
+    std::cout << res.description() << std::endl;
+
+    // successful detection among 3 flags within a grouped validator
+    res = update_flag("medium_value", "6");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_medium_value, 6);
+
+    // failed detection among 3 flags within a grouped validator
+    res = update_flag("medium_value", "0");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_medium_value, 6);
+    std::cout << res.description() << std::endl;
+
+    // failed detection among 3 flags within a grouped validator
+    res = update_flag("medium_value", "10");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_medium_value, 6);
+    std::cout << res.description() << std::endl;
+
+    // successful detection among 3 flags within both 2 grouped validators
+    res = update_flag("lesser", "1");
+    ASSERT_TRUE(res.is_ok());
+    ASSERT_EQ(FLAGS_lesser, 1);
+
+    // failed detection among 3 flags within one of 2 grouped validators
+    res = update_flag("lesser", "6");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_lesser, 1);
+    std::cout << res.description() << std::endl;
+
+    // failed detection among 3 flags within both 2 grouped validators
+    res = update_flag("lesser", "11");
+    ASSERT_EQ(res.code(), ERR_INVALID_PARAMETERS);
+    ASSERT_EQ(FLAGS_lesser, 1);
+    std::cout << res.description() << std::endl;
 }
 
 DSN_DEFINE_int32("flag_test", has_tag, 5, "");


### PR DESCRIPTION
## Motivation
We've implemented `flag_validator` to validate the value of individual flag. However, there are scenarios where inconsistency should be detected and avoided between 2 or more flags.

For example, `FLAGS_a` and `FLAGS_b` are mutually exclusive: they cannot both be true. Therefore, the related validator may be something like:
```c++
bool validate() {
    return !FLAGS_a || !FLAGS_b;
}
```

Another example is that FLAGS_c must be less than FLAGS_d. As for this example, the related validator can be implemented as:
```c++
bool validate() {
    return FLAGS_c < FLAGS_d;
}
```

A recent scenario is from https://github.com/XiaoMi/rdsn/pull/963 where we should guarantee that  `FLAGS_min_allowed_replica_count` will never be greater than `FLAGS_max_allowed_replica_count`.

Unfortunately, `flag_validator` is used to validate an individual flag without involving others. Once another flag is involved in a `flag_validator`, perhaps the validation is ineffective since that flag may not have been loaded from the configuration file.

## Grouped flag validator
Inspired from https://github.com/apache/kudu/commit/e7334c2e6607ac0fa778499eda2df3f4cfcd3fe3, we can use grouped flag validator to detect the inconsistency between 2 or more flags.

In contrast with `flag_validator` for individual flag, `group_flag_validator` has a guarantee that it will be run after all flags have been loaded from the configuration file.

Also, after a flag is updated dynamically with some new value, all grouped validators will be run to find potential inconsistency.

## Usage
### Implement a validator
The grouped flag validator must be the type of `std::function<bool(std::string &)>`. It does not receive any input argument, but return true if the validation passed otherwise false, with a hint message set as the output argument `std::string &`, if any.

### Register a validator
The macro `DSN_DEFINE_group_validator` is used to register the validator. Similar with `DSN_DEFINE_validator`, a name should be given for each grouped flag validator.

### Example
Take the mutually exclusive flags illustrated above for example, the validator can be implemented and registered as:
```c++
DSN_DEFINE_group_validator(inconsistent_flags, [](std::string &message) -> bool {
    if (FLAGS_a && FLAGS_b) {
        message = fmt::format("a({}) is conflicted with b({})", FLAGS_a, FLAGS_b);
        return false;
    }
    return true;
});
```

For more detailed examples, please see the test cases in `src/utils/test/flag_test.cpp`.
