### PR TITLE
feat: change the nfs limiter diable by default

### DIFF
--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -275,7 +275,7 @@ void nfs_client_impl::continue_copy()
             zauto_lock l(req->lock);
             const user_request_ptr &ureq = req->file_ctx->user_req;
             if (req->is_valid) {
-                if (!FLAGS_max_copy_rate_megabytes_per_disk) {
+                if (FLAGS_max_copy_rate_megabytes_per_disk) {
                     _copy_token_buckets->get_token_bucket(ureq->file_size_req.dest_disk_tag)
                         ->consumeWithBorrowAndWait(
                             req->size,

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -52,6 +52,7 @@ DSN_DEFINE_int32(
     "max rate per disk of copying from remote node(MB/s), zero means disable rate limiter");
 DSN_TAG_VARIABLE(max_copy_rate_megabytes_per_disk, FT_MUTABLE);
 
+
 DSN_DEFINE_int32("nfs",
                  max_concurrent_remote_copy_requests,
                  50,

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -111,8 +111,8 @@ nfs_client_impl::nfs_client_impl()
         COUNTER_TYPE_VOLATILE_NUMBER,
         "nfs client write fail count count in the recent period");
 
-    // max_copy_rate_bytes should be greater than nfs_copy_block_bytes which is the max batch copy
-    // size once
+    // max_copy_rate_bytes should be zero or greater than nfs_copy_block_bytes which is the max
+    // batch copy size once
     dassert(FLAGS_max_copy_rate_megabytes_per_disk == 0 ||
                 (FLAGS_max_copy_rate_megabytes_per_disk << 20) > FLAGS_nfs_copy_block_bytes,
             "max_copy_rate_bytes should be greater than nfs_copy_block_bytes");

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -45,12 +45,18 @@ DSN_DEFINE_uint32("nfs",
                   nfs_copy_block_bytes,
                   4 * 1024 * 1024,
                   "max block size (bytes) for each network copy");
-DSN_DEFINE_int32(
+DSN_DEFINE_uint32(
     "nfs",
     max_copy_rate_megabytes_per_disk,
     0,
     "max rate per disk of copying from remote node(MB/s), zero means disable rate limiter");
 DSN_TAG_VARIABLE(max_copy_rate_megabytes_per_disk, FT_MUTABLE);
+// max_copy_rate_bytes should be zero or greater than nfs_copy_block_bytes which is the max
+// batch copy size once
+DSN_DEFINE_group_validator(max_copy_rate_megabytes_per_disk, [](std::string &message) -> bool {
+    return FLAGS_max_copy_rate_megabytes_per_disk == 0 ||
+           (FLAGS_max_copy_rate_megabytes_per_disk << 20) > FLAGS_nfs_copy_block_bytes;
+});
 
 DSN_DEFINE_int32("nfs",
                  max_concurrent_remote_copy_requests,
@@ -111,11 +117,6 @@ nfs_client_impl::nfs_client_impl()
         COUNTER_TYPE_VOLATILE_NUMBER,
         "nfs client write fail count count in the recent period");
 
-    // max_copy_rate_bytes should be zero or greater than nfs_copy_block_bytes which is the max
-    // batch copy size once
-    dassert(FLAGS_max_copy_rate_megabytes_per_disk == 0 ||
-                (FLAGS_max_copy_rate_megabytes_per_disk << 20) > FLAGS_nfs_copy_block_bytes,
-            "max_copy_rate_bytes should be greater than nfs_copy_block_bytes");
     _copy_token_buckets = std::make_unique<utils::token_buckets>();
 
     register_cli_commands();

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -52,7 +52,6 @@ DSN_DEFINE_int32(
     "max rate per disk of copying from remote node(MB/s), zero means disable rate limiter");
 DSN_TAG_VARIABLE(max_copy_rate_megabytes_per_disk, FT_MUTABLE);
 
-
 DSN_DEFINE_int32("nfs",
                  max_concurrent_remote_copy_requests,
                  50,

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -113,7 +113,8 @@ nfs_client_impl::nfs_client_impl()
 
     // max_copy_rate_bytes should be greater than nfs_copy_block_bytes which is the max batch copy
     // size once
-    dassert((FLAGS_max_copy_rate_megabytes_per_disk << 20) > FLAGS_nfs_copy_block_bytes,
+    dassert(FLAGS_max_copy_rate_megabytes_per_disk == 0 ||
+                (FLAGS_max_copy_rate_megabytes_per_disk << 20) > FLAGS_nfs_copy_block_bytes,
             "max_copy_rate_bytes should be greater than nfs_copy_block_bytes");
     _copy_token_buckets = std::make_unique<utils::token_buckets>();
 

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -275,7 +275,7 @@ void nfs_client_impl::continue_copy()
             zauto_lock l(req->lock);
             const user_request_ptr &ureq = req->file_ctx->user_req;
             if (req->is_valid) {
-                if (FLAGS_max_copy_rate_megabytes_per_disk) {
+                if (FLAGS_max_copy_rate_megabytes_per_disk > 0) {
                     _copy_token_buckets->get_token_bucket(ureq->file_size_req.dest_disk_tag)
                         ->consumeWithBorrowAndWait(
                             req->size,

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -42,10 +42,11 @@
 namespace dsn {
 namespace service {
 
-DSN_DEFINE_int32("nfs",
-                 max_send_rate_megabytes_per_disk,
-                 0,
-                 "max rate per disk of send to remote node(MB/s)，zero means disable rate limiter");
+DSN_DEFINE_uint32(
+    "nfs",
+    max_send_rate_megabytes_per_disk,
+    0,
+    "max rate per disk of send to remote node(MB/s)，zero means disable rate limiter");
 DSN_TAG_VARIABLE(max_send_rate_megabytes_per_disk, FT_MUTABLE);
 
 DSN_DECLARE_int32(file_close_timer_interval_ms_on_server);

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -141,7 +141,7 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
 
 void nfs_service_impl::internal_read_callback(error_code err, size_t sz, callback_para &cp)
 {
-    if (FLAGS_max_send_rate_megabytes_per_disk) {
+    if (FLAGS_max_send_rate_megabytes_per_disk > 0) {
         _send_token_buckets->get_token_bucket(cp.source_disk_tag)
             ->consumeWithBorrowAndWait(sz,
                                        FLAGS_max_send_rate_megabytes_per_disk << 20,

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -44,8 +44,8 @@ namespace service {
 
 DSN_DEFINE_int32("nfs",
                  max_send_rate_megabytes_per_disk,
-                 500,
-                 "max rate per disk of send to remote node(MB/s)");
+                 0,
+                 "max rate per disk of send to remote node(MB/s)，zero means disable rate limiter");
 DSN_TAG_VARIABLE(max_send_rate_megabytes_per_disk, FT_MUTABLE);
 
 DSN_DECLARE_int32(file_close_timer_interval_ms_on_server);
@@ -141,10 +141,13 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
 
 void nfs_service_impl::internal_read_callback(error_code err, size_t sz, callback_para &cp)
 {
-    _send_token_buckets->get_token_bucket(cp.source_disk_tag)
-        ->consumeWithBorrowAndWait(sz,
-                                   FLAGS_max_send_rate_megabytes_per_disk << 20,
-                                   1.5 * (FLAGS_max_send_rate_megabytes_per_disk << 20));
+    if (!FLAGS_max_send_rate_megabytes_per_disk) {
+        _send_token_buckets->get_token_bucket(cp.source_disk_tag)
+            ->consumeWithBorrowAndWait(sz,
+                                       FLAGS_max_send_rate_megabytes_per_disk << 20,
+                                       1.5 * (FLAGS_max_send_rate_megabytes_per_disk << 20));
+    }
+
     {
         zauto_lock l(_handles_map_lock);
         auto it = _handles_map.find(cp.file_path);

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -141,7 +141,7 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
 
 void nfs_service_impl::internal_read_callback(error_code err, size_t sz, callback_para &cp)
 {
-    if (!FLAGS_max_send_rate_megabytes_per_disk) {
+    if (FLAGS_max_send_rate_megabytes_per_disk) {
         _send_token_buckets->get_token_bucket(cp.source_disk_tag)
             ->consumeWithBorrowAndWait(sz,
                                        FLAGS_max_send_rate_megabytes_per_disk << 20,


### PR DESCRIPTION
Setting nfs rate 500MB is equal with `no limiter`, so we disable the nfs limiter to avoid some bugs of `folly-limiter`: https://github.com/apache/incubator-pegasus/issues/846