### PR TITLE
ci: fix syntax errors in action yaml files

### DIFF
--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [ synchronize, opened, reopened ]
     paths:
-      # test - .github/workflows/cpp_actions.yaml
+      - .github/workflows/cpp_actions.yaml
       - CMakeLists.txt
       - bin/**
       - compile_thrift.py

--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -63,8 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get changed files
-        id: changed-files
         uses: tj-actions/changed-files@v18.7
+        with:
+          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -100,8 +101,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get changed files
-        id: changed-files
         uses: tj-actions/changed-files@v18.7
+        with:
+          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -137,8 +139,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get changed files
-        id: changed-files
         uses: tj-actions/changed-files@v18.7
+        with:
+          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -174,8 +177,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get changed files
-        id: changed-files
         uses: tj-actions/changed-files@v18.7
+        with:
+          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty

--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -66,10 +66,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v18.7
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty') == false
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty')
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
         working-directory: thirdparty
         run: |
           mkdir build
@@ -103,10 +103,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v18.7
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty') == false
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty')
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
         working-directory: thirdparty
         run: |
           mkdir build
@@ -140,10 +140,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v18.7
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty') == false
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty')
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
         working-directory: thirdparty
         run: |
           mkdir build
@@ -177,10 +177,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v18.7
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty') == false
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.modified_files, 'thirdparty')
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
         working-directory: thirdparty
         run: |
           mkdir build

--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -64,8 +64,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changed files
         uses: tj-actions/changed-files@v18.7
-        with:
-          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -102,8 +100,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changed files
         uses: tj-actions/changed-files@v18.7
-        with:
-          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -140,8 +136,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changed files
         uses: tj-actions/changed-files@v18.7
-        with:
-          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -178,8 +172,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changed files
         uses: tj-actions/changed-files@v18.7
-        with:
-          fetch-depth: 0
       - name: Unpack prebuilt third-parties
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty

--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -62,13 +62,17 @@ jobs:
       options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
-      - name: Get changed files
-        uses: tj-actions/changed-files@v18.7
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            thirdparty:
+              - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
+        if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
+        if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         run: |
           mkdir build
@@ -98,13 +102,17 @@ jobs:
       options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
-      - name: Get changed files
-        uses: tj-actions/changed-files@v18.7
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            thirdparty:
+              - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
+        if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
+        if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         run: |
           mkdir build
@@ -134,13 +142,17 @@ jobs:
       options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
-      - name: Get changed files
-        uses: tj-actions/changed-files@v18.7
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            thirdparty:
+              - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
+        if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
+        if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         run: |
           mkdir build
@@ -170,13 +182,17 @@ jobs:
       options: --mount type=tmpfs,destination=/tmp/pegasus --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
-      - name: Get changed files
-        uses: tj-actions/changed-files@v18.7
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            thirdparty:
+              - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty') == false
+        if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
-        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'thirdparty')
+        if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         run: |
           mkdir build

--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [ synchronize, opened, reopened ]
     paths:
-      - .github/workflows/cpp_actions.yaml
+      # test - .github/workflows/cpp_actions.yaml
       - CMakeLists.txt
       - bin/**
       - compile_thrift.py

--- a/.github/workflows/cpp_actions.yaml
+++ b/.github/workflows/cpp_actions.yaml
@@ -13,13 +13,13 @@ on:
     paths:
       - .github/workflows/cpp_actions.yaml
       - CMakeLists.txt
-      - bin
+      - bin/**
       - compile_thrift.py
-      - include
+      - include/**
       - run.sh
-      - scripts
-      - src
-      - thirdparty
+      - scripts/**
+      - src/**
+      - thirdparty/**
     branches:
       - master
       - 'v[0-9]+.*' # release branch

--- a/.github/workflows/cpp_always_pass_actions.yaml
+++ b/.github/workflows/cpp_always_pass_actions.yaml
@@ -26,16 +26,16 @@ on:
   # run on each pull request
   pull_request:
     types: [ synchronize, opened, reopened ]
-    paths:
+    paths-ignore:
       - .github/workflows/cpp_actions.yaml
       - CMakeLists.txt
-      - bin
+      - bin/**
       - compile_thrift.py
-      - include
+      - include/**
       - run.sh
-      - scripts
-      - src
-      - thirdparty
+      - scripts/**
+      - src/**
+      - thirdparty/**
     branches:
       - master
       - 'v[0-9]+.*' # release branch


### PR DESCRIPTION
ref: https://github.com/apache/incubator-pegasus/issues/954
- fix the paths and paths-ignore syntax errors in on.pull_request
- use dorny/paths-filter@v2 instead of tj-actions/changed-files@v18.7, which seems more stable