### PR TITLE
fix(bulk_load): fix replica validate status check

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -303,8 +303,7 @@ replica_bulk_loader::validate_status(const bulk_load_status::type meta_status,
     case bulk_load_status::BLS_DOWNLOADING:
         if (local_status == bulk_load_status::BLS_FAILED ||
             local_status == bulk_load_status::BLS_PAUSING ||
-            local_status == bulk_load_status::BLS_CANCELED ||
-            local_status == bulk_load_status::BLS_SUCCEED) {
+            local_status == bulk_load_status::BLS_CANCELED) {
             err = ERR_INVALID_STATE;
         }
         break;

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -889,7 +889,7 @@ TEST_F(replica_bulk_loader_test, validate_status_test)
                  {bulk_load_status::BLS_CANCELED, bulk_load_status::BLS_SUCCEED, true},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_INVALID, true},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_INGESTING, true},
-                 {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_SUCCEED, false},
+                 {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_SUCCEED, true},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_FAILED, false},
                  {bulk_load_status::BLS_DOWNLOADING, bulk_load_status::BLS_CANCELED, false},
                  {bulk_load_status::BLS_DOWNLOADED, bulk_load_status::BLS_INVALID, false},


### PR DESCRIPTION
#958 updates the bulk load status check for replica server, it considers that SUCCEED into DOWNLOADING is an invalid transition. However, If a table meet error during ingestion, some partitions have already switch to SUCCEED, and some partitions are INGESTING, it's possible for replica switch SUCCEED into DOWNLOADING. This pull request fixs it.