### PR TITLE
fix(bulk_load): update ingestion error handling with move_files mode

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -106,7 +106,7 @@ public:
     // Whether this replica is duplicating.
     bool is_duplicating() const;
 
-    ballot get_ballot() const;
+    const ballot &get_ballot() const;
 
     //
     // Open the app.

--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -106,6 +106,8 @@ public:
     // Whether this replica is duplicating.
     bool is_duplicating() const;
 
+    ballot get_ballot() const;
+
     //
     // Open the app.
     //

--- a/src/common/bulk_load.thrift
+++ b/src/common/bulk_load.thrift
@@ -152,6 +152,7 @@ struct ingestion_request
     1:string                app_name;
     2:bulk_load_metadata    metadata;
     3:bool                  ingest_behind;
+    4:i64                   ballot;
 }
 
 struct ingestion_response

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1094,7 +1094,13 @@ void bulk_load_service::update_app_status_on_remote_storage_reply(const app_bulk
 
     if (new_status == bulk_load_status::BLS_INGESTING) {
         for (int i = 0; i < partition_count; ++i) {
-            partition_ingestion(ainfo.app_name, gpid(app_id, i));
+            tasking::enqueue(
+                LPC_META_STATE_NORMAL,
+                _meta_svc->tracker(),
+                std::bind(
+                    &bulk_load_service::partition_ingestion, this, ainfo.app_name, gpid(app_id, i)),
+                0,
+                std::chrono::seconds(bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL));
         }
     }
 

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -188,7 +188,8 @@ private:
 
     void send_ingestion_request(const std::string &app_name,
                                 const gpid &pid,
-                                const rpc_address &primary_addr);
+                                const rpc_address &primary_addr,
+                                const ballot &meta_ballot);
 
     void on_partition_ingestion_reply(error_code err,
                                       const ingestion_response &&resp,

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -171,7 +171,7 @@ public:
     //
     //  local information query
     //
-    ballot get_ballot() const { return _config.ballot; }
+    const ballot &get_ballot() const { return _config.ballot; }
     partition_status::type status() const { return _config.status; }
     replication_app_base *get_app() { return _app.get(); }
     const app_info *get_app_info() const { return &_app_info; }

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -335,7 +335,7 @@ bool replication_app_base::is_primary() const
 
 bool replication_app_base::is_duplicating() const { return _replica->is_duplicating(); }
 
-ballot replication_app_base::get_ballot() const { return _replica->get_ballot(); }
+const ballot &replication_app_base::get_ballot() const { return _replica->get_ballot(); }
 
 error_code replication_app_base::open_internal(replica *r)
 {

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -335,6 +335,8 @@ bool replication_app_base::is_primary() const
 
 bool replication_app_base::is_duplicating() const { return _replica->is_duplicating(); }
 
+ballot replication_app_base::get_ballot() const { return _replica->get_ballot(); }
+
 error_code replication_app_base::open_internal(replica *r)
 {
     if (!dsn::utils::filesystem::directory_exists(_dir_data)) {


### PR DESCRIPTION
As https://github.com/apache/incubator-pegasus/issues/877 shows, move files during ingestion will speech up ingestion and decrease disk write throughput. (https://github.com/apache/incubator-pegasus/pull/864)

However, it exposes that in some error handling cases, it is possible to execute an out-dated ingestion request repeated. 

In previous `copy_files` mode, it won't have problems, just ingest files repeatly, now is `move_files` mode, once ingestion is succeed, the original files doesn't exist, which will lead to unexpected ingestion failed.

This pull request is to update error handling during ingestion, including:
- Delay to send ingestion_request to make replica server receive request with ingestion status
- Add ballot in `ingestion_request` (It will be used in pegasus repo to do ballot check)