### PR TITLE
feat(bulk_load): support different tables can execute bulk load concurrently

### DIFF
--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -40,6 +40,12 @@ DSN_DEFINE_bool("meta_server",
                 "verify files according to metadata before ingest");
 DSN_TAG_VARIABLE(bulk_load_verify_before_ingest, FT_MUTABLE);
 
+DSN_DEFINE_bool("meta_server",
+                concurrent_bulk_load,
+                false,
+                "different app can execute bulk load at the same time if this value is true");
+DSN_TAG_VARIABLE(concurrent_bulk_load, FT_MUTABLE);
+
 bulk_load_service::bulk_load_service(meta_service *meta_svc, const std::string &bulk_load_dir)
     : _meta_svc(meta_svc), _state(meta_svc->get_server_state()), _bulk_load_root(bulk_load_dir)
 {
@@ -68,7 +74,8 @@ void bulk_load_service::on_start_bulk_load(start_bulk_load_rpc rpc)
     auto &response = rpc.response();
     response.err = ERR_OK;
 
-    if (!_meta_svc->try_lock_meta_op_status(meta_op_status::BULKLOAD)) {
+    if (!FLAGS_concurrent_bulk_load &&
+        !_meta_svc->try_lock_meta_op_status(meta_op_status::BULKLOAD)) {
         response.hint_msg = "meta server is busy now, please wait";
         derror_f("{}", response.hint_msg);
         response.err = ERR_BUSY;

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -41,10 +41,10 @@ DSN_DEFINE_bool("meta_server",
 DSN_TAG_VARIABLE(bulk_load_verify_before_ingest, FT_MUTABLE);
 
 DSN_DEFINE_bool("meta_server",
-                concurrent_bulk_load,
+                enable_concurrent_bulk_load,
                 false,
-                "different app can execute bulk load at the same time if this value is true");
-DSN_TAG_VARIABLE(concurrent_bulk_load, FT_MUTABLE);
+                "whether to enable different apps to execute bulk load at the same time");
+DSN_TAG_VARIABLE(enable_concurrent_bulk_load, FT_MUTABLE);
 
 bulk_load_service::bulk_load_service(meta_service *meta_svc, const std::string &bulk_load_dir)
     : _meta_svc(meta_svc), _state(meta_svc->get_server_state()), _bulk_load_root(bulk_load_dir)
@@ -74,7 +74,7 @@ void bulk_load_service::on_start_bulk_load(start_bulk_load_rpc rpc)
     auto &response = rpc.response();
     response.err = ERR_OK;
 
-    if (!FLAGS_concurrent_bulk_load &&
+    if (!FLAGS_enable_concurrent_bulk_load &&
         !_meta_svc->try_lock_meta_op_status(meta_op_status::BULKLOAD)) {
         response.hint_msg = "meta server is busy now, please wait";
         derror_f("{}", response.hint_msg);

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1914,7 +1914,8 @@ void bulk_load_service::do_continue_app_bulk_load(
     const int32_t same_count = pinfo_map.size() - different_count;
     const int32_t invalid_count = partition_count - pinfo_map.size();
 
-    if (!_meta_svc->try_lock_meta_op_status(meta_op_status::BULKLOAD)) {
+    if (!FLAGS_enable_concurrent_bulk_load &&
+        !_meta_svc->try_lock_meta_op_status(meta_op_status::BULKLOAD)) {
         derror_f("fatal, the op status of meta server must be meta_op_status::FREE");
         return;
     }

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -25,6 +25,7 @@ namespace dsn {
 namespace replication {
 
 DSN_DECLARE_uint32(bulk_load_max_rollback_times);
+DSN_DECLARE_bool(concurrent_bulk_load);
 
 ///
 /// bulk load path on remote storage:

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -25,7 +25,7 @@ namespace dsn {
 namespace replication {
 
 DSN_DECLARE_uint32(bulk_load_max_rollback_times);
-DSN_DECLARE_bool(concurrent_bulk_load);
+DSN_DECLARE_bool(enable_concurrent_bulk_load);
 
 ///
 /// bulk load path on remote storage:

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -502,7 +502,7 @@ TEST_F(bulk_load_service_test, start_bulk_load_succeed)
     fail::setup();
     fail::cfg("meta_check_bulk_load_request_params", "return()");
     fail::cfg("meta_bulk_load_partition_bulk_load", "return()");
-    FLAGS_concurrent_bulk_load = false;
+    FLAGS_enable_concurrent_bulk_load = false;
 
     auto resp = start_bulk_load(APP_NAME);
     ASSERT_EQ(resp.err, ERR_OK);

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -502,6 +502,7 @@ TEST_F(bulk_load_service_test, start_bulk_load_succeed)
     fail::setup();
     fail::cfg("meta_check_bulk_load_request_params", "return()");
     fail::cfg("meta_bulk_load_partition_bulk_load", "return()");
+    FLAGS_concurrent_bulk_load = false;
 
     auto resp = start_bulk_load(APP_NAME);
     ASSERT_EQ(resp.err, ERR_OK);
@@ -527,9 +528,6 @@ TEST_F(bulk_load_service_test, check_partition_status_app_wrong_test)
     app->status = app_status::AS_DROPPED;
     ASSERT_FALSE(check_partition_status(table_name, false, false, gpid(app->app_id, 0), false));
     ASSERT_TRUE(is_app_bulk_load_states_reset(app->app_id));
-    meta_op_status st = get_op_status();
-    ASSERT_EQ(st, meta_op_status::BULKLOAD);
-    unlock_meta_op_status();
 }
 
 TEST_F(bulk_load_service_test, check_partition_status_test)
@@ -726,7 +724,6 @@ public:
         _app_id = app->app_id;
         _partition_count = app->partition_count;
         ASSERT_EQ(app->is_bulk_loading, true);
-        ASSERT_EQ(get_op_status(), meta_op_status::BULKLOAD);
     }
 
     void TearDown()


### PR DESCRIPTION
[Pegasus#872](https://github.com/apache/incubator-pegasus/issues/872)
In previous implementation, we restrict only one table can execute bulk load in cluster to guarantee performance. We have already added more restriction to control bulk load download and ingestion, it is safety to permit concurrent bulk load. This pull request adds a gflags to control it.
```diff
[meta_server]
+ enable_concurrent_bulk_load = false
```