### PR TITLE
fix: remove min_live_node_count_for_unfreeze from meta_options to ensure it can be correctly updated dynamically

### DIFF
--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -39,14 +39,6 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint64("meta_server",
-                  min_live_node_count_for_unfreeze,
-                  3,
-                  "minimum live node count without which the state is freezed");
-DSN_TAG_VARIABLE(min_live_node_count_for_unfreeze, FT_MUTABLE);
-DSN_DEFINE_validator(min_live_node_count_for_unfreeze,
-                     [](uint64_t min_live_node_count) -> bool { return min_live_node_count > 0; });
-
 std::string meta_options::concat_path_unix_style(const std::string &prefix,
                                                  const std::string &postfix)
 {
@@ -81,8 +73,6 @@ void meta_options::initialize()
         65,
         "if live_node_count * 100 < total_node_count * node_live_percentage_threshold_for_update, "
         "then freeze the cluster; default is 65");
-
-    min_live_node_count_for_unfreeze = FLAGS_min_live_node_count_for_unfreeze;
 
     meta_function_level_on_start = meta_function_level::fl_invalid;
     const char *level_str = dsn_config_get_value_string(

--- a/src/meta/meta_options.h
+++ b/src/meta/meta_options.h
@@ -70,7 +70,6 @@ public:
     std::vector<std::string> meta_state_service_args;
 
     uint64_t node_live_percentage_threshold_for_update;
-    uint64_t min_live_node_count_for_unfreeze;
     meta_function_level::type meta_function_level_on_start;
     bool recover_from_replica_server;
     int32_t hold_seconds_for_dropped_app;

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -58,7 +58,7 @@ DSN_DEFINE_uint64("meta_server",
                   "minimum live node count without which the state is freezed");
 DSN_TAG_VARIABLE(min_live_node_count_for_unfreeze, FT_MUTABLE);
 DSN_DEFINE_validator(min_live_node_count_for_unfreeze,
-                     [](uint64_t min_live_node_count) -> bool { return min_live_node_count >= 0; });
+                     [](uint64_t min_live_node_count) -> bool { return min_live_node_count > 0; });
 
 meta_service::meta_service()
     : serverlet("meta_service"), _failure_detector(nullptr), _started(false), _recovering(false)

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -52,6 +52,14 @@
 namespace dsn {
 namespace replication {
 
+DSN_DEFINE_uint64("meta_server",
+                  min_live_node_count_for_unfreeze,
+                  3,
+                  "minimum live node count without which the state is freezed");
+DSN_TAG_VARIABLE(min_live_node_count_for_unfreeze, FT_MUTABLE);
+DSN_DEFINE_validator(min_live_node_count_for_unfreeze,
+                     [](uint64_t min_live_node_count) -> bool { return min_live_node_count >= 0; });
+
 meta_service::meta_service()
     : serverlet("meta_service"), _failure_detector(nullptr), _started(false), _recovering(false)
 {
@@ -101,7 +109,7 @@ void meta_service::stop()
 bool meta_service::check_freeze() const
 {
     zauto_lock l(_failure_detector->_lock);
-    if (_alive_set.size() < _meta_opts.min_live_node_count_for_unfreeze)
+    if (_alive_set.size() < FLAGS_min_live_node_count_for_unfreeze)
         return true;
     int total = _alive_set.size() + _dead_set.size();
     return _alive_set.size() * 100 < _node_live_percentage_threshold_for_update * total;

--- a/src/meta/test/meta_app_operation_test.cpp
+++ b/src/meta/test/meta_app_operation_test.cpp
@@ -26,6 +26,7 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_uint64(min_live_node_count_for_unfreeze);
 DSN_DECLARE_int32(min_allowed_replica_count);
 DSN_DECLARE_int32(max_allowed_replica_count);
 
@@ -207,6 +208,9 @@ TEST_F(meta_app_operation_test, create_app)
     // even if alive_nodes >= min_live_node_count_for_unfreeze
     set_node_live_percentage_threshold_for_update(0);
 
+    // save original FLAGS_min_live_node_count_for_unfreeze
+    auto reserved_min_live_node_count_for_unfreeze = FLAGS_min_live_node_count_for_unfreeze;
+
     // save original FLAGS_max_allowed_replica_count
     auto reserved_max_allowed_replica_count = FLAGS_max_allowed_replica_count;
 
@@ -290,6 +294,9 @@ TEST_F(meta_app_operation_test, create_app)
                       std::to_string(reserved_max_allowed_replica_count));
     ASSERT_TRUE(res.is_ok());
     ASSERT_EQ(FLAGS_max_allowed_replica_count, reserved_max_allowed_replica_count);
+
+    // recover original FLAGS_min_live_node_count_for_unfreeze
+    set_min_live_node_count_for_unfreeze(reserved_min_live_node_count_for_unfreeze);
 }
 
 TEST_F(meta_app_operation_test, drop_app)

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -88,7 +88,8 @@ void meta_test_base::wait_all() { _ms->tracker()->wait_outstanding_tasks(); }
 
 void meta_test_base::set_min_live_node_count_for_unfreeze(uint64_t node_count)
 {
-    _ms->_meta_opts.min_live_node_count_for_unfreeze = node_count;
+    auto res = update_flag("min_live_node_count_for_unfreeze", std::to_string(node_count));
+    ASSERT_TRUE(res.is_ok());
 }
 
 void meta_test_base::set_node_live_percentage_threshold_for_update(uint64_t percentage_threshold)

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -30,6 +30,8 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_uint64(min_live_node_count_for_unfreeze);
+
 meta_test_base::~meta_test_base() {}
 
 void meta_test_base::SetUp()
@@ -88,8 +90,7 @@ void meta_test_base::wait_all() { _ms->tracker()->wait_outstanding_tasks(); }
 
 void meta_test_base::set_min_live_node_count_for_unfreeze(uint64_t node_count)
 {
-    auto res = update_flag("min_live_node_count_for_unfreeze", std::to_string(node_count));
-    ASSERT_TRUE(res.is_ok());
+    FLAGS_min_live_node_count_for_unfreeze = node_count;
 }
 
 void meta_test_base::set_node_live_percentage_threshold_for_update(uint64_t percentage_threshold)

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -406,7 +406,8 @@ void meta_service_test_app::apply_balancer_test()
 void meta_service_test_app::cannot_run_balancer_test()
 {
     std::shared_ptr<null_meta_service> svc(new null_meta_service());
-    svc->_meta_opts.min_live_node_count_for_unfreeze = 0;
+    auto res = update_flag("min_live_node_count_for_unfreeze", "0");
+    ASSERT_TRUE(res.is_ok());
     svc->_meta_opts.node_live_percentage_threshold_for_update = 0;
 
     svc->_state->initialize(svc.get(), "/");


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/896