### PR TITLE
fix: break when disable latency tracer in macro

### DIFF
--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -46,6 +46,7 @@ namespace utils {
                 (ts));                                                                             \
     } while (0)
 
+
 /**
  * latency_tracer is a tool for tracking the time spent in each of the stages during request
  * execution. It can help users to figure out where the latency bottleneck is located. User needs to

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -27,20 +27,20 @@ namespace utils {
 
 #define ADD_POINT(tracer)                                                                          \
     do {                                                                                           \
-        if ((tracer) && (tracer)->enable_trace())                                               \
+        if ((tracer) && (tracer)->enable_trace())                                                  \
             (tracer)->add_point(fmt::format("{}:{}:{}", __FILENAME__, __LINE__, __FUNCTION__));    \
     } while (0)
 
 #define ADD_CUSTOM_POINT(tracer, message)                                                          \
     do {                                                                                           \
-        if ((tracer) && (tracer)->enable_trace())                                               \
+        if ((tracer) && (tracer)->enable_trace())                                                  \
             (tracer)->add_point(                                                                   \
                 fmt::format("{}:{}:{}_{}", __FILENAME__, __LINE__, __FUNCTION__, (message)));      \
     } while (0)
 
 #define APPEND_EXTERN_POINT(tracer, ts, message)                                                   \
     do {                                                                                           \
-        if ((tracer) && (tracer)->enable_trace())                                               \
+        if ((tracer) && (tracer)->enable_trace())                                                  \
             (tracer)->append_point(                                                                \
                 fmt::format("{}:{}:{}_{}", __FILENAME__, __LINE__, __FUNCTION__, (message)),       \
                 (ts));                                                                             \

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -46,7 +46,6 @@ namespace utils {
                 (ts));                                                                             \
     } while (0)
 
-
 /**
  * latency_tracer is a tool for tracking the time spent in each of the stages during request
  * execution. It can help users to figure out where the latency bottleneck is located. User needs to

--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -27,20 +27,20 @@ namespace utils {
 
 #define ADD_POINT(tracer)                                                                          \
     do {                                                                                           \
-        if ((tracer))                                                                              \
+        if ((tracer) && (tracer)->enable_trace())                                               \
             (tracer)->add_point(fmt::format("{}:{}:{}", __FILENAME__, __LINE__, __FUNCTION__));    \
     } while (0)
 
 #define ADD_CUSTOM_POINT(tracer, message)                                                          \
     do {                                                                                           \
-        if ((tracer))                                                                              \
+        if ((tracer) && (tracer)->enable_trace())                                               \
             (tracer)->add_point(                                                                   \
                 fmt::format("{}:{}:{}_{}", __FILENAME__, __LINE__, __FUNCTION__, (message)));      \
     } while (0)
 
 #define APPEND_EXTERN_POINT(tracer, ts, message)                                                   \
     do {                                                                                           \
-        if ((tracer))                                                                              \
+        if ((tracer) && (tracer)->enable_trace())                                               \
             (tracer)->append_point(                                                                \
                 fmt::format("{}:{}:{}_{}", __FILENAME__, __LINE__, __FUNCTION__, (message)),       \
                 (ts));                                                                             \
@@ -153,6 +153,8 @@ public:
     uint64_t start_time() const { return _start_time; }
 
     uint64_t last_time() const { return _last_time; }
+
+    bool enable_trace() const { return _enable_trace; }
 
     const std::string &last_stage_name() const { return _last_stage; }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/883

macro with latency tracer should break when disable. 