### PR TITLE
refactor: move manual compaction common  types to a seperate file

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -46,6 +46,7 @@
 #include "common/replication_common.h"
 #include "common/bulk_load_common.h"
 #include "common/partition_split_common.h"
+#include "common/manual_compact.h"
 #include "meta/meta_rpc_types.h"
 
 namespace dsn {

--- a/src/common/manual_compact.h
+++ b/src/common/manual_compact.h
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <dsn/cpp/rpc_holder.h>
+
+namespace dsn {
+namespace replication {
+typedef rpc_holder<start_app_manual_compact_request, start_app_manual_compact_response>
+        start_manual_compact_rpc;
+typedef rpc_holder<query_app_manual_compact_request, query_app_manual_compact_response>
+        query_manual_compact_rpc;
+} // namespace replication
+} // namespace dsn

--- a/src/common/manual_compact.h
+++ b/src/common/manual_compact.h
@@ -17,13 +17,14 @@
 
 #pragma once
 
+#include "meta_admin_types.h"
 #include <dsn/cpp/rpc_holder.h>
 
 namespace dsn {
 namespace replication {
 typedef rpc_holder<start_app_manual_compact_request, start_app_manual_compact_response>
-        start_manual_compact_rpc;
+    start_manual_compact_rpc;
 typedef rpc_holder<query_app_manual_compact_request, query_app_manual_compact_response>
-        query_manual_compact_rpc;
+    query_manual_compact_rpc;
 } // namespace replication
 } // namespace dsn

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -47,11 +47,6 @@ typedef rpc_holder<configuration_update_app_env_request, configuration_update_ap
 
 typedef rpc_holder<backup_request, backup_response> backup_rpc;
 
-typedef rpc_holder<start_app_manual_compact_request, start_app_manual_compact_response>
-    start_manual_compact_rpc;
-typedef rpc_holder<query_app_manual_compact_request, query_app_manual_compact_response>
-    query_manual_compact_rpc;
-
 class replication_options
 {
 public:

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -44,6 +44,7 @@
 #include "common/replication_common.h"
 #include "common/bulk_load_common.h"
 #include "common/partition_split_common.h"
+#include "common/manual_compact.h"
 #include "meta_rpc_types.h"
 #include "meta_options.h"
 #include "meta_backup_service.h"


### PR DESCRIPTION
manual compaction has nothing to do with replication. So in this pull request, I move the corresponding typs to a seperate file named `manual_compaction.h`