### PR TITLE
fix: make is_bulk_loading filed optional in query_bulk_load_response

### DIFF
--- a/src/common/bulk_load.thrift
+++ b/src/common/bulk_load.thrift
@@ -213,5 +213,5 @@ struct query_bulk_load_response
     // detailed bulk load state for each replica
     6:list<map<dsn.rpc_address, partition_bulk_load_state>> bulk_load_states;
     7:optional string                                       hint_msg;
-    8:bool                                                  is_bulk_loading;
+    8:optional bool                                         is_bulk_loading;
 }

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1505,7 +1505,7 @@ void bulk_load_service::on_query_bulk_load_status(query_bulk_load_rpc rpc)
         }
     }
 
-    response.is_bulk_loading = app->is_bulk_loading;
+    response.__set_is_bulk_loading(app->is_bulk_loading);
 
     if (!app->is_bulk_loading && bulk_load_status::BLS_FAILED == response.app_status) {
         response.err = get_app_bulk_load_err_unlocked(app_id);


### PR DESCRIPTION
#986 adds `is_bulk_loading` filed in `query_bulk_load_response` to support manager function(https://github.com/apache/incubator-pegasus/issues/856).

To make related tools (pegasus-spark) compatible, this pull request updates it as optional and other corresponding modification.