### PR TITLE
fix: change the ticket-check-action  default title format

### DIFF
--- a/.github/workflows/issue_ref.yaml
+++ b/.github/workflows/issue_ref.yaml
@@ -34,4 +34,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketPrefix: '#'
+          titleFormat: %title%
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'

--- a/.github/workflows/issue_ref.yaml
+++ b/.github/workflows/issue_ref.yaml
@@ -34,5 +34,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketPrefix: '#'
-          titleFormat: %title%
+          titleFormat: '%title%'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/869 support `issue`ref check, but the bot will force change the title to default format like this: `#859: feat: remove shared log`, the reason is the default format config is: `%prefix%%id%: %title%`

This pr change it to `%title%`