### PR TITLE
fix: message body size unset after parsed which leads to large io throughputs

### DIFF
--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -199,6 +199,8 @@ message_ex *thrift_message_parser::parse_request_body_v0(message_reader *reader,
         return nullptr;
     }
 
+    buf = buf.range(0, _meta_v0->body_length);
+    reader->consume_buffer(_meta_v0->body_length);
     message_ex *msg = create_message_from_request_blob(buf);
     if (msg == nullptr) {
         read_next = -1;
@@ -206,7 +208,6 @@ message_ex *thrift_message_parser::parse_request_body_v0(message_reader *reader,
         return nullptr;
     }
 
-    reader->consume_buffer(_meta_v0->body_length);
     read_next = (reader->_buffer_occupied >= HEADER_LENGTH_V0
                      ? 0
                      : HEADER_LENGTH_V0 - reader->_buffer_occupied);
@@ -246,6 +247,8 @@ message_ex *thrift_message_parser::parse_request_body_v1(message_reader *reader,
         read_next = _v1_specific_vars->_body_length - buf.size();
         return nullptr;
     }
+    buf = buf.range(0, _v1_specific_vars->_body_length);
+    reader->consume_buffer(_v1_specific_vars->_meta_length + _v1_specific_vars->_body_length);
     message_ex *msg = create_message_from_request_blob(buf);
     if (msg == nullptr) {
         read_next = -1;
@@ -253,7 +256,6 @@ message_ex *thrift_message_parser::parse_request_body_v1(message_reader *reader,
         return nullptr;
     }
 
-    reader->consume_buffer(_v1_specific_vars->_meta_length + _v1_specific_vars->_body_length);
     read_next = (reader->_buffer_occupied >= HEADER_LENGTH_V1
                      ? 0
                      : HEADER_LENGTH_V1 - reader->_buffer_occupied);

--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -30,6 +30,7 @@
 #include <dsn/cpp/serialization_helper/thrift_helper.h>
 #include <dsn/cpp/serialization_helper/dsn.layer2_types.h>
 #include <dsn/cpp/message_utils.h>
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/ports.h>
 #include <dsn/utility/crc.h>
 #include <dsn/utility/endians.h>
@@ -213,6 +214,7 @@ message_ex *thrift_message_parser::parse_request_body_v0(message_reader *reader,
                      : HEADER_LENGTH_V0 - reader->_buffer_occupied);
 
     msg->header->body_length = _meta_v0->body_length;
+    dcheck_eq(msg->header->body_length, msg->buffers[1].size());
     msg->header->gpid.set_app_id(_meta_v0->app_id);
     msg->header->gpid.set_partition_index(_meta_v0->partition_index);
     msg->header->client.timeout_ms = _meta_v0->client_timeout;
@@ -261,6 +263,7 @@ message_ex *thrift_message_parser::parse_request_body_v1(message_reader *reader,
                      : HEADER_LENGTH_V1 - reader->_buffer_occupied);
 
     msg->header->body_length = _v1_specific_vars->_body_length;
+    dcheck_eq(msg->header->body_length, msg->buffers[1].size());
     msg->header->gpid.set_app_id(_v1_specific_vars->_meta_v1->app_id);
     msg->header->gpid.set_partition_index(_v1_specific_vars->_meta_v1->partition_index);
     msg->header->client.timeout_ms = _v1_specific_vars->_meta_v1->client_timeout;

--- a/src/runtime/test/thrift_message_parser_test.cpp
+++ b/src/runtime/test/thrift_message_parser_test.cpp
@@ -30,7 +30,8 @@ DEFINE_TASK_CODE_RPC(RPC_TEST_THRIFT_MESSAGE_PARSER, TASK_PRIORITY_COMMON, THREA
 class thrift_message_parser_test : public testing::Test
 {
 public:
-    void mock_reader_read_data(message_reader &reader, const std::string &data, int message_count = 1)
+    void
+    mock_reader_read_data(message_reader &reader, const std::string &data, int message_count = 1)
     {
         char *buf = reader.read_buffer_ptr(data.length() * message_count);
         for (int i = 0; i < message_count; i++) {

--- a/src/runtime/test/thrift_message_parser_test.cpp
+++ b/src/runtime/test/thrift_message_parser_test.cpp
@@ -30,16 +30,19 @@ DEFINE_TASK_CODE_RPC(RPC_TEST_THRIFT_MESSAGE_PARSER, TASK_PRIORITY_COMMON, THREA
 class thrift_message_parser_test : public testing::Test
 {
 public:
-    void mock_reader_read_data(message_reader &reader, const std::string &data)
+    void mock_reader_read_data(message_reader &reader, const std::string &data, int message_num)
     {
-        char *buf = reader.read_buffer_ptr(data.length());
-        memcpy(buf, data.c_str(), data.size());
-        reader.mark_read(data.length());
+        char *buf = reader.read_buffer_ptr(data.length() * message_num);
+        for (int i = 0; i < message_num; i++) {
+            memcpy(buf + i * data.length(), data.c_str(), data.length());
+            reader.mark_read(data.length());
+        }
     }
 
     void test_get_message_on_receive_v0_data(message_reader &reader,
                                              apache::thrift::protocol::TMessageType messageType,
-                                             bool is_request)
+                                             bool is_request,
+                                             int message_num)
     {
         /// write rpc message
         size_t body_length = 0;
@@ -72,50 +75,54 @@ public:
         ASSERT_EQ(stream.get_buffer().size(), body_length);
         memcpy(&data[48], stream.get_buffer().data(), stream.get_buffer().size());
 
-        mock_reader_read_data(reader, data);
-        msg = parser.get_message_on_receive(&reader, read_next);
+        mock_reader_read_data(reader, data, message_num);
 
-        if (is_request) {
-            ASSERT_NE(msg, nullptr);
-            ASSERT_EQ(msg->hdr_format, NET_HDR_THRIFT);
+        for (int i = 0; i < message_num; i++) {
+            msg = parser.get_message_on_receive(&reader, read_next);
 
-            ASSERT_EQ(msg->header->body_length, body_length);
-            ASSERT_EQ(msg->header->gpid, gpid(1, 28));
-            ASSERT_EQ(msg->header->hdr_type, THRIFT_HDR_SIG);
-            ASSERT_EQ(msg->header->hdr_length, sizeof(message_header));
-            ASSERT_EQ(msg->header->hdr_crc32, CRC_INVALID);
-            ASSERT_EQ(msg->header->body_crc32, CRC_INVALID);
-            ASSERT_EQ(msg->header->id, 999);
+            if (is_request) {
+                ASSERT_NE(msg, nullptr);
+                ASSERT_EQ(msg->hdr_format, NET_HDR_THRIFT);
 
-            ASSERT_EQ(msg->header->client.timeout_ms, 1000);
-            ASSERT_EQ(msg->header->client.thread_hash, 64);
-            ASSERT_EQ(msg->header->client.partition_hash, 5000000000);
+                ASSERT_EQ(msg->header->body_length, body_length);
+                ASSERT_EQ(msg->header->gpid, gpid(1, 28));
+                ASSERT_EQ(msg->header->hdr_type, THRIFT_HDR_SIG);
+                ASSERT_EQ(msg->header->hdr_length, sizeof(message_header));
+                ASSERT_EQ(msg->header->hdr_crc32, CRC_INVALID);
+                ASSERT_EQ(msg->header->body_crc32, CRC_INVALID);
+                ASSERT_EQ(msg->header->id, 999);
 
-            ASSERT_EQ(msg->header->context.u.is_request, true);
-            ASSERT_EQ(msg->header->context.u.serialize_format, DSF_THRIFT_BINARY);
+                ASSERT_EQ(msg->header->client.timeout_ms, 1000);
+                ASSERT_EQ(msg->header->client.thread_hash, 64);
+                ASSERT_EQ(msg->header->client.partition_hash, 5000000000);
 
-            // v0 Thrift network format doesn't support message context.
-            ASSERT_EQ(msg->header->context.u.is_backup_request, false);
-            ASSERT_EQ(msg->header->context.u.is_forwarded, false);
-            ASSERT_EQ(msg->header->context.u.is_forward_supported, false);
+                ASSERT_EQ(msg->header->context.u.is_request, true);
+                ASSERT_EQ(msg->header->context.u.serialize_format, DSF_THRIFT_BINARY);
 
-            ASSERT_EQ(reader.buffer().size(), 0);
+                // v0 Thrift network format doesn't support message context.
+                ASSERT_EQ(msg->header->context.u.is_backup_request, false);
+                ASSERT_EQ(msg->header->context.u.is_forwarded, false);
+                ASSERT_EQ(msg->header->context.u.is_forward_supported, false);
 
-            // must be reset
-            ASSERT_EQ(parser._header_version, -1);
-            ASSERT_EQ(parser._v1_specific_vars->_meta_parsed, false);
-            ASSERT_EQ(parser._v1_specific_vars->_meta_length, 0);
-            ASSERT_EQ(parser._v1_specific_vars->_body_length, 0);
-        } else {
-            ASSERT_EQ(msg, nullptr);
-            ASSERT_EQ(read_next, -1);
+                ASSERT_EQ(msg->buffers[1].size(), body_length);
+
+                // must be reset
+                ASSERT_EQ(parser._header_version, -1);
+                ASSERT_EQ(parser._v1_specific_vars->_meta_parsed, false);
+                ASSERT_EQ(parser._v1_specific_vars->_meta_length, 0);
+                ASSERT_EQ(parser._v1_specific_vars->_body_length, 0);
+            } else {
+                ASSERT_EQ(msg, nullptr);
+                ASSERT_EQ(read_next, -1);
+            }
         }
     }
 
     void test_get_message_on_receive_v1_data(message_reader &reader,
                                              apache::thrift::protocol::TMessageType messageType,
                                              bool is_request,
-                                             bool is_backup_request)
+                                             bool is_backup_request,
+                                             int message_num)
     {
         /// write rpc message
         size_t body_length = 0;
@@ -165,43 +172,43 @@ public:
         memcpy(&data[16 + meta_length],
                body_stream.get_buffer().data(),
                body_stream.get_buffer().size());
+        ASSERT_EQ(16 + meta_length + body_length, data.size());
+        mock_reader_read_data(reader, data, message_num);
+        ASSERT_EQ(reader.buffer().size(), data.size() * message_num);
 
-        mock_reader_read_data(reader, data);
-        ASSERT_EQ(reader.buffer().size(), data.size());
-        ASSERT_EQ(reader.buffer().size(), 16 + meta_length + body_length);
+        for (int i = 0; i != message_num; ++i) {
+            msg = parser.get_message_on_receive(&reader, read_next);
 
-        msg = parser.get_message_on_receive(&reader, read_next);
+            if (is_request) {
+                ASSERT_NE(msg, nullptr);
+                ASSERT_EQ(msg->hdr_format, NET_HDR_THRIFT);
 
-        if (is_request) {
-            ASSERT_NE(msg, nullptr);
-            ASSERT_EQ(msg->hdr_format, NET_HDR_THRIFT);
+                ASSERT_EQ(msg->header->body_length, body_length);
+                ASSERT_EQ(msg->header->gpid, gpid(1, 28));
+                ASSERT_EQ(msg->header->hdr_type, THRIFT_HDR_SIG);
+                ASSERT_EQ(msg->header->hdr_length, sizeof(message_header));
+                ASSERT_EQ(msg->header->hdr_crc32, CRC_INVALID);
+                ASSERT_EQ(msg->header->body_crc32, CRC_INVALID);
+                ASSERT_EQ(msg->header->id, 999);
 
-            ASSERT_EQ(msg->header->body_length, body_length);
-            ASSERT_EQ(msg->header->gpid, gpid(1, 28));
-            ASSERT_EQ(msg->header->hdr_type, THRIFT_HDR_SIG);
-            ASSERT_EQ(msg->header->hdr_length, sizeof(message_header));
-            ASSERT_EQ(msg->header->hdr_crc32, CRC_INVALID);
-            ASSERT_EQ(msg->header->body_crc32, CRC_INVALID);
-            ASSERT_EQ(msg->header->id, 999);
+                ASSERT_EQ(msg->header->client.timeout_ms, 1000);
+                ASSERT_EQ(msg->header->client.thread_hash, 7947);
+                ASSERT_EQ(msg->header->client.partition_hash, 5000000000);
 
-            ASSERT_EQ(msg->header->client.timeout_ms, 1000);
-            ASSERT_EQ(msg->header->client.thread_hash, 7947);
-            ASSERT_EQ(msg->header->client.partition_hash, 5000000000);
+                ASSERT_EQ(msg->header->context.u.is_request, true);
+                ASSERT_EQ(msg->header->context.u.serialize_format, DSF_THRIFT_BINARY);
+                ASSERT_EQ(msg->header->context.u.is_backup_request, is_backup_request);
+                ASSERT_EQ(msg->header->context.u.is_forwarded, false);
+                ASSERT_EQ(msg->header->context.u.is_forward_supported, false);
 
-            ASSERT_EQ(msg->header->context.u.is_request, true);
-            ASSERT_EQ(msg->header->context.u.serialize_format, DSF_THRIFT_BINARY);
-            ASSERT_EQ(msg->header->context.u.is_backup_request, is_backup_request);
-            ASSERT_EQ(msg->header->context.u.is_forwarded, false);
-            ASSERT_EQ(msg->header->context.u.is_forward_supported, false);
-
-            ASSERT_EQ(reader.buffer().size(), 0);
-
-            // must be reset
-            ASSERT_EQ(parser._header_version, -1);
-            ASSERT_EQ(parser._v1_specific_vars->_meta_parsed, false);
-        } else {
-            ASSERT_EQ(msg, nullptr);
-            ASSERT_EQ(read_next, -1);
+                // must be reset
+                ASSERT_EQ(parser._header_version, -1);
+                ASSERT_EQ(parser._v1_specific_vars->_meta_parsed, false);
+                ASSERT_EQ(msg->buffers[1].size(), body_length);
+            } else {
+                ASSERT_EQ(msg, nullptr);
+                ASSERT_EQ(read_next, -1);
+            }
         }
     }
 };
@@ -215,7 +222,7 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_incomplete_second_fiel
         int read_next = 0;
         message_reader reader(64);
         data = std::string("THFT") + std::string(i, ' ');
-        mock_reader_read_data(reader, data);
+        mock_reader_read_data(reader, data, 1);
         ASSERT_EQ(reader._buffer_occupied, 4 + i);
         ASSERT_EQ(reader.buffer().size(), 4 + i);
 
@@ -246,7 +253,7 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_incomplete_v0_hdr_len)
         out.write_u32(0);
         out.write_u32(48);
 
-        mock_reader_read_data(reader, data);
+        mock_reader_read_data(reader, data, 1);
         ASSERT_EQ(reader.buffer().size(), data.length());
 
         message_ex *msg = parser.get_message_on_receive(&reader, read_next);
@@ -272,7 +279,7 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_invalid_v0_hdr_length)
         // hdr_length = i
         out.write_u32(i);
 
-        mock_reader_read_data(reader, data);
+        mock_reader_read_data(reader, data, 1);
         message_ex *msg = parser.get_message_on_receive(&reader, read_next);
         ASSERT_EQ(msg, nullptr);
         ASSERT_EQ(read_next, -1);
@@ -299,7 +306,7 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_valid_v0_hdr)
     out.write_u32(64);         // client_thread_hash
     out.write_u64(5000000000); // client_partition_hash
 
-    mock_reader_read_data(reader, data);
+    mock_reader_read_data(reader, data, 1);
 
     message_ex *msg = parser.get_message_on_receive(&reader, read_next);
     ASSERT_EQ(msg, nullptr);
@@ -321,9 +328,9 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_valid_v0_data)
     message_reader reader(64);
 
     ASSERT_NO_FATAL_FAILURE(
-        test_get_message_on_receive_v0_data(reader, apache::thrift::protocol::T_CALL, true));
+        test_get_message_on_receive_v0_data(reader, apache::thrift::protocol::T_CALL, true, 1));
     ASSERT_NO_FATAL_FAILURE(
-        test_get_message_on_receive_v0_data(reader, apache::thrift::protocol::T_ONEWAY, true));
+        test_get_message_on_receive_v0_data(reader, apache::thrift::protocol::T_ONEWAY, true, 1));
 }
 
 TEST_F(thrift_message_parser_test, get_message_on_receive_v0_not_request)
@@ -332,10 +339,10 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_v0_not_request)
 
     // ensure server won't corrupt when it receives a non-request.
     ASSERT_NO_FATAL_FAILURE(
-        test_get_message_on_receive_v0_data(reader, apache::thrift::protocol::T_REPLY, false));
+        test_get_message_on_receive_v0_data(reader, apache::thrift::protocol::T_REPLY, false, 1));
     reader.truncate_read();
     ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v0_data(
-        reader, apache::thrift::protocol::TMessageType(65), false));
+        reader, apache::thrift::protocol::TMessageType(65), false, 1));
     reader.truncate_read();
 }
 
@@ -352,7 +359,7 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_incomplete_v1_hdr)
         data_output out(&data[4], 8);
         out.write_u32(1);
 
-        mock_reader_read_data(reader, data);
+        mock_reader_read_data(reader, data, 1);
         ASSERT_EQ(reader.buffer().size(), data.length());
 
         message_ex *msg = parser.get_message_on_receive(&reader, read_next);
@@ -376,7 +383,7 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_valid_v1_hdr)
     out.write_u32(100); // meta_length
     out.write_u32(200); // body_length
 
-    mock_reader_read_data(reader, data);
+    mock_reader_read_data(reader, data, 1);
     ASSERT_EQ(reader.buffer().size(), 16);
 
     message_ex *msg = parser.get_message_on_receive(&reader, read_next);
@@ -392,18 +399,32 @@ TEST_F(thrift_message_parser_test, get_message_on_receive_valid_v1_hdr)
 TEST_F(thrift_message_parser_test, get_message_on_receive_v1_data)
 {
     message_reader reader(64);
-    ASSERT_NO_FATAL_FAILURE(
-        test_get_message_on_receive_v1_data(reader, apache::thrift::protocol::T_CALL, true, true));
-    ASSERT_NO_FATAL_FAILURE(
-        test_get_message_on_receive_v1_data(reader, apache::thrift::protocol::T_CALL, true, false));
     ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
-        reader, apache::thrift::protocol::T_ONEWAY, true, true));
+        reader, apache::thrift::protocol::T_CALL, true, true, 1));
     ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
-        reader, apache::thrift::protocol::T_ONEWAY, true, false));
+        reader, apache::thrift::protocol::T_CALL, true, false, 1));
+    ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
+        reader, apache::thrift::protocol::T_ONEWAY, true, true, 1));
+    ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
+        reader, apache::thrift::protocol::T_ONEWAY, true, false, 1));
 
     ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
-        reader, apache::thrift::protocol::TMessageType(65), false, false));
+        reader, apache::thrift::protocol::TMessageType(65), false, false, 1));
     reader.truncate_read();
+}
+
+TEST_F(thrift_message_parser_test, get_message_on_large_writes_pileup_v0)
+{
+    message_reader reader(4096);
+    ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
+        reader, apache::thrift::protocol::T_CALL, true, false, 10));
+}
+
+TEST_F(thrift_message_parser_test, get_message_on_large_writes_pileup_v1)
+{
+    message_reader reader(4096);
+    ASSERT_NO_FATAL_FAILURE(test_get_message_on_receive_v1_data(
+        reader, apache::thrift::protocol::T_CALL, true, true, 10));
 }
 
 } // namespace dsn


### PR DESCRIPTION
## Issue
see https://github.com/apache/incubator-pegasus/issues/866

## Description

We have noticed pegasus 2.0 are using much more network/disk bandwidths than pegasus 1.12.3. After weeks of debugging, we have finally found that this is a bug introduced in #255, when a new thrift message parser that compatible with both old format and new format is refactored to replace the old one. Now we are trying to fix this.

The main cause is that when parsing the message body, instead of return exactly size of the body, it actually return the whole buffer that holds all the received messages. Thus, when there are many write requests piled up, from the moment the write request arrives,  to the moment it writes to mutation logs and to other nodes, the throughput is significantly amplified.

To fix that we merely add one line to set the message body size before calling create_message_from_request_blob().

We also noticed that when a message header is found invalid, the bad message will not be consumed and discarded, instead it stays in the buffer forever. We think it is a bug. To fix this bug, we consume the buffer before calling create_message_from_request_blob().
