### PR TITLE
refactor: change the type of prepare_list from raw pointer to std::unique_ptr

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -167,11 +167,11 @@ void replica::init_state()
     _inactive_is_transient = false;
     _is_initializing = false;
     _deny_client_write = false;
-    _prepare_list =
-        new prepare_list(this,
-                         0,
-                         _options->max_mutation_count_in_prepare_list,
-                         std::bind(&replica::execute_mutation, this, std::placeholders::_1));
+    _prepare_list = dsn::make_unique<prepare_list>(
+        this,
+        0,
+        _options->max_mutation_count_in_prepare_list,
+        std::bind(&replica::execute_mutation, this, std::placeholders::_1));
 
     _config.ballot = 0;
     _config.pid.set_app_id(0);
@@ -189,12 +189,7 @@ void replica::init_state()
 replica::~replica(void)
 {
     close();
-
-    if (nullptr != _prepare_list) {
-        delete _prepare_list;
-        _prepare_list = nullptr;
-    }
-
+    _prepare_list = nullptr;
     dinfo("%s: replica destroyed", name());
 }
 

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -483,7 +483,7 @@ private:
     uint64_t _next_checkpoint_interval_trigger_time_ms;
 
     // prepare list
-    prepare_list *_prepare_list;
+    std::unique_ptr<prepare_list> _prepare_list;
 
     // private prepare log (may be empty, depending on config)
     mutation_log_ptr _private_log;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -482,7 +482,6 @@ private:
     uint64_t _last_checkpoint_generate_time_ms;
     uint64_t _next_checkpoint_interval_trigger_time_ms;
 
-    // prepare list
     std::unique_ptr<prepare_list> _prepare_list;
 
     // private prepare log (may be empty, depending on config)

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -296,8 +296,7 @@ void replica_split_manager::child_copy_prepare_list(
 
     // copy parent prepare list
     plist->set_committer(std::bind(&replica::execute_mutation, _replica, std::placeholders::_1));
-    delete _replica->_prepare_list;
-    _replica->_prepare_list = new prepare_list(this, *plist);
+    _replica->_prepare_list.reset(new prepare_list(this, *plist));
     for (decree d = last_committed_decree + 1; d <= _replica->_prepare_list->max_decree(); ++d) {
         mutation_ptr mu = _replica->_prepare_list->get_mutation_by_decree(d);
         dassert_replica(mu != nullptr, "can not find mutation, dercee={}", d);

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -129,7 +129,7 @@ public:
                 mu->set_logged();
             }
         }
-        rep->_prepare_list = _mock_plist;
+        rep->_prepare_list.reset(_mock_plist);
     }
 
     void mock_parent_states()

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -149,7 +149,7 @@ public:
     void set_replica_config(replica_configuration &config) { _config = config; }
     void set_partition_status(partition_status::type status) { _config.status = status; }
     void set_last_committed_decree(decree d) { _prepare_list->reset(d); }
-    prepare_list *get_plist() { return _prepare_list; }
+    prepare_list *get_plist() { return _prepare_list.get(); }
     void prepare_list_truncate(decree d) { _prepare_list->truncate(d); }
     void prepare_list_commit_hard(decree d) { _prepare_list->commit(d, COMMIT_TO_DECREE_HARD); }
     decree get_app_last_committed_decree() { return _app->last_committed_decree(); }

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -149,7 +149,7 @@ public:
     void set_replica_config(replica_configuration &config) { _config = config; }
     void set_partition_status(partition_status::type status) { _config.status = status; }
     void set_last_committed_decree(decree d) { _prepare_list->reset(d); }
-    prepare_list *get_plist() { return _prepare_list.get(); }
+    prepare_list *get_plist() const { return _prepare_list.get(); }
     void prepare_list_truncate(decree d) { _prepare_list->truncate(d); }
     void prepare_list_commit_hard(decree d) { _prepare_list->commit(d, COMMIT_TO_DECREE_HARD); }
     decree get_app_last_committed_decree() { return _app->last_committed_decree(); }


### PR DESCRIPTION
Use `std::unique_ptr` to avoid memory leak, for example: L132 in src/replica/split/test/replica_split_test.cpp

https://github.com/apache/incubator-pegasus/issues/887