### PR TITLE
feat(manual_compaction): replica report status part1. add function query_compact_status

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -253,6 +253,8 @@ public:
     // query pegasus data version
     virtual uint32_t query_data_version() const = 0;
 
+    virtual manual_compaction_status::type query_compact_status() const = 0;
+
 public:
     //
     // utility functions to be used by app

--- a/include/dsn/dist/replication/replication_enums.h
+++ b/include/dsn/dist/replication/replication_enums.h
@@ -122,4 +122,13 @@ ENUM_BEGIN2(replication::disk_status::type, disk_status, replication::disk_statu
 ENUM_REG(replication::disk_status::NORMAL)
 ENUM_REG(replication::disk_status::SPACE_INSUFFICIENT)
 ENUM_END2(replication::disk_status::type, disk_status)
+
+ENUM_BEGIN2(replication::manual_compaction_status::type,
+            manual_compaction_status,
+            replication::manual_compaction_status::IDLE)
+ENUM_REG(replication::manual_compaction_status::IDLE)
+ENUM_REG(replication::manual_compaction_status::QUEUING)
+ENUM_REG(replication::manual_compaction_status::RUNNING)
+ENUM_REG(replication::manual_compaction_status::FINISHED)
+ENUM_END2(replication::manual_compaction_status::type, manual_compaction_status)
 } // namespace dsn

--- a/src/common/metadata.thrift
+++ b/src/common/metadata.thrift
@@ -76,6 +76,14 @@ enum disk_status
     SPACE_INSUFFICIENT
 }
 
+enum manual_compaction_status
+{
+    IDLE = 0,
+    QUEUING,
+    RUNNING,
+    FINISHED
+}
+
 // Used for cold backup and bulk load
 struct file_meta
 {
@@ -104,12 +112,13 @@ struct replica_configuration
 
 struct replica_info
 {
-    1:dsn.gpid               pid;
-    2:i64                    ballot;
-    3:partition_status       status;
-    4:i64                    last_committed_decree;
-    5:i64                    last_prepared_decree;
-    6:i64                    last_durable_decree;
-    7:string                 app_type;
-    8:string                 disk_tag;
+    1:dsn.gpid                          pid;
+    2:i64                               ballot;
+    3:partition_status                  status;
+    4:i64                               last_committed_decree;
+    5:i64                               last_prepared_decree;
+    6:i64                               last_durable_decree;
+    7:string                            app_type;
+    8:string                            disk_tag;
+    9:optional manual_compaction_status manual_compact_status;
 }

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -550,7 +550,7 @@ void replica::init_disk_tag()
 {
     dsn::error_code err = _stub->_fs_manager.get_disk_tag(dir(), _disk_tag);
     if (dsn::ERR_OK != err) {
-        derror_replica("get disk tag of %s failed: %s, init it to empty ", dir(), err);
+        derror_replica("get disk tag of {} failed: {}, init it to empty ", dir(), err);
     }
 }
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -503,44 +503,10 @@ std::string replica::query_manual_compact_state() const
     return _app->query_compact_state();
 }
 
-const char *manual_compaction_status_to_string(manual_compaction_status status)
+manual_compaction_status::type replica::get_manual_compact_status() const
 {
-    switch (status) {
-    case kIdle:
-        return "idle";
-    case kQueuing:
-        return "queuing";
-    case kRunning:
-        return "running";
-    case kFinished:
-        return "finished";
-    default:
-        dassert(false, "invalid status({})", status);
-        __builtin_unreachable();
-    }
-}
-
-manual_compaction_status replica::get_manual_compact_status() const
-{
-    std::string compact_state = query_manual_compact_state();
-    // query_manual_compact_state will return a message like:
-    // Case1. last finish at [-]
-    // - partition is not manual compaction
-    // Case2. last finish at [timestamp], last used {time_used} ms
-    // - partition manual compaction finished
-    // Case3. last finish at [-], recent enqueue at [timestamp]
-    // - partition is in manual compaction queue
-    // Case4. last finish at [-], recent enqueue at [timestamp], recent start at [timestamp]
-    // - partition is running manual compaction
-    if (compact_state.find("recent start at") != std::string::npos) {
-        return kRunning;
-    } else if (compact_state.find("recent enqueue at") != std::string::npos) {
-        return kQueuing;
-    } else if (compact_state.find("last used") != std::string::npos) {
-        return kFinished;
-    } else {
-        return kIdle;
-    }
+    dassert_replica(_app != nullptr, "");
+    return _app->query_compact_status();
 }
 
 // Replicas on the server which serves for the same table will share the same perf-counter.

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -78,15 +78,6 @@ namespace test {
 class test_checker;
 }
 
-enum manual_compaction_status
-{
-    kIdle = 0,
-    kQueuing,
-    kRunning,
-    kFinished
-};
-const char *manual_compaction_status_to_string(manual_compaction_status status);
-
 #define CHECK_REQUEST_IF_SPLITTING(op_type)                                                        \
     if (_validate_partition_hash) {                                                                \
         if (_split_mgr->should_reject_request()) {                                                 \
@@ -419,8 +410,7 @@ private:
     // now this remote commend will be used by `scripts/pegasus_manual_compact.sh`
     std::string query_manual_compact_state() const;
 
-    // Used for http interface
-    manual_compaction_status get_manual_compact_status() const;
+    manual_compaction_status::type get_manual_compact_status() const;
 
     void init_table_level_latency_counters();
 

--- a/src/replica/replica_http_service.cpp
+++ b/src/replica/replica_http_service.cpp
@@ -123,7 +123,7 @@ void replica_http_service::query_manual_compaction_handler(const http_request &r
         return;
     }
 
-    std::unordered_map<gpid, manual_compaction_status> partition_compaction_status;
+    std::unordered_map<gpid, manual_compaction_status::type> partition_compaction_status;
     _stub->query_app_manual_compact_status(app_id, partition_compaction_status);
 
     int32_t idle_count = 0;
@@ -131,23 +131,23 @@ void replica_http_service::query_manual_compaction_handler(const http_request &r
     int32_t queuing_count = 0;
     int32_t finished_count = 0;
     for (const auto &kv : partition_compaction_status) {
-        if (kv.second == kRunning) {
+        if (kv.second == manual_compaction_status::RUNNING) {
             running_count++;
-        } else if (kv.second == kQueuing) {
+        } else if (kv.second == manual_compaction_status::QUEUING) {
             queuing_count++;
-        } else if (kv.second == kFinished) {
+        } else if (kv.second == manual_compaction_status::FINISHED) {
             finished_count++;
-        } else if (kv.second == kIdle) {
+        } else if (kv.second == manual_compaction_status::IDLE) {
             idle_count++;
         }
     }
 
     nlohmann::json json;
-    json["status"] =
-        nlohmann::json{{manual_compaction_status_to_string(kIdle), idle_count},
-                       {manual_compaction_status_to_string(kRunning), running_count},
-                       {manual_compaction_status_to_string(kQueuing), queuing_count},
-                       {manual_compaction_status_to_string(kFinished), finished_count}};
+    json["status"] = nlohmann::json{
+        {manual_compaction_status_to_string(manual_compaction_status::IDLE), idle_count},
+        {manual_compaction_status_to_string(manual_compaction_status::RUNNING), running_count},
+        {manual_compaction_status_to_string(manual_compaction_status::QUEUING), queuing_count},
+        {manual_compaction_status_to_string(manual_compaction_status::FINISHED), finished_count}};
     resp.status_code = http_status_code::ok;
     resp.body = json.dump();
 }

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -53,6 +53,23 @@ public:
     void query_app_data_version_handler(const http_request &req, http_response &resp);
     void query_manual_compaction_handler(const http_request &req, http_response &resp);
 
+    inline const char *manual_compaction_status_to_string(manual_compaction_status::type status)
+    {
+        switch (status) {
+        case manual_compaction_status::IDLE:
+            return "idle";
+        case manual_compaction_status::QUEUING:
+            return "queuing";
+        case manual_compaction_status::RUNNING:
+            return "running";
+        case manual_compaction_status::FINISHED:
+            return "finished";
+        default:
+            dassert(false, "invalid status({})", status);
+            __builtin_unreachable();
+        }
+    }
+
 private:
     replica_stub *_stub;
 };

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1326,6 +1326,7 @@ void replica_stub::get_replica_info(replica_info &info, replica_ptr r)
     info.last_committed_decree = r->last_committed_decree();
     info.last_prepared_decree = r->last_prepared_decree();
     info.last_durable_decree = r->last_durable_decree();
+    // TODO(heyuchen): add manual compaction status
 
     dsn::error_code err = _fs_manager.get_disk_tag(r->dir(), info.disk_tag);
     if (dsn::ERR_OK != err) {
@@ -2958,7 +2959,7 @@ void replica_stub::query_app_data_version(
 }
 
 void replica_stub::query_app_manual_compact_status(
-    int32_t app_id, std::unordered_map<gpid, manual_compaction_status> &status)
+    int32_t app_id, std::unordered_map<gpid, manual_compaction_status::type> &status)
 {
     zauto_read_lock l(_replicas_lock);
     for (auto it = _replicas.begin(); it != _replicas.end(); ++it) {

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -223,7 +223,7 @@ public:
 
     // query partitions compact status by app_id
     void query_app_manual_compact_status(
-        int32_t app_id, /*out*/ std::unordered_map<gpid, manual_compaction_status> &status);
+        int32_t app_id, /*out*/ std::unordered_map<gpid, manual_compaction_status::type> &status);
 
     void on_add_new_disk(add_new_disk_rpc rpc);
 

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.h
@@ -93,6 +93,11 @@ public:
 
     virtual uint32_t query_data_version() const override { return 0; }
 
+    virtual ::dsn::replication::manual_compaction_status::type query_compact_status() const override
+    {
+        return dsn::replication::manual_compaction_status::IDLE;
+    }
+
 private:
     void recover();
     void recover(const std::string &name, int64_t version);

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
@@ -93,6 +93,11 @@ public:
 
     virtual uint32_t query_data_version() const override { return 0; }
 
+    virtual ::dsn::replication::manual_compaction_status::type query_compact_status() const override
+    {
+        return dsn::replication::manual_compaction_status::IDLE;
+    }
+
 private:
     void recover();
     void recover(const std::string &name, int64_t version);

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -83,6 +83,11 @@ public:
 
     uint32_t query_data_version() const { return 1; }
 
+    manual_compaction_status::type query_compact_status() const
+    {
+        return manual_compaction_status::IDLE;
+    }
+
 private:
     std::map<std::string, std::string> _envs;
     decree _decree = 5;


### PR DESCRIPTION
As https://github.com/apache/incubator-pegasus/issues/850 shows, meta server should know the status of manual compaction.
This pull request is the part1 of the replica servers report manual compaction status to meta server:
1. move structure manual_compaction_status from `replica.h` to `metadata.thrift`
2. add a new function `query_compact_status` in `replication_app_base.h`, which will be implemented by pegasus repo to return the actual compaction status.