### PR TITLE
fix: remove unused judgement of FLAGS_enable_latency_tracer in private log

### DIFF
--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -223,9 +223,7 @@ mutation_log_private::mutation_log_private(const std::string &dir,
 
     _plock.lock();
 
-    if (dsn_unlikely(utils::FLAGS_enable_latency_tracer)) {
-        ADD_POINT(mu->_tracer);
-    }
+    ADD_POINT(mu->_tracer);
 
     // init pending buffer
     if (nullptr == _pending_write) {


### PR DESCRIPTION
I will add dsn_unlikely in ADD_POINT in later pull request