### PR TITLE
feat(manual_compaction): replica report status part3

### DIFF
--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -439,9 +439,7 @@ void config_context::collect_serving_replica(const rpc_address &node, const repl
     if (iter != serving.end()) {
         iter->disk_tag = info.disk_tag;
         iter->storage_mb = 0;
-        if (iter->compact_status != compact_status) {
-            iter->compact_status = compact_status;
-        }
+        iter->compact_status = compact_status;
     } else {
         serving.emplace_back(serving_replica{node, 0, info.disk_tag, compact_status});
     }

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -434,11 +434,16 @@ bool config_context::remove_from_serving(const rpc_address &node)
 void config_context::collect_serving_replica(const rpc_address &node, const replica_info &info)
 {
     auto iter = find_from_serving(node);
+    auto compact_status = info.__isset.manual_compact_status ? info.manual_compact_status
+                                                             : manual_compaction_status::IDLE;
     if (iter != serving.end()) {
         iter->disk_tag = info.disk_tag;
         iter->storage_mb = 0;
+        if (iter->compact_status != compact_status) {
+            iter->compact_status = compact_status;
+        }
     } else {
-        serving.emplace_back(serving_replica{node, 0, info.disk_tag});
+        serving.emplace_back(serving_replica{node, 0, info.disk_tag, compact_status});
     }
 }
 

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -182,6 +182,7 @@ struct serving_replica
     // TODO: report the storage size of replica
     int64_t storage_mb;
     std::string disk_tag;
+    manual_compaction_status::type compact_status;
 };
 
 class config_context

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1326,11 +1326,15 @@ void replica_stub::get_replica_info(replica_info &info, replica_ptr r)
     info.last_committed_decree = r->last_committed_decree();
     info.last_prepared_decree = r->last_prepared_decree();
     info.last_durable_decree = r->last_durable_decree();
-    // TODO(heyuchen): add manual compaction status
 
     dsn::error_code err = _fs_manager.get_disk_tag(r->dir(), info.disk_tag);
     if (dsn::ERR_OK != err) {
         dwarn("get disk tag of %s failed: %s", r->dir().c_str(), err.to_string());
+    }
+
+    auto compact_status = r->get_manual_compact_status();
+    if (compact_status != manual_compaction_status::IDLE) {
+        info.__set_manual_compact_status(compact_status);
     }
 }
 

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1332,10 +1332,7 @@ void replica_stub::get_replica_info(replica_info &info, replica_ptr r)
         dwarn("get disk tag of %s failed: %s", r->dir().c_str(), err.to_string());
     }
 
-    auto compact_status = r->get_manual_compact_status();
-    if (compact_status != manual_compaction_status::IDLE) {
-        info.__set_manual_compact_status(compact_status);
-    }
+    info.__set_manual_compact_status(r->get_manual_compact_status());
 }
 
 void replica_stub::get_local_replicas(std::vector<replica_info> &replicas)


### PR DESCRIPTION
As apache/incubator-pegasus#850 shows, meta server should know the status of manual compaction.
This pull request is the part3 of the replica servers report manual compaction status to meta server:
1. replica report manual compaction status through `on_config_sync`, reference `get_replica_info` in this pr
2. meta also update manual compaction status throught `on_config_sync`, reference `collect_serving_replica` in this pr