### PR TITLE
feat(online_migration): part2 - add ingest_behind option for bulk load

### DIFF
--- a/include/dsn/dist/replication/replication_ddl_client.h
+++ b/include/dsn/dist/replication/replication_ddl_client.h
@@ -187,7 +187,8 @@ public:
     error_with<start_bulk_load_response> start_bulk_load(const std::string &app_name,
                                                          const std::string &cluster_name,
                                                          const std::string &file_provider_type,
-                                                         const std::string &remote_root_path);
+                                                         const std::string &remote_root_path,
+                                                         bool ingest_behind = false);
 
     error_with<control_bulk_load_response>
     control_bulk_load(const std::string &app_name, const bulk_load_control_type::type control_type);

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1579,13 +1579,15 @@ error_with<start_bulk_load_response>
 replication_ddl_client::start_bulk_load(const std::string &app_name,
                                         const std::string &cluster_name,
                                         const std::string &file_provider_type,
-                                        const std::string &remote_root_path)
+                                        const std::string &remote_root_path,
+                                        const bool ingest_behind)
 {
     auto req = make_unique<start_bulk_load_request>();
     req->app_name = app_name;
     req->cluster_name = cluster_name;
     req->file_provider_type = file_provider_type;
     req->remote_root_path = remote_root_path;
+    req->ingest_behind = ingest_behind;
     return call_rpc_sync(start_bulk_load_rpc(std::move(req), RPC_CM_START_BULK_LOAD));
 }
 

--- a/src/common/bulk_load.thrift
+++ b/src/common/bulk_load.thrift
@@ -56,6 +56,7 @@ struct start_bulk_load_request
     2:string    cluster_name;
     3:string    file_provider_type;
     4:string    remote_root_path;
+    5:bool      ingest_behind = false;
 }
 
 struct start_bulk_load_response
@@ -150,6 +151,7 @@ struct ingestion_request
 {
     1:string                app_name;
     2:bulk_load_metadata    metadata;
+    3:bool                  ingest_behind;
 }
 
 struct ingestion_response

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <dsn/dist/fmt_logging.h>
+#include <dsn/dist/replication/replica_envs.h>
 #include <dsn/utility/fail_point.h>
 
 #include "meta_bulk_load_service.h"
@@ -91,13 +92,8 @@ void bulk_load_service::on_start_bulk_load(start_bulk_load_rpc rpc)
     }
 
     std::string hint_msg;
-    error_code e = check_bulk_load_request_params(request.app_name,
-                                                  request.cluster_name,
-                                                  request.file_provider_type,
-                                                  request.remote_root_path,
-                                                  app->app_id,
-                                                  app->partition_count,
-                                                  hint_msg);
+    error_code e = check_bulk_load_request_params(
+        request, app->app_id, app->partition_count, app->envs, hint_msg);
     if (e != ERR_OK) {
         response.err = e;
         response.hint_msg = hint_msg;
@@ -105,11 +101,13 @@ void bulk_load_service::on_start_bulk_load(start_bulk_load_rpc rpc)
         return;
     }
 
-    ddebug_f("app({}) start bulk load, cluster_name = {}, provider = {}, remote root path = {}",
+    ddebug_f("app({}) start bulk load, cluster_name = {}, provider = {}, remote root path = {}, "
+             "ingest_behind = {}",
              request.app_name,
              request.cluster_name,
              request.file_provider_type,
-             request.remote_root_path);
+             request.remote_root_path,
+             request.ingest_behind);
 
     // clear old bulk load result
     reset_local_bulk_load_states(app->app_id, app->app_name, true);
@@ -123,17 +121,23 @@ void bulk_load_service::on_start_bulk_load(start_bulk_load_rpc rpc)
 }
 
 // ThreadPool: THREAD_POOL_META_SERVER
-error_code bulk_load_service::check_bulk_load_request_params(const std::string &app_name,
-                                                             const std::string &cluster_name,
-                                                             const std::string &file_provider,
-                                                             const std::string &remote_root_path,
-                                                             const int32_t app_id,
-                                                             const int32_t partition_count,
-                                                             std::string &hint_msg)
+error_code
+bulk_load_service::check_bulk_load_request_params(const start_bulk_load_request &request,
+                                                  const int32_t app_id,
+                                                  const int32_t partition_count,
+                                                  const std::map<std::string, std::string> envs,
+                                                  std::string &hint_msg)
 {
     FAIL_POINT_INJECT_F("meta_check_bulk_load_request_params",
                         [](dsn::string_view) -> error_code { return ERR_OK; });
 
+    if (!validate_ingest_behind(envs, request.ingest_behind)) {
+        hint_msg = fmt::format("inconsistent ingestion behind option");
+        derror_f("{}", hint_msg);
+        return ERR_INCONSISTENT_STATE;
+    }
+
+    auto file_provider = request.file_provider_type;
     // check file provider
     dsn::dist::block_service::block_filesystem *blk_fs =
         _meta_svc->get_block_service_manager().get_or_create_block_filesystem(file_provider);
@@ -145,7 +149,7 @@ error_code bulk_load_service::check_bulk_load_request_params(const std::string &
 
     // sync get bulk_load_info file_handler
     const std::string remote_path =
-        get_bulk_load_info_path(app_name, cluster_name, remote_root_path);
+        get_bulk_load_info_path(request.app_name, request.cluster_name, request.remote_root_path);
     dsn::dist::block_service::create_file_request cf_req;
     cf_req.file_name = remote_path;
     cf_req.ignore_metadata = true;
@@ -193,7 +197,7 @@ error_code bulk_load_service::check_bulk_load_request_params(const std::string &
     if (bl_info.app_id != app_id || bl_info.partition_count != partition_count) {
         derror_f("app({}) information is inconsistent, local app_id({}) VS remote app_id({}), "
                  "local partition_count({}) VS remote partition_count({})",
-                 app_name,
+                 request.app_name,
                  app_id,
                  bl_info.app_id,
                  partition_count,
@@ -246,6 +250,7 @@ void bulk_load_service::create_app_bulk_load_dir(const std::string &app_name,
     ainfo.cluster_name = req.cluster_name;
     ainfo.file_provider_type = req.file_provider_type;
     ainfo.remote_root_path = req.remote_root_path;
+    ainfo.ingest_behind = req.ingest_behind;
     ainfo.is_ever_ingesting = false;
     ainfo.bulk_load_err = ERR_OK;
 
@@ -1186,6 +1191,7 @@ void bulk_load_service::send_ingestion_request(const std::string &app_name,
     {
         zauto_read_lock l(_lock);
         req.metadata = _partition_bulk_load_info[pid].metadata;
+        req.ingest_behind = _app_bulk_load_info[pid.get_app_id()].ingest_behind;
     }
     // create a client request, whose gpid field in header should be pid
     message_ex *msg = message_ex::create_request(dsn::apps::RPC_RRDB_RRDB_BULK_LOAD,
@@ -1623,7 +1629,7 @@ void bulk_load_service::try_to_continue_app_bulk_load(
     }
 
     // check app bulk load info
-    if (!validate_app(app->app_id, app->partition_count, ainfo, pinfo_map.size())) {
+    if (!validate_app(app->app_id, app->partition_count, app->envs, ainfo, pinfo_map.size())) {
         remove_bulk_load_dir_on_remote_storage(std::move(app), true);
         return;
     }
@@ -1652,8 +1658,27 @@ void bulk_load_service::try_to_continue_app_bulk_load(
 }
 
 // ThreadPool: THREAD_POOL_META_SERVER
+/*static*/ bool
+bulk_load_service::validate_ingest_behind(const std::map<std::string, std::string> &envs, bool val)
+{
+    bool app_allow_ingest_behind = false;
+    auto iter = envs.find(replica_envs::ROCKSDB_ALLOW_INGEST_BEHIND);
+    if (iter != envs.end()) {
+        if (!buf2bool(iter->second, app_allow_ingest_behind)) {
+            dwarn_f("can not convert {} to bool", iter->second);
+            app_allow_ingest_behind = false;
+        }
+    }
+    if (val && !app_allow_ingest_behind) {
+        return false;
+    }
+    return true;
+}
+
+// ThreadPool: THREAD_POOL_META_SERVER
 /*static*/ bool bulk_load_service::validate_app(int32_t app_id,
                                                 int32_t partition_count,
+                                                const std::map<std::string, std::string> &envs,
                                                 const app_bulk_load_info &ainfo,
                                                 int32_t pinfo_count)
 {
@@ -1691,6 +1716,11 @@ void bulk_load_service::try_to_continue_app_bulk_load(
                  ainfo.app_name,
                  dsn::enum_to_string(ainfo.status),
                  partition_count - pinfo_count);
+        return false;
+    }
+
+    if (!validate_ingest_behind(envs, ainfo.ingest_behind)) {
+        derror_f("app({}) has inconsistent ingest_behind option", ainfo.app_name);
         return false;
     }
 

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1659,7 +1659,8 @@ void bulk_load_service::try_to_continue_app_bulk_load(
 
 // ThreadPool: THREAD_POOL_META_SERVER
 /*static*/ bool
-bulk_load_service::validate_ingest_behind(const std::map<std::string, std::string> &envs, bool val)
+bulk_load_service::validate_ingest_behind(const std::map<std::string, std::string> &envs,
+                                          bool ingest_behind)
 {
     bool app_allow_ingest_behind = false;
     const auto &iter = envs.find(replica_envs::ROCKSDB_ALLOW_INGEST_BEHIND);
@@ -1669,7 +1670,7 @@ bulk_load_service::validate_ingest_behind(const std::map<std::string, std::strin
             app_allow_ingest_behind = false;
         }
     }
-    if (val && !app_allow_ingest_behind) {
+    if (ingest_behind && !app_allow_ingest_behind) {
         return false;
     }
     return true;

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1662,7 +1662,7 @@ void bulk_load_service::try_to_continue_app_bulk_load(
 bulk_load_service::validate_ingest_behind(const std::map<std::string, std::string> &envs, bool val)
 {
     bool app_allow_ingest_behind = false;
-    auto iter = envs.find(replica_envs::ROCKSDB_ALLOW_INGEST_BEHIND);
+    const auto iter = envs.find(replica_envs::ROCKSDB_ALLOW_INGEST_BEHIND);
     if (iter != envs.end()) {
         if (!buf2bool(iter->second, app_allow_ingest_behind)) {
             dwarn_f("can not convert {} to bool", iter->second);

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -125,7 +125,7 @@ error_code
 bulk_load_service::check_bulk_load_request_params(const start_bulk_load_request &request,
                                                   const int32_t app_id,
                                                   const int32_t partition_count,
-                                                  const std::map<std::string, std::string> envs,
+                                                  const std::map<std::string, std::string> &envs,
                                                   std::string &hint_msg)
 {
     FAIL_POINT_INJECT_F("meta_check_bulk_load_request_params",

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1662,7 +1662,7 @@ void bulk_load_service::try_to_continue_app_bulk_load(
 bulk_load_service::validate_ingest_behind(const std::map<std::string, std::string> &envs, bool val)
 {
     bool app_allow_ingest_behind = false;
-    const auto iter = envs.find(replica_envs::ROCKSDB_ALLOW_INGEST_BEHIND);
+    const auto &iter = envs.find(replica_envs::ROCKSDB_ALLOW_INGEST_BEHIND);
     if (iter != envs.end()) {
         if (!buf2bool(iter->second, app_allow_ingest_behind)) {
             dwarn_f("can not convert {} to bool", iter->second);

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -40,6 +40,7 @@ struct app_bulk_load_info
     std::string file_provider_type;
     bulk_load_status::type status;
     std::string remote_root_path;
+    bool ingest_behind;
     bool is_ever_ingesting;
     error_code bulk_load_err;
     DEFINE_JSON_SERIALIZATION(app_id,
@@ -49,6 +50,7 @@ struct app_bulk_load_info
                               file_provider_type,
                               status,
                               remote_root_path,
+                              ingest_behind,
                               is_ever_ingesting,
                               bulk_load_err)
 };
@@ -134,12 +136,10 @@ private:
     // - ERR_OBJECT_NOT_FOUND: bulk_load_info not exist, may wrong cluster_name or app_name
     // - ERR_CORRUPTION: bulk_load_info is damaged on file_provider
     // - ERR_INCONSISTENT_STATE: app_id or partition_count inconsistent
-    error_code check_bulk_load_request_params(const std::string &app_name,
-                                              const std::string &cluster_name,
-                                              const std::string &file_provider,
-                                              const std::string &remote_root_path,
+    error_code check_bulk_load_request_params(const start_bulk_load_request &request,
                                               const int32_t app_id,
                                               const int32_t partition_count,
+                                              const std::map<std::string, std::string> envs,
                                               std::string &hint_msg);
 
     void do_start_app_bulk_load(std::shared_ptr<app_state> app, start_bulk_load_rpc rpc);
@@ -287,8 +287,11 @@ private:
         const app_bulk_load_info &ainfo,
         const std::unordered_map<int32_t, partition_bulk_load_info> &partition_map);
 
+    static bool validate_ingest_behind(const std::map<std::string, std::string> &envs, bool val);
+
     static bool validate_app(int32_t app_id,
                              int32_t partition_count,
+                             const std::map<std::string, std::string> &envs,
                              const app_bulk_load_info &ainfo,
                              int32_t pinfo_count);
 

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -139,7 +139,7 @@ private:
     error_code check_bulk_load_request_params(const start_bulk_load_request &request,
                                               const int32_t app_id,
                                               const int32_t partition_count,
-                                              const std::map<std::string, std::string> envs,
+                                              const std::map<std::string, std::string> &envs,
                                               std::string &hint_msg);
 
     void do_start_app_bulk_load(std::shared_ptr<app_state> app, start_bulk_load_rpc rpc);

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -287,7 +287,8 @@ private:
         const app_bulk_load_info &ainfo,
         const std::unordered_map<int32_t, partition_bulk_load_info> &partition_map);
 
-    static bool validate_ingest_behind(const std::map<std::string, std::string> &envs, bool val);
+    static bool validate_ingest_behind(const std::map<std::string, std::string> &envs,
+                                       bool ingest_behind);
 
     static bool validate_app(int32_t app_id,
                              int32_t partition_count,


### PR DESCRIPTION
As apache/incubator-pegasus#851 show, we decide to support online migration.

This pull request add `ingest_behind` option for bulk load, including:
- Add `ingest_behind` in `start_bulk_load_request` and `app_bulk_load_info`
- Add parameter check for `ingest_behind`, reference function `validate_ingest_behind`
- Add related unit test