### PR TITLE
fix: crash when huge write

### DIFF
--- a/include/dsn/tool-api/aio_task.h
+++ b/include/dsn/tool-api/aio_task.h
@@ -55,7 +55,7 @@ public:
     // filled by apps
     dsn_handle_t file;
     void *buffer;
-    uint32_t buffer_size;
+    uint64_t buffer_size;
     uint64_t file_offset;
 
     // filled by frameworks

--- a/src/aio/aio_provider.cpp
+++ b/src/aio/aio_provider.cpp
@@ -31,7 +31,7 @@ namespace dsn {
 
 aio_provider::aio_provider(disk_engine *disk) : _engine(disk) {}
 
-void aio_provider::complete_io(aio_task *aio, error_code err, uint32_t bytes)
+void aio_provider::complete_io(aio_task *aio, error_code err, uint64_t bytes)
 {
     _engine->complete_io(aio, err, bytes);
 }

--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -59,8 +59,8 @@ public:
 
     virtual error_code close(dsn_handle_t fh) = 0;
     virtual error_code flush(dsn_handle_t fh) = 0;
-    virtual error_code write(const aio_context &aio_ctx, /*out*/ uint32_t *processed_bytes) = 0;
-    virtual error_code read(const aio_context &aio_ctx, /*out*/ uint32_t *processed_bytes) = 0;
+    virtual error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
+    virtual error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
 
     // Submits the aio_task to the underlying disk-io executor.
     // This task may not be executed immediately, call `aio_task::wait`
@@ -69,7 +69,7 @@ public:
 
     virtual aio_context *prepare_aio_context(aio_task *) = 0;
 
-    void complete_io(aio_task *aio, error_code err, uint32_t bytes);
+    void complete_io(aio_task *aio, error_code err, uint64_t bytes);
 
 private:
     disk_engine *_engine;

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -53,7 +53,7 @@ static disk_engine_initializer disk_engine_init;
 aio_task *disk_write_queue::unlink_next_workload(void *plength)
 {
     uint64_t next_offset = 0;
-    uint32_t &sz = *(uint32_t *)plength;
+    uint64_t &sz = *(uint64_t *)plength;
     sz = 0;
 
     aio_task *first = _hdr._first, *current = first, *last = first;
@@ -126,9 +126,9 @@ aio_task *disk_file::on_write_completed(aio_task *wk, void *ctx, error_code err,
         if (err == ERR_OK) {
             size_t this_size = (size_t)wk->get_aio_context()->buffer_size;
             dassert(size >= this_size,
-                    "written buffer size does not equal to input buffer's size: %d vs %d",
-                    (int)size,
-                    (int)this_size);
+                    "written buffer size does not equal to input buffer's size: %lld vs %lld",
+                    size,
+                    this_size);
 
             wk->enqueue(err, this_size);
             size -= this_size;
@@ -167,7 +167,7 @@ public:
     virtual void exec() override
     {
         auto df = (disk_file *)_tasks->get_aio_context()->file_object;
-        uint32_t sz;
+        uint64_t sz;
 
         auto wk = df->on_write_completed(_tasks, (void *)&sz, error(), get_transferred_size());
         if (wk) {
@@ -193,14 +193,14 @@ void disk_engine::write(aio_task *aio)
     dio->engine = this;
     dio->type = AIO_Write;
 
-    uint32_t sz;
+    uint64_t sz;
     auto wk = df->write(aio, &sz);
     if (wk) {
         process_write(wk, sz);
     }
 }
 
-void disk_engine::process_write(aio_task *aio, uint32_t sz)
+void disk_engine::process_write(aio_task *aio, uint64_t sz)
 {
     aio_context *dio = aio->get_aio_context();
 
@@ -243,7 +243,7 @@ void disk_engine::process_write(aio_task *aio, uint32_t sz)
     }
 }
 
-void disk_engine::complete_io(aio_task *aio, error_code err, uint32_t bytes)
+void disk_engine::complete_io(aio_task *aio, error_code err, uint64_t bytes)
 {
     if (err != ERR_OK) {
         dinfo("disk operation failure with code %s, err = %s, aio_task_id = %016" PRIx64,

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -125,11 +125,7 @@ aio_task *disk_file::on_write_completed(aio_task *wk, void *ctx, error_code err,
 
         if (err == ERR_OK) {
             size_t this_size = (size_t)wk->get_aio_context()->buffer_size;
-            dassert(size >= this_size,
-                    "written buffer size does not equal to input buffer's size: %lld vs %lld",
-                    size,
-                    this_size);
-
+            dcheck_ge(size, this_size);
             wk->enqueue(err, this_size);
             size -= this_size;
         } else {

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -266,7 +266,7 @@ void disk_engine::complete_io(aio_task *aio, error_code err, uint64_t bytes)
 
         // write
         else {
-            uint32_t sz;
+            uint64_t sz;
             auto wk = df->on_write_completed(aio, (void *)&sz, err, (size_t)bytes);
             if (wk) {
                 process_write(wk, sz);

--- a/src/aio/disk_engine.h
+++ b/src/aio/disk_engine.h
@@ -79,8 +79,8 @@ private:
     disk_engine();
     ~disk_engine() = default;
 
-    void process_write(aio_task *wk, uint32_t sz);
-    void complete_io(aio_task *aio, error_code err, uint32_t bytes);
+    void process_write(aio_task *wk, uint64_t sz);
+    void complete_io(aio_task *aio, error_code err, uint64_t bytes);
 
     std::unique_ptr<aio_provider> _provider;
 

--- a/src/aio/native_linux_aio_provider.h
+++ b/src/aio/native_linux_aio_provider.h
@@ -39,8 +39,8 @@ public:
     dsn_handle_t open(const char *file_name, int flag, int pmode) override;
     error_code close(dsn_handle_t fh) override;
     error_code flush(dsn_handle_t fh) override;
-    error_code write(const aio_context &aio_ctx, /*out*/ uint32_t *processed_bytes) override;
-    error_code read(const aio_context &aio_ctx, /*out*/ uint32_t *processed_bytes) override;
+    error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) override;
+    error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) override;
 
     void submit_aio_task(aio_task *aio) override;
     aio_context *prepare_aio_context(aio_task *tsk) override { return new aio_context; }


### PR DESCRIPTION
# Related-Issue
https://github.com/apache/incubator-pegasus/issues/903

# Change
when buffer of slog is more 2GB, then flush to slog file, it maybe crash.