### PR TITLE
fix: use fsync() to prevent .app-info/.init-info lost risk on XFS after power outage

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -63,8 +63,8 @@ public:
     std::string to_string();
 
 private:
-    error_code load_json(const char *file);
-    error_code store_json(const char *file);
+    error_code load_json(const std::string &file);
+    error_code store_json(const std::string &file);
 };
 
 class replica_app_info
@@ -74,8 +74,8 @@ private:
 
 public:
     replica_app_info(app_info *app) { _app = app; }
-    error_code load(const char *file);
-    error_code store(const char *file);
+    error_code load(const std::string &file);
+    error_code store(const std::string &file);
 };
 
 /// The store engine interface of Pegasus.

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -563,7 +563,7 @@ error_code replica::store_app_info(app_info &info, const std::string &path)
 {
     replica_app_info new_info((app_info *)&info);
     const auto &info_path = path.empty() ? utils::filesystem::path_combine(_dir, kAppInfo) : path;
-    auto err = new_info.store(info_path.c_str());
+    auto err = new_info.store(info_path);
     if (dsn_unlikely(err != ERR_OK)) {
         derror_replica("failed to save app_info to {}, error = {}", info_path, err);
     }

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -147,7 +147,7 @@ error_code replica::initialize_on_load()
     dsn::app_info info;
     replica_app_info info2(&info);
     std::string path = utils::filesystem::path_combine(dir, kAppInfo);
-    auto err = info2.load(path.c_str());
+    auto err = info2.load(path);
     if (ERR_OK != err) {
         derror("load app-info from %s failed, err = %s", path.c_str(), err.to_string());
         return nullptr;

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -30,6 +30,7 @@
 #include <dsn/utils/latency_tracer.h>
 #include <dsn/dist/fmt_logging.h>
 #include <dsn/dist/replication/replication_app_base.h>
+#include <dsn/utility/defer.h>
 #include <dsn/utility/factory_store.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/crc.h>
@@ -53,6 +54,7 @@ error_code write_blob_to_file(const std::string &file, const blob &data)
     std::string tmp_file = file + ".tmp";
     disk_file *hfile = file::open(tmp_file.c_str(), O_WRONLY | O_CREAT | O_BINARY | O_TRUNC, 0666);
     ERR_LOG_AND_RETURN_NOT_TRUE(hfile, ERR_FILE_OPERATION_FAILED, "open file {} failed", tmp_file);
+    auto cleanup = defer([tmp_file]() { utils::filesystem::remove_path(tmp_file); });
 
     error_code err;
     size_t sz = 0;

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -90,7 +90,7 @@ error_code replica_init_info::load(const std::string &dir)
     std::string info_path = utils::filesystem::path_combine(dir, kInitInfo);
     dassert_f(utils::filesystem::path_exists(info_path), "file({}) not exist", info_path);
     ERR_LOG_AND_RETURN_NOT_OK(
-        load_json(info_path.c_str()), "load replica_init_info from {} failed", info_path);
+        load_json(info_path), "load replica_init_info from {} failed", info_path);
     ddebug_f("load replica_init_info from {} succeed: {}", info_path, to_string());
     return ERR_OK;
 }
@@ -99,7 +99,7 @@ error_code replica_init_info::store(const std::string &dir)
 {
     uint64_t start = dsn_now_ns();
     std::string info_path = utils::filesystem::path_combine(dir, kInitInfo);
-    ERR_LOG_AND_RETURN_NOT_OK(store_json(info_path.c_str()),
+    ERR_LOG_AND_RETURN_NOT_OK(store_json(info_path),
                               "store replica_init_info to {} failed, time_used_ns = {}",
                               info_path,
                               dsn_now_ns() - start);
@@ -110,7 +110,7 @@ error_code replica_init_info::store(const std::string &dir)
     return ERR_OK;
 }
 
-error_code replica_init_info::load_json(const char *file)
+error_code replica_init_info::load_json(const std::string &file)
 {
     std::ifstream is(file, std::ios::binary);
     ERR_LOG_AND_RETURN_NOT_TRUE(
@@ -136,7 +136,7 @@ error_code replica_init_info::load_json(const char *file)
     return ERR_OK;
 }
 
-error_code replica_init_info::store_json(const char *file)
+error_code replica_init_info::store_json(const std::string &file)
 {
     return write_blob_to_file(file, json::json_forwarder<replica_init_info>::encode(*this));
 }
@@ -151,7 +151,7 @@ std::string replica_init_info::to_string()
     return oss.str();
 }
 
-error_code replica_app_info::load(const char *file)
+error_code replica_app_info::load(const std::string &file)
 {
     std::ifstream is(file, std::ios::binary);
     ERR_LOG_AND_RETURN_NOT_TRUE(
@@ -178,7 +178,7 @@ error_code replica_app_info::load(const char *file)
     return ERR_OK;
 }
 
-error_code replica_app_info::store(const char *file)
+error_code replica_app_info::store(const std::string &file)
 {
     binary_writer writer;
     int magic = 0xdeadbeef;


### PR DESCRIPTION
ref issue:
https://github.com/apache/incubator-pegasus/issues/879