### PR TITLE
fix(dup_enhancement#19): change checkpoint status after manual checkpoint completed

### DIFF
--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -64,7 +64,7 @@ public:
 
     duplication_info() = default;
 
-    void start() { alter_status(duplication_status::DS_PREPARE); }
+    error_code start() { return alter_status(duplication_status::DS_PREPARE); }
 
     // error will be returned if this state transition is not allowed.
     error_code

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -188,7 +188,11 @@ void meta_duplication_service::do_add_duplication(std::shared_ptr<app_state> &ap
                                                   duplication_info_s_ptr &dup,
                                                   duplication_add_rpc &rpc)
 {
-    dup->start();
+    const auto err = dup->start();
+    if (err != ERR_OK) {
+        derror_f("start dup[{}({})] failed: err = {}", app->app_name, dup->id, err.to_string());
+        return;
+    }
     blob value = dup->to_json_blob();
 
     std::queue<std::string> nodes({get_duplication_path(*app), std::to_string(dup->id)});
@@ -365,7 +369,7 @@ void meta_duplication_service::create_follower_app_for_duplication(
             } else {
                 derror_f("created follower app[{}.{}] to trigger duplicate checkpoint failed: "
                          "duplication_status = {}, create_err = {}, update_err = {}",
-                         get_current_cluster_name(),
+                         dup->follower_cluster_name,
                          dup->app_name,
                          duplication_status_to_string(dup->status()),
                          create_err.to_string(),
@@ -443,7 +447,7 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                   } else {
                       derror_f("query follower app[{}.{}] replica configuration completed, result: "
                                "duplication_status = {}, query_err = {}, update_err = {}",
-                               get_current_cluster_name(),
+                               dup->follower_cluster_name,
                                dup->app_name,
                                duplication_status_to_string(dup->status()),
                                query_err.to_string(),

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -189,7 +189,7 @@ void meta_duplication_service::do_add_duplication(std::shared_ptr<app_state> &ap
                                                   duplication_add_rpc &rpc)
 {
     const auto err = dup->start();
-    if (err != ERR_OK) {
+    if (dsn_unlikely(err != ERR_OK)) {
         derror_f("start dup[{}({})] failed: err = {}", app->app_name, dup->id, err.to_string());
         return;
     }

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -280,6 +280,7 @@ error_code replica::background_async_checkpoint(bool is_emergency)
             ? 0
             : (--_stub->_manual_emergency_checkpointing_count);
     }
+
     if (err == ERR_WRONG_TIMING) {
         // do nothing
         ddebug("%s: call app.async_checkpoint() returns ERR_WRONG_TIMING, time_used_ns = %" PRIu64

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -280,7 +280,6 @@ error_code replica::background_async_checkpoint(bool is_emergency)
             ? 0
             : (--_stub->_manual_emergency_checkpointing_count);
     }
-
     if (err == ERR_WRONG_TIMING) {
         // do nothing
         ddebug("%s: call app.async_checkpoint() returns ERR_WRONG_TIMING, time_used_ns = %" PRIu64

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -358,7 +358,9 @@ TEST_F(replica_test, test_trigger_manual_emergency_checkpoint)
     force_update_checkpointing(true);
     ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(101), ERR_BUSY);
     ASSERT_TRUE(is_checkpointing());
-    force_update_checkpointing(false);
+    // test running task completed
+    _mock_replica->tracker()->wait_outstanding_tasks();
+    ASSERT_FALSE(is_checkpointing());
 
     // test exceed max concurrent count
     ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(101), ERR_OK);


### PR DESCRIPTION
# Ref-Issue
https://github.com/apache/incubator-pegasus/issues/892

# Change
 `manual checkpoint` status need recovery to `false` when completed.  In the past, the status is updated by [old_decree < last_durable](https://github.com/XiaoMi/rdsn/blob/duplication_dev/src/replica/replica_chkpt.cpp#L144), But once checkpoint may not catch up with `old_decree`, and the following `catch up with task` request will be block. This pr fix it