### PR TITLE
fix: drop redundant recent_choose_primary_fail_count

### DIFF
--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -120,14 +120,7 @@ public:
 local_module_initializer local_module_initializer::_instance;
 //// end of server load balancer extensions for node state
 
-server_load_balancer::server_load_balancer(meta_service *svc) : _svc(svc)
-{
-    _recent_choose_primary_fail_count.init_app_counter(
-        "eon.server_load_balancer",
-        "recent_choose_primary_fail_count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "choose primary fail count in the recent period");
-}
+server_load_balancer::server_load_balancer(meta_service *svc) : _svc(svc) {}
 
 void server_load_balancer::register_proposals(meta_view view,
                                               const configuration_balancer_request &req,

--- a/src/meta/server_load_balancer.h
+++ b/src/meta/server_load_balancer.h
@@ -199,7 +199,6 @@ public:
 
 protected:
     meta_service *_svc;
-    perf_counter_wrapper _recent_choose_primary_fail_count;
 };
 } // namespace replication
 } // namespace dsn


### PR DESCRIPTION
As we've moved `on_missing_primary` from `server_load_balancer` to `partition_guardian` in https://github.com/XiaoMi/rdsn/pull/885,  `recent_choose_primary_fail_count` is counted in `partition_guardian` rather than `server_load_balancer`. `recent_choose_primary_fail_count` can be removed from `server_load_balancer`.