### PR TITLE
fix(network): use multi io_services in asio

### DIFF
--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -44,9 +44,9 @@ const int threads_per_event_loop = 1;
 asio_network_provider::asio_network_provider(rpc_engine *srv, network *inner_provider)
     : connection_oriented_network(srv, inner_provider), _acceptor(nullptr)
 {
-    // Using thread-local operation queues in single-threaded use cases (i.e. when
-    // concurrency_hint is 1) to eliminate a lock/unlock pair.
     for (auto i = 0; i < FLAGS_io_service_worker_count; i++) {
+        // Using thread-local operation queues in single-threaded use cases (i.e. when
+        // concurrency_hint is 1) to eliminate a lock/unlock pair.
         _io_services.emplace_back(
             std::make_unique<boost::asio::io_service>(threads_per_event_loop));
     }

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -45,6 +45,8 @@ asio_network_provider::asio_network_provider(rpc_engine *srv, network *inner_pro
     _acceptor = nullptr;
 
     for (auto i = 0; i < FLAGS_io_service_worker_count; i++) {
+        // Using thread-local operation queues in single-threaded use cases (i.e. when
+        // concurrency_hint is 1) to eliminate a lock/unlock pair.
         io_service_ptr io_service(new boost::asio::io_service(1));
         _io_services.push_back(io_service);
     }

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -401,5 +401,21 @@ error_code asio_udp_provider::start(rpc_channel channel, int port, bool client_o
 
     return ERR_OK;
 }
+
+boost::asio::io_context &asio_network_provider::get_io_context()
+{
+    // Use a round-robin scheme to choose the next io_context to use.
+    int tmp = _next_io_context;
+    if (tmp >= _service_count) {
+        tmp = 0;
+    }
+    boost::asio::io_context &io_context = *_io_services[tmp];
+    ++_next_io_context;
+    if (_next_io_context >= _service_count) {
+        _next_io_context = 0;
+    }
+    return io_context;
+}
+
 } // namespace tools
 } // namespace dsn

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -410,22 +410,24 @@ boost::asio::io_service &asio_network_provider::get_io_service()
 {
     // use a round-robin scheme to choose the next io_service to use.
 
-    // Q: Why not return *_io_services[tmp++ % FLAGS_io_service_worker_count]?
-    // A: % operation is slow
+    ++_next_io_service;
+    if (_next_io_service >= FLAGS_io_service_worker_count) {
+        _next_io_service = 0;
+    }
+
     int tmp = _next_io_service;
     if (tmp >= FLAGS_io_service_worker_count) {
         tmp = 0;
     }
 
-    // Q: why not return *_io_services[_next_io_service]
-    // A: this function may be executed by multi threads, so it should get snapshot of
+    // Q1: why not return *_io_services[_next_io_service]
+    // A1: this function may be executed by multi threads, so it should get snapshot of
     // `_next_io_service`. Otherwise, after other threads change the value of `_next_io_service`,
     // `_io_services` may take `out_of_range` exception.
+    //
+    // Q2: Why not return *_io_services[tmp++ % FLAGS_io_service_worker_count]?
+    // A2: % operation is slow
     boost::asio::io_service &io_service = *_io_services[tmp];
-    ++_next_io_service;
-    if (_next_io_service >= FLAGS_io_service_worker_count) {
-        _next_io_service = 0;
-    }
     return io_service;
 }
 

--- a/src/runtime/rpc/asio_net_provider.h
+++ b/src/runtime/rpc/asio_net_provider.h
@@ -45,16 +45,16 @@ public:
 
 private:
     void do_accept();
-    boost::asio::io_context &get_io_context();
+    boost::asio::io_service &get_io_service();
 
 private:
     friend class asio_rpc_session;
     friend class asio_network_provider_test;
 
     std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
-    int _next_io_context = 0;
-    typedef std::shared_ptr<boost::asio::io_context> io_context_ptr;
-    std::vector<io_context_ptr> _io_services;
+    int _next_io_service = 0;
+    typedef std::shared_ptr<boost::asio::io_service> io_service_ptr;
+    std::vector<io_service_ptr> _io_services;
     std::vector<std::shared_ptr<std::thread>> _workers;
     ::dsn::rpc_address _address;
 };

--- a/src/runtime/rpc/asio_net_provider.h
+++ b/src/runtime/rpc/asio_net_provider.h
@@ -75,8 +75,8 @@ private:
     friend class asio_network_provider_test;
 
     std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
-    int _next_io_service = 0;
-    std::vector<boost::asio::io_service *> _io_services;
+    std::atomic<int> _next_io_service;
+    std::vector<std::unique_ptr<boost::asio::io_service>> _io_services;
     std::vector<std::shared_ptr<std::thread>> _workers;
     ::dsn::rpc_address _address;
 };

--- a/src/runtime/rpc/asio_net_provider.h
+++ b/src/runtime/rpc/asio_net_provider.h
@@ -45,28 +45,14 @@ public:
 
 private:
     void do_accept();
-
-    boost::asio::io_context &get_io_context()
-    {
-        // Use a round-robin scheme to choose the next io_context to use.
-        int tmp = next_io_context_;
-        if (tmp >= _service_count) {
-            tmp = 0;
-        }
-        boost::asio::io_context &io_context = *_io_services[tmp];
-        ++next_io_context_;
-        if (next_io_context_ >= _service_count) {
-            next_io_context_ = 0;
-        }
-        return io_context;
-    }
+    boost::asio::io_context &get_io_context();
 
 private:
     friend class asio_rpc_session;
     friend class asio_network_provider_test;
 
     std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
-    int next_io_context_ = 0;
+    int _next_io_context = 0;
     int _service_count;
     typedef std::shared_ptr<boost::asio::io_context> io_context_ptr;
     std::vector<io_context_ptr> _io_services;

--- a/src/runtime/rpc/asio_net_provider.h
+++ b/src/runtime/rpc/asio_net_provider.h
@@ -53,7 +53,6 @@ private:
 
     std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
     int _next_io_context = 0;
-    int _service_count;
     typedef std::shared_ptr<boost::asio::io_context> io_context_ptr;
     std::vector<io_context_ptr> _io_services;
     std::vector<std::shared_ptr<std::thread>> _workers;

--- a/src/runtime/rpc/asio_net_provider.h
+++ b/src/runtime/rpc/asio_net_provider.h
@@ -75,7 +75,6 @@ private:
     friend class asio_network_provider_test;
 
     std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
-    std::atomic<int> _next_io_service;
     std::vector<std::unique_ptr<boost::asio::io_service>> _io_services;
     std::vector<std::shared_ptr<std::thread>> _workers;
     ::dsn::rpc_address _address;

--- a/src/runtime/rpc/asio_rpc_session.cpp
+++ b/src/runtime/rpc/asio_rpc_session.cpp
@@ -31,7 +31,6 @@ namespace tools {
 
 void asio_rpc_session::set_options()
 {
-    utils::auto_write_lock socket_guard(_socket_lock);
 
     if (_socket->is_open()) {
         boost::system::error_code ec;
@@ -83,7 +82,6 @@ void asio_rpc_session::do_read(int read_next)
     void *ptr = _reader.read_buffer_ptr(read_next);
     int remaining = _reader.read_buffer_capacity();
 
-    utils::auto_read_lock socket_guard(_socket_lock);
 
     _socket->async_read_some(
         boost::asio::buffer(ptr, remaining),
@@ -141,8 +139,7 @@ void asio_rpc_session::send(uint64_t signature)
     }
 
     add_ref();
-
-    utils::auto_read_lock socket_guard(_socket_lock);
+    
     boost::asio::async_write(
         *_socket, asio_wbufs, [this, signature](boost::system::error_code ec, std::size_t length) {
             if (ec) {
@@ -169,7 +166,6 @@ asio_rpc_session::asio_rpc_session(asio_network_provider &net,
 
 void asio_rpc_session::close()
 {
-    utils::auto_write_lock socket_guard(_socket_lock);
 
     boost::system::error_code ec;
     _socket->shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);

--- a/src/runtime/rpc/asio_rpc_session.cpp
+++ b/src/runtime/rpc/asio_rpc_session.cpp
@@ -82,7 +82,6 @@ void asio_rpc_session::do_read(int read_next)
     void *ptr = _reader.read_buffer_ptr(read_next);
     int remaining = _reader.read_buffer_capacity();
 
-
     _socket->async_read_some(
         boost::asio::buffer(ptr, remaining),
         [this](boost::system::error_code ec, std::size_t length) {
@@ -139,7 +138,7 @@ void asio_rpc_session::send(uint64_t signature)
     }
 
     add_ref();
-    
+
     boost::asio::async_write(
         *_socket, asio_wbufs, [this, signature](boost::system::error_code ec, std::size_t length) {
             if (ec) {

--- a/src/runtime/rpc/asio_rpc_session.h
+++ b/src/runtime/rpc/asio_rpc_session.h
@@ -68,7 +68,6 @@ private:
     // boost::asio::socket is thread-unsafe, must use lock to prevent a
     // reading/writing socket being modified or closed concurrently.
     std::shared_ptr<boost::asio::ip::tcp::socket> _socket;
-    ::dsn::utils::rw_lock_nr _socket_lock;
 };
 
 } // namespace tools


### PR DESCRIPTION
## Background
related issue: https://github.com/apache/incubator-pegasus/issues/307
This issue reported a bug that the core dump will happen in some scenes. It's caused by the race condition when multi-threads read/write/close the same socket. 

## how to fix this bug
**Original way**
```
Epoll
+-------------------------------+
| socket1  socket2  socket3     |
|  +--+     +--+     +--+       |
|  +--+     +--+     +--+       |
|                               |
+------------^------------------+
             |
io_service   |polling
+------------+------------------+
| task_queue                    |
| +-----------+--------------+  |
| | epollwait | call_back    |  |
| +-----+-----+--+--------+--+  |
|       |        |        |     |
+-------+--------+--------+-----+
Thread1 |  2     |     3  |
      +-v-+    +-v-+    +-v-+
      |   |    |   |    |   |
      +---+    +---+    +---+

```
In the past, we used multi-threads to execute polling or callback in one event loop. But like the coredump information showed, the `Use-After-Free`  may happen in the high-traffic scene. It's hard for us to add mutex to prevent this problem, so I change the way we use ASIO in this PR.

**New way**
```
+-----------------------------------------------+
|Linux kernel                                   |
| +-----------+   +-----------+   +-----------+ |
| |   Epoll1  |   |   Epoll2  |   |   Epoll3  | |
| +-----^-----+   +-----^-----+   +-----^-----+ |
+-------|---------------|---------------|-------+
  +-----------+   +-----------+   +-----------+
  |  polling  |   |  polling  |   |  polling  |
  | +-------+ |   | +-------+ |   | +-------+ |
  | |Thread1| |   | |Thread2| |   | |Thread3| |
  | +-------+ |   | +-------+ |   | +-------+ |
  |io_service1|   |io_service2|   |io_service3|
  +-----------+   +-----------+   +-----------+
```
 I use one loop per thread model in the network service, the operations of one socket are executed in the single thread. So we won't worry about race conditions anymore.

## Benchmark
Original benchmark
```
+--------------------------+----------+------------+--------+------------+--------------+----------------------------------------------+-----------------------------------------------+
|      operation_case      | run_time | throughput | length | read_write | thread_count |     read(qps|ave|min|max|95|99|999|9999)     |     write(qps|ave|min|max|95|99|999|9999)     |
+--------------------------+----------+------------+--------+------------+--------------+----------------------------------------------+-----------------------------------------------+
| write=single,read=single | 8284     | 36210      | 1000   | 0 : 1      | 15           | {0 0 0 0 0 0 0 0}                            | {36212 1240 365 236287 2386 5349 12119 18929} |
| write=single,read=single | 3124     | 289183     | 1000   | 1 : 0      | 50           | {289233 518 116 163924 853 1500 15120 21369} | {0 0 0 0 0 0 0 0}                             |
| write=single,read=single | 3151     | 76148      | 1000   | 1 : 1      | 30           | {38078 712 116 179583 1892 8137 38959 51305} | {38075 1643 368 322815 3995 6908 18257 32436} |
| write=single,read=single | 3317     | 45208      | 1000   | 1 : 3      | 15           | {11306 568 121 148287 1191 5044 31439 39956} | {33909 1133 378 253524 1992 4940 16777 27567} |
| write=single,read=single | 2348     | 38309      | 1000   | 1 : 30     | 15           | {1234 588 148 99583 1204 4399 29561 38324}   | {37083 1190 374 242303 2189 5061 12209 22660} |
| write=single,read=single | 2498     | 120131     | 1000   | 3 : 1      | 30           | {90117 535 115 149247 1083 4484 29825 45375} | {30040 1379 375 303273 2717 5896 30233 50068} |
| write=single,read=single | 3393     | 267123     | 1000   | 30 : 1     | 50           | {258529 543 113 177535 957 2168 16620 25764} | {8615 1121 418 266537 1585 4980 23660 48585}  |
+--------------------------+----------+------------+--------+------------+--------------+----------------------------------------------+-----------------------------------------------+
```
After change
```
+--------------------------+----------+------------+--------+------------+--------------+-----------------------------------------------+-----------------------------------------------+
|      operation_case      | run_time | throughput | length | read_write | thread_count |     read(qps|ave|min|max|95|99|999|9999)      |     write(qps|ave|min|max|95|99|999|9999)     |
+--------------------------+----------+------------+--------+------------+--------------+-----------------------------------------------+-----------------------------------------------+
| write=single,read=single | 8000     | 37495      | 1000   | 0 : 1      | 15           | {0 0 0 0 0 0 0 0}                             | {37497 1197 359 210644 2199 5193 16247 23100} |
| write=single,read=single | 3076     | 293209     | 1000   | 1 : 0      | 50           | {293270 510 112 176489 848 1346 16665 24001}  | {0 0 0 0 0 0 0 0}                             |
| write=single,read=single | 3056     | 78516      | 1000   | 1 : 1      | 30           | {39266 720 118 170367 1954 8243 38601 51241}  | {39262 1564 353 253609 3555 6564 17687 34548} |
| write=single,read=single | 3213     | 46676      | 1000   | 1 : 3      | 15           | {11671 561 121 157055 1211 5136 30281 38335}  | {35013 1093 357 215679 1844 4887 11745 22825} |
| write=single,read=single | 2292     | 39252      | 1000   | 1 : 30     | 15           | {1266 600 150 119081 1258 4555 29892 38025}   | {37994 1161 367 242260 2003 4985 10463 19873} |
| write=single,read=single | 2422     | 123899     | 1000   | 3 : 1      | 30           | {92937 527 114 127593 1072 4433 23495 37716}  | {30979 1310 364 227199 2375 5739 17865 35332} |
| write=single,read=single | 3808     | 241281     | 1000   | 30 : 1     | 50           | {233521 613 110 186708 1264 2553 16615 24703} | {7784 1148 400 244820 1914 5060 24692 47156}  |
+--------------------------+----------+------------+--------+------------+--------------+-----------------------------------------------+-----------------------------------------------+
```
**The change has no significant performance impact**

## Actual performance
This change has fixed the bug in our production environment.
