### PR TITLE
feat: make option empty_write_disable mutable

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -41,6 +41,10 @@ DSN_DEFINE_int32("replication",
                  5,
                  "concurrent bulk load downloading replica count");
 
+/**
+ * Empty write is used for flushing WAL log entry which is submit asynchronously.
+ * Make sure it can work well if you diable it.
+ */
 DSN_DEFINE_bool("replication",
                 empty_write_disabled,
                 false,

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -41,13 +41,18 @@ DSN_DEFINE_int32("replication",
                  5,
                  "concurrent bulk load downloading replica count");
 
+DSN_DEFINE_bool("replication",
+                empty_write_disabled,
+                false,
+                "whether to disable empty write, default is false");
+DSN_TAG_VARIABLE(empty_write_disabled, FT_MUTABLE);
+
 replication_options::replication_options()
 {
     deny_client_on_start = false;
     verbose_client_log_on_start = false;
     verbose_commit_log_on_start = false;
     delay_for_fd_timeout_on_start = false;
-    empty_write_disabled = false;
     duplication_enabled = true;
 
     prepare_timeout_ms_for_secondaries = 1000;
@@ -182,11 +187,6 @@ void replication_options::initialize()
                                   delay_for_fd_timeout_on_start,
                                   "whether to delay for beacon grace period to make failure "
                                   "detector timeout when starting the server, default is false");
-    empty_write_disabled =
-        dsn_config_get_value_bool("replication",
-                                  "empty_write_disabled",
-                                  empty_write_disabled,
-                                  "whether to disable empty write, default is false");
 
     duplication_enabled = dsn_config_get_value_bool(
         "replication", "duplication_enabled", duplication_enabled, "is duplication enabled");

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -53,7 +53,6 @@ public:
     bool verbose_client_log_on_start;
     bool verbose_commit_log_on_start;
     bool delay_for_fd_timeout_on_start;
-    bool empty_write_disabled;
     bool duplication_enabled;
 
     int32_t prepare_timeout_ms_for_secondaries;

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -47,6 +47,7 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_bool(empty_write_disabled);
 
 void replica::init_group_check()
 {
@@ -139,7 +140,7 @@ void replica::broadcast_group_check()
     }
 
     // send empty prepare when necessary
-    if (!_options->empty_write_disabled &&
+    if (!FLAGS_empty_write_disabled &&
         dsn_now_ms() >= _primary_states.last_prepare_ts_ms + _options->group_check_interval_ms) {
         mutation_ptr mu = new_mutation(invalid_decree);
         mu->add_client_request(RPC_REPLICATION_WRITE_EMPTY, nullptr);
@@ -248,5 +249,5 @@ void replica::inject_error(error_code err)
                      [this, err]() { handle_local_failure(err); },
                      get_gpid().thread_hash());
 }
-}
-} // end namepspace
+} // namespace replication
+} // namespace dsn

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -26,6 +26,7 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_bool(empty_write_disabled);
 
 replica_split_manager::replica_split_manager(replica *r)
     : replica_base(r), _replica(r), _stub(r->get_replica_stub())
@@ -631,7 +632,7 @@ void replica_split_manager::parent_handle_child_catch_up(
     // sync_point is the first decree after parent send write request to child synchronously
     // when sync_point commit, parent consider child has all data it should have during async-learn
     decree sync_point = _replica->_prepare_list->max_decree() + 1;
-    if (!_replica->_options->empty_write_disabled) {
+    if (!FLAGS_empty_write_disabled) {
         // empty wirte here to commit sync_point
         mutation_ptr mu = _replica->new_mutation(invalid_decree);
         mu->add_client_request(RPC_REPLICATION_WRITE_EMPTY, nullptr);


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/859

Empty write is used for flushing WAL log entry which is submit asynchronously. Make sure it can work well if you diable it.