### PR TITLE
refactor: move backup common types to backup_common.h

### DIFF
--- a/src/common/backup_common.cpp
+++ b/src/common/backup_common.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "backup_utils.h"
+#include "backup_common.h"
 #include "replica/backup/cold_backup_context.h"
 
 namespace dsn {
@@ -26,6 +26,16 @@ const std::string cold_backup_constant::CURRENT_CHECKPOINT("current_checkpoint")
 const std::string cold_backup_constant::BACKUP_METADATA("backup_metadata");
 const std::string cold_backup_constant::BACKUP_INFO("backup_info");
 const int32_t cold_backup_constant::PROGRESS_FINISHED = 1000;
+
+const std::string backup_restore_constant::FORCE_RESTORE("restore.force_restore");
+const std::string backup_restore_constant::BLOCK_SERVICE_PROVIDER("restore.block_service_provider");
+const std::string backup_restore_constant::CLUSTER_NAME("restore.cluster_name");
+const std::string backup_restore_constant::POLICY_NAME("restore.policy_name");
+const std::string backup_restore_constant::APP_NAME("restore.app_name");
+const std::string backup_restore_constant::APP_ID("restore.app_id");
+const std::string backup_restore_constant::BACKUP_ID("restore.backup_id");
+const std::string backup_restore_constant::SKIP_BAD_PARTITION("restore.skip_bad_partition");
+const std::string backup_restore_constant::RESTORE_PATH("restore.restore_path");
 
 namespace cold_backup {
 

--- a/src/common/backup_common.h
+++ b/src/common/backup_common.h
@@ -19,6 +19,8 @@
 
 #include <string>
 #include <dsn/tool-api/gpid.h>
+#include "backup_types.h"
+#include <dsn/cpp/rpc_holder.h>
 
 namespace dsn {
 namespace replication {
@@ -32,6 +34,22 @@ public:
     static const std::string BACKUP_METADATA;
     static const std::string BACKUP_INFO;
     static const int32_t PROGRESS_FINISHED;
+};
+
+typedef rpc_holder<backup_request, backup_response> backup_rpc;
+
+class backup_restore_constant
+{
+public:
+    static const std::string FORCE_RESTORE;
+    static const std::string BLOCK_SERVICE_PROVIDER;
+    static const std::string CLUSTER_NAME;
+    static const std::string POLICY_NAME;
+    static const std::string APP_NAME;
+    static const std::string APP_ID;
+    static const std::string BACKUP_ID;
+    static const std::string SKIP_BAD_PARTITION;
+    static const std::string RESTORE_PATH;
 };
 
 namespace cold_backup {

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -610,16 +610,6 @@ replication_options::check_if_in_black_list(const std::vector<std::string> &blac
     return false;
 }
 
-const std::string backup_restore_constant::FORCE_RESTORE("restore.force_restore");
-const std::string backup_restore_constant::BLOCK_SERVICE_PROVIDER("restore.block_service_provider");
-const std::string backup_restore_constant::CLUSTER_NAME("restore.cluster_name");
-const std::string backup_restore_constant::POLICY_NAME("restore.policy_name");
-const std::string backup_restore_constant::APP_NAME("restore.app_name");
-const std::string backup_restore_constant::APP_ID("restore.app_id");
-const std::string backup_restore_constant::BACKUP_ID("restore.backup_id");
-const std::string backup_restore_constant::SKIP_BAD_PARTITION("restore.skip_bad_partition");
-const std::string backup_restore_constant::RESTORE_PATH("restore.restore_path");
-
 const std::string replica_envs::DENY_CLIENT_WRITE("replica.deny_client_write");
 const std::string replica_envs::WRITE_QPS_THROTTLING("replica.write_throttling");
 const std::string replica_envs::WRITE_SIZE_THROTTLING("replica.write_throttling_by_size");

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -45,8 +45,6 @@ typedef std::unordered_map<::dsn::rpc_address, dsn::task_ptr> node_tasks;
 typedef rpc_holder<configuration_update_app_env_request, configuration_update_app_env_response>
     update_app_env_rpc;
 
-typedef rpc_holder<backup_request, backup_response> backup_rpc;
-
 class replication_options
 {
 public:
@@ -146,20 +144,6 @@ private:
 };
 
 extern const char *partition_status_to_string(partition_status::type status);
-
-class backup_restore_constant
-{
-public:
-    static const std::string FORCE_RESTORE;
-    static const std::string BLOCK_SERVICE_PROVIDER;
-    static const std::string CLUSTER_NAME;
-    static const std::string POLICY_NAME;
-    static const std::string APP_NAME;
-    static const std::string APP_ID;
-    static const std::string BACKUP_ID;
-    static const std::string SKIP_BAD_PARTITION;
-    static const std::string RESTORE_PATH;
-};
 
 } // namespace replication
 } // namespace dsn

--- a/src/meta/backup_engine.cpp
+++ b/src/meta/backup_engine.cpp
@@ -18,7 +18,7 @@
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/filesystem.h>
 
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "common/replication_common.h"
 #include "server_state.h"
 

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -22,7 +22,7 @@
 #include <dsn/utils/time_utils.h>
 
 #include "block_service/block_service_manager.h"
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "meta_backup_service.h"
 #include "meta_service.h"
 #include "server_state.h"

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -21,7 +21,7 @@
 #include <dsn/utility/filesystem.h>
 
 #include "block_service/block_service_manager.h"
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "meta_service.h"
 #include "server_state.h"
 

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -19,7 +19,7 @@
 #include <dsn/utility/filesystem.h>
 #include <gtest/gtest.h>
 
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "meta/meta_backup_service.h"
 #include "meta/meta_service.h"
 #include "meta/server_state.h"

--- a/src/meta/test/server_state_restore_test.cpp
+++ b/src/meta/test/server_state_restore_test.cpp
@@ -19,7 +19,7 @@
 #include <dsn/utility/filesystem.h>
 #include <gtest/gtest.h>
 
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "meta/meta_service.h"
 #include "meta/server_state.h"
 #include "meta_test_base.h"

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "cold_backup_context.h"
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "replica/replica.h"
 #include "replica/replica_stub.h"
 #include "block_service/block_service_manager.h"

--- a/src/replica/backup/cold_backup_context.h
+++ b/src/replica/backup/cold_backup_context.h
@@ -21,7 +21,7 @@
 #include <dsn/cpp/json_helper.h>
 #include <dsn/dist/block_service.h>
 
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 
 class replication_service_test_app;
 

--- a/src/replica/backup/replica_backup_server.h
+++ b/src/replica/backup/replica_backup_server.h
@@ -20,7 +20,7 @@
 #include <dsn/dist/replication/replication_types.h>
 #include <dsn/cpp/rpc_holder.h>
 
-#include "common/replication_common.h"
+#include "common/backup_common.h"
 
 namespace dsn {
 namespace replication {

--- a/src/replica/test/backup_block_service_mock.h
+++ b/src/replica/test/backup_block_service_mock.h
@@ -25,7 +25,7 @@
 #include "replica/replica_context.h"
 #include "replication_service_test_app.h"
 #include "block_service/test/block_service_mock.h"
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 
 using namespace ::dsn;
 using namespace ::dsn::dist::block_service;

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -24,7 +24,6 @@
 #include "common/backup_common.h"
 #include "replica_test_base.h"
 #include "replica/replica_http_service.h"
-#include "common/backup_common.h"
 
 namespace dsn {
 namespace replication {

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -21,10 +21,10 @@
 #include <gtest/gtest.h>
 #include "runtime/rpc/network.sim.h"
 
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 #include "replica_test_base.h"
 #include "replica/replica_http_service.h"
-#include "common/backup_utils.h"
+#include "common/backup_common.h"
 
 namespace dsn {
 namespace replication {


### PR DESCRIPTION
backup types have nothing to do with replication. So move it from replication_common.h to backup_common.h