### PR TITLE
build: split ci to different task

### DIFF
--- a/.github/workflows/sanitizer_address.yaml
+++ b/.github/workflows/sanitizer_address.yaml
@@ -54,5 +54,3 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server          
           ulimit -s unlimited
           ./run.sh test --sanitizer address --skip_thirdparty --disable_gperf
-
-

--- a/.github/workflows/sanitizer_address.yaml
+++ b/.github/workflows/sanitizer_address.yaml
@@ -1,0 +1,58 @@
+# Developer Notes:
+#
+# This config is for github actions. Before merging your changes of this file,
+# it's recommended to create a PR against the ci-test branch to test if it works
+# as expected.
+
+name: pull_request
+
+on:
+  # run on each pull request
+  pull_request:
+    types: [ synchronize, opened, reopened ]
+    branches:
+      - master
+      - 'v[0-9]+.*' # release branch
+      - ci-test # testing branch for github action
+      - '*dev' # developing branch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-with-sanitizer-address:
+    name: Test With Sanitizer Address
+    needs: lint
+    runs-on: self-hosted
+    container:
+      image: registry.cn-beijing.aliyuncs.com/apachepegasus/thirdparties-bin:ubuntu1804
+      env:
+        CCACHE_DIR: /tmp/ccache/pegasus
+        CCACHE_MAXSIZE: 10G
+      volumes:
+        # Place ccache compilation intermediate results in host memory, that's shared among containers.
+        - /tmp/ccache/pegasus:/tmp/ccache/pegasus
+      # Read docs at https://docs.docker.com/storage/tmpfs/ for more details of using tmpfs in docker.
+      options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
+    steps:
+      - uses: actions/checkout@v2
+      - name: Unpack prebuilt third-parties
+        if: contains(github.event.pull_request.labels.*.name, 'thirdparty-modified') == false
+        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+      - name: Rebuild third-parties
+        if: contains(github.event.pull_request.labels.*.name, 'thirdparty-modified')
+        working-directory: thirdparty
+        run: |
+          mkdir build
+          cmake -DCMAKE_BUILD_TYPE=Release -B build/
+          cmake --build build/ -j $(($(nproc)/2+1))
+      - name: Compilation
+        run: ./run.sh build -c --sanitizer address --skip_thirdparty --disable_gperf
+      - name: Unit Testing
+        run: |
+          export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server          
+          ulimit -s unlimited
+          ./run.sh test --sanitizer address --skip_thirdparty --disable_gperf
+
+

--- a/.github/workflows/sanitizer_leak.yaml
+++ b/.github/workflows/sanitizer_leak.yaml
@@ -1,0 +1,56 @@
+# Developer Notes:
+#
+# This config is for github actions. Before merging your changes of this file,
+# it's recommended to create a PR against the ci-test branch to test if it works
+# as expected.
+
+name: pull_request
+
+on:
+  # run on each pull request
+  pull_request:
+    types: [ synchronize, opened, reopened ]
+    branches:
+      - master
+      - 'v[0-9]+.*' # release branch
+      - ci-test # testing branch for github action
+      - '*dev' # developing branch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-with-sanitizer-leak:
+    name: Test With Sanitizer Leak
+    needs: lint
+    runs-on: self-hosted
+    container:
+      image: registry.cn-beijing.aliyuncs.com/apachepegasus/thirdparties-bin:ubuntu1804
+      env:
+        CCACHE_DIR: /tmp/ccache/pegasus
+        CCACHE_MAXSIZE: 10G
+      volumes:
+        # Place ccache compilation intermediate results in host memory, that's shared among containers.
+        - /tmp/ccache/pegasus:/tmp/ccache/pegasus
+      # Read docs at https://docs.docker.com/storage/tmpfs/ for more details of using tmpfs in docker.
+      options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
+    steps:
+      - uses: actions/checkout@v2
+      - name: Unpack prebuilt third-parties
+        if: contains(github.event.pull_request.labels.*.name, 'thirdparty-modified') == false
+        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+      - name: Rebuild third-parties
+        if: contains(github.event.pull_request.labels.*.name, 'thirdparty-modified')
+        working-directory: thirdparty
+        run: |
+          mkdir build
+          cmake -DCMAKE_BUILD_TYPE=Release -B build/
+          cmake --build build/ -j $(($(nproc)/2+1))
+      - name: Compilation
+        run: ./run.sh build -c --sanitizer leak --skip_thirdparty --disable_gperf
+      - name: Unit Testing
+        run: |
+          export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server          
+          ulimit -s unlimited
+          ./run.sh test --sanitizer leak --skip_thirdparty --disable_gperf

--- a/.github/workflows/sanitizer_undefined.yaml
+++ b/.github/workflows/sanitizer_undefined.yaml
@@ -1,0 +1,56 @@
+# Developer Notes:
+#
+# This config is for github actions. Before merging your changes of this file,
+# it's recommended to create a PR against the ci-test branch to test if it works
+# as expected.
+
+name: pull_request
+
+on:
+  # run on each pull request
+  pull_request:
+    types: [ synchronize, opened, reopened ]
+    branches:
+      - master
+      - 'v[0-9]+.*' # release branch
+      - ci-test # testing branch for github action
+      - '*dev' # developing branch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-with-sanitizer-undefined:
+    name: Test With Sanitizer Undefined
+    needs: lint
+    runs-on: self-hosted
+    container:
+      image: registry.cn-beijing.aliyuncs.com/apachepegasus/thirdparties-bin:ubuntu1804
+      env:
+        CCACHE_DIR: /tmp/ccache/pegasus
+        CCACHE_MAXSIZE: 10G
+      volumes:
+        # Place ccache compilation intermediate results in host memory, that's shared among containers.
+        - /tmp/ccache/pegasus:/tmp/ccache/pegasus
+      # Read docs at https://docs.docker.com/storage/tmpfs/ for more details of using tmpfs in docker.
+      options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
+    steps:
+      - uses: actions/checkout@v2
+      - name: Unpack prebuilt third-parties
+        if: contains(github.event.pull_request.labels.*.name, 'thirdparty-modified') == false
+        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+      - name: Rebuild third-parties
+        if: contains(github.event.pull_request.labels.*.name, 'thirdparty-modified')
+        working-directory: thirdparty
+        run: |
+          mkdir build
+          cmake -DCMAKE_BUILD_TYPE=Release -B build/
+          cmake --build build/ -j $(($(nproc)/2+1))
+      - name: Compilation
+        run: ./run.sh build -c --sanitizer undefined --skip_thirdparty --disable_gperf
+      - name: Unit Testing
+        run: |
+          export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server          
+          ulimit -s unlimited
+          ./run.sh test --sanitizer undefined --skip_thirdparty --disable_gperf

--- a/.github/workflows/sanitizer_undefined.yaml
+++ b/.github/workflows/sanitizer_undefined.yaml
@@ -54,4 +54,3 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server          
           ulimit -s unlimited
           ./run.sh test --sanitizer undefined --skip_thirdparty --disable_gperf
-

--- a/.github/workflows/sanitizer_undefined.yaml
+++ b/.github/workflows/sanitizer_undefined.yaml
@@ -54,3 +54,4 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server          
           ulimit -s unlimited
           ./run.sh test --sanitizer undefined --skip_thirdparty --disable_gperf
+


### PR DESCRIPTION
# Issue
https://github.com/apache/incubator-pegasus/issues/903

# Change
In the past, we have to re-run all jobs if ci failed, this pr split to different task, we just re-run one task when one ci failed.