### PR TITLE
fix(dup_enhancement#20): put `async_duplicate_checkpoint_from_master_replica` into `DEFAULT_POOL` to avoid thread lock

### DIFF
--- a/include/dsn/tool-api/task_tracker.h
+++ b/include/dsn/tool-api/task_tracker.h
@@ -167,7 +167,9 @@ public:
     // return not finished task count
     int cancel_but_not_wait_outstanding_tasks();
 
-    void set_success() { _all_tasks_success = true; }
+    void set_tasks_success() { _all_tasks_success = true; }
+
+    void clear_tasks_state() { _all_tasks_success = false; }
 
     bool all_tasks_success() const { return _all_tasks_success; }
 

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -415,7 +415,7 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                                   break;
                               }
 
-                              if (partition.secondaries.size() <= 1) {
+                              if (partition.secondaries.empty()) {
                                   query_err = ERR_NOT_ENOUGH_MEMBER;
                                   break;
                               }

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -415,6 +415,11 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                                   break;
                               }
 
+                              if (partition.secondaries.size() <= 1) {
+                                  query_err = ERR_NOT_ENOUGH_MEMBER;
+                                  break;
+                              }
+
                               for (const auto &secondary : partition.secondaries) {
                                   if (secondary.is_invalid()) {
                                       query_err = ERR_INACTIVE_STATE;

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -365,7 +365,7 @@ void meta_duplication_service::create_follower_app_for_duplication(
             } else {
                 derror_f("created follower app[{}.{}] to trigger duplicate checkpoint failed: "
                          "duplication_status = {}, create_err = {}, update_err = {}",
-                         get_current_cluster_name(),
+                         dup->follower_cluster_name,
                          dup->app_name,
                          duplication_status_to_string(dup->status()),
                          create_err.to_string(),
@@ -448,7 +448,7 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                   } else {
                       derror_f("query follower app[{}.{}] replica configuration completed, result: "
                                "duplication_status = {}, query_err = {}, update_err = {}",
-                               get_current_cluster_name(),
+                               dup->follower_cluster_name,
                                dup->app_name,
                                duplication_status_to_string(dup->status()),
                                query_err.to_string(),

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -55,9 +55,10 @@ replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
 void replica_duplicator::prepare_dup()
 {
     ddebug_replica("start prepare checkpoint to catch up with latest durable decree: "
-                   "start_point_decree({}) vs last_durable_decree({})",
+                   "start_point_decree({}) < last_durable_decree({}) = {}",
                    _start_point_decree,
-                   _replica->last_durable_decree());
+                   _replica->last_durable_decree(),
+                   _start_point_decree < _replica->last_durable_decree());
 
     tasking::enqueue(
         LPC_REPLICATION_COMMON,

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -78,11 +78,11 @@ error_code replica_follower::duplicate_checkpoint()
         async_duplicate_checkpoint_from_master_replica();
     });
     _tracker.wait_outstanding_tasks();
+    _duplicating_checkpoint = false;
     if (_tracker.all_tasks_success()) {
         _tracker.clear_tasks_state();
         return ERR_OK;
     }
-    _duplicating_checkpoint = false;
     return ERR_TRY_AGAIN;
 }
 

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -158,6 +158,11 @@ replica_follower::update_master_replica_config(error_code err,
 
     // since the request just specify one partition, the result size is single
     _master_replica_config = resp.partitions[0];
+    ddebug_replica(
+        "query master[{}] config successfully and update local config: remote={}, gpid={}",
+        master_replica_name(),
+        _master_replica_config.primary.to_string(),
+        _master_replica_config.pid.to_string());
     return ERR_OK;
 }
 

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -86,7 +86,7 @@ error_code replica_follower::duplicate_checkpoint()
     return ERR_TRY_AGAIN;
 }
 
-// ThreadPool: THREAD_POOL_REPLICATION_LONG
+// ThreadPool: THREAD_POOL_DEFAULT
 void replica_follower::async_duplicate_checkpoint_from_master_replica()
 {
     rpc_address meta_servers;

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -74,7 +74,7 @@ public:
 
     void mark_tracker_tasks_success(replica_follower *follower)
     {
-        follower->_tracker.set_success();
+        follower->_tracker.set_tasks_success();
     }
 
     error_code update_master_replica_config(replica_follower *follower,

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -137,7 +137,7 @@ TEST_F(replica_follower_test, test_duplicate_checkpoint)
 
     auto follower = _mock_replica->get_replica_follower();
 
-    ASSERT_EQ(follower->duplicate_checkpoint(), ERR_CORRUPTION);
+    ASSERT_EQ(follower->duplicate_checkpoint(), ERR_TRY_AGAIN);
     ASSERT_FALSE(get_duplicating(follower));
 
     mark_tracker_tasks_success(follower);

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -118,7 +118,7 @@ error_code replica::initialize_on_new()
     // clear work on failure
     utils::filesystem::remove_path(path);
     stub->_fs_manager.remove_replica(pid);
-    return rep;
+    return nullptr;
 }
 
 error_code replica::initialize_on_load()


### PR DESCRIPTION
# Ref-Issue
https://github.com/apache/incubator-pegasus/issues/892

# Change
`THREAD_POOL_REPLICATION_LONG` has limited count, when `duplicate_checkpoint` put into it and `sync execute`, it will be exhausted and casue thread lock, this pr fix it