### PR TITLE
feat: add dsn_unlikely in macro ADD_POINT

### DIFF
--- a/include/dsn/utils/latency_tracer.h
+++ b/include/dsn/utils/latency_tracer.h
@@ -27,20 +27,20 @@ namespace utils {
 
 #define ADD_POINT(tracer)                                                                          \
     do {                                                                                           \
-        if (tracer != nullptr && (tracer)->enabled())                                              \
+        if (dsn_unlikely(tracer != nullptr && (tracer)->enabled()))                                \
             (tracer)->add_point(fmt::format("{}:{}:{}", __FILENAME__, __LINE__, __FUNCTION__));    \
     } while (0)
 
 #define ADD_CUSTOM_POINT(tracer, message)                                                          \
     do {                                                                                           \
-        if (tracer != nullptr && (tracer)->enabled())                                              \
+        if (dsn_unlikely(tracer != nullptr && (tracer)->enabled()))                                \
             (tracer)->add_point(                                                                   \
                 fmt::format("{}:{}:{}_{}", __FILENAME__, __LINE__, __FUNCTION__, (message)));      \
     } while (0)
 
 #define APPEND_EXTERN_POINT(tracer, ts, message)                                                   \
     do {                                                                                           \
-        if (tracer != nullptr && (tracer)->enabled())                                              \
+        if (dsn_unlikely(tracer != nullptr && (tracer)->enabled()))                                \
             (tracer)->append_point(                                                                \
                 fmt::format("{}:{}:{}_{}", __FILENAME__, __LINE__, __FUNCTION__, (message)),       \
                 (ts));                                                                             \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/883

To improve execution efficiency, add dsn_unlikely in macro ADD_POINT. Because in most situations, we don't need to add tracer point.