### PR TITLE
feat(backup): add write limiter for hdfs

### DIFF
--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -43,11 +43,11 @@ DSN_DEFINE_uint64("replication",
                   "hdfs read batch size, the default value is 64MB");
 DSN_TAG_VARIABLE(hdfs_read_batch_size_bytes, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", hdfs_read_limit_rate_megabytes, 200, "hdfs read limit(MB/s)");
-DSN_TAG_VARIABLE(hdfs_read_limit_rate_megabytes, FT_MUTABLE);
+DSN_DEFINE_uint32("replication", hdfs_read_limit_rate_mb_per_sec, 200, "hdfs read limit(MB/s)");
+DSN_TAG_VARIABLE(hdfs_read_limit_rate_mb_per_sec, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", hdfs_write_limit_rate_megabytes, 200, "hdfs write limit(MB/s)");
-DSN_TAG_VARIABLE(hdfs_write_limit_rate_megabytes, FT_MUTABLE);
+DSN_DEFINE_uint32("replication", hdfs_write_limit_rate_mb_per_sec, 200, "hdfs write limit(MB/s)");
+DSN_TAG_VARIABLE(hdfs_write_limit_rate_mb_per_sec, FT_MUTABLE);
 
 DSN_DEFINE_uint64("replication",
                   hdfs_write_batch_size_bytes,
@@ -302,9 +302,9 @@ error_code hdfs_file_object::write_data_in_batches(const char *data,
     uint64_t write_len = 0;
     while (cur_pos < data_size) {
         write_len = std::min(data_size - cur_pos, FLAGS_hdfs_write_batch_size_bytes);
-        const uint64_t rate = FLAGS_hdfs_write_limit_rate_megabytes << 20;
-        _service->_write_token_bucket->consumeWithBorrowAndWait(
-            write_len, rate, std::max(2 * rate, write_len));
+        const uint64_t rate = FLAGS_hdfs_write_limit_rate_mb_per_sec << 20;
+        const uint64_t burst_size = std::max(2 * rate, write_len);
+        _service->_write_token_bucket->consumeWithBorrowAndWait(write_len, rate, burst_size);
 
         tSize num_written_bytes = hdfsWrite(_service->get_fs(),
                                             write_file,
@@ -419,11 +419,11 @@ error_code hdfs_file_object::read_data_in_batches(uint64_t start_pos,
     uint64_t read_size = 0;
     bool read_success = true;
     while (cur_pos < start_pos + data_length) {
-        const uint64_t rate = FLAGS_hdfs_read_limit_rate_megabytes << 20;
+        const uint64_t rate = FLAGS_hdfs_read_limit_rate_mb_per_sec << 20;
         read_size = std::min(start_pos + data_length - cur_pos, FLAGS_hdfs_read_batch_size_bytes);
         // burst size should not be less than consume size
-        _service->_read_token_bucket->consumeWithBorrowAndWait(
-            read_size, rate, std::max(2 * rate, read_size));
+        const uint64_t burst_size = std::max(2 * rate, read_size);
+        _service->_read_token_bucket->consumeWithBorrowAndWait(read_size, rate, burst_size);
 
         tSize num_read_bytes = hdfsPread(_service->get_fs(),
                                          read_file,

--- a/src/block_service/hdfs/hdfs_service.h
+++ b/src/block_service/hdfs/hdfs_service.h
@@ -64,7 +64,7 @@ private:
     std::string _hdfs_path;
 
     std::unique_ptr<folly::DynamicTokenBucket> _read_token_bucket;
-    // TODO: add write limiter
+    std::unique_ptr<folly::DynamicTokenBucket> _write_token_bucket;
 
     friend class hdfs_file_object;
 };


### PR DESCRIPTION
### What this pr solves
This pull request adds a folly read limiter for HDFS, different from FDS implementation, this pr uses `BasicDynamicTokenBucket` provided by folly to make it thread-safe to update limiter size dynamically.

### Test
- Unit test
- Manual test
![image](https://user-images.githubusercontent.com/22953824/146534375-7cc68088-1f63-413b-a206-518453358f8f.png)


### Config changed
```diff
+ [replication]
+ hdfs_read_limit_rate_mb_per_sec = 200
+ hdfs_write_limit_rate_mb_per_sec = 200
- hdfs_read_limit_rate_megabytes
```