### PR TITLE
feat(update_replication_factor#8): recover uncompleted update of replication factor during initialization of meta service

### DIFF
--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -64,13 +64,14 @@ namespace replication {
 // another option `max_reserved_dropped_replicas` representing the max reserved number allowed for
 // dropped replicas.
 //
-// If `max_reserved_dropped_replicas` is set to 1, there is at most one dropped replicas reserved;
-// If it's set to 0, however, none of dropped replicas can be reserved.
+// If `max_reserved_dropped_replicas` is set to 1, there is at most one dropped replicas reserved,
+// which means, once the number of alive replicas reaches max_replica_count, at most one dropped
+// replica can be reserved and others will be eliminated; If `max_reserved_dropped_replicas` is
+// set to 0, however, none of dropped replicas can be reserved.
 //
-// Thus the default value of `max_reserved_dropped_replicas` is set to 1 so that the unit tests
-// can be passed. For production environments, it should be set to 0 to be consistent with
-// `max_replicas_in_group`, which also means, once the number of alive replicas reaches
-// max_replica_count, at most one dropped replica can be reserved and others will be eliminated.
+// To be consistent with `max_replicas_in_group`, default value of `max_reserved_dropped_replicas`
+// is set to 1 so that the unit tests can be passed. For production environments, it should be set
+// to 0.
 DSN_DEFINE_uint32("meta_server",
                   max_reserved_dropped_replicas,
                   1,

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -463,6 +463,8 @@ error_code meta_service::start()
                err.to_string());
     }
 
+    _state->recover_from_max_replica_count_env();
+
     initialize_duplication_service();
     recover_duplication_from_meta_state();
 

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3736,5 +3736,108 @@ void server_state::update_partition_max_replica_count_locally(
              new_config_str);
 }
 
+void server_state::recover_from_max_replica_count_env()
+{
+    std::vector<std::pair<std::shared_ptr<app_state>, int32_t>> tasks;
+    {
+        zauto_read_lock l(_lock);
+        for (auto &e : _exist_apps) {
+            auto &app = e.second;
+            auto iter = app->envs.find(replica_envs::UPDATE_MAX_REPLICA_COUNT);
+            if (iter == app->envs.end()) {
+                continue;
+            }
+
+            std::vector<std::string> args;
+            utils::split_args(iter->second.c_str(), args, ';');
+            if (args[0] != "updating") {
+                continue;
+            }
+
+            int32_t max_replica_count = 0;
+            if (args.size() < 2 || !dsn::buf2int32(args[1], max_replica_count) || max_replica_count <= 0) {
+                dassert_f(false, "invalid max_replica_count_env: app_name={}, app_id={}, max_replica_count={}, {}={}", app->app_name, app->app_id, app->max_replica_count, iter->first, iter->second);
+            }
+
+            tasks.emplace_back(app, max_replica_count);
+        }
+    }
+
+    dsn::task_tracker tracker;
+
+    for (auto &task : tasks) {
+        recover_all_partitions_max_replica_count(task.first, task.second, tracker);
+    }
+    tracker.wait_outstanding_tasks();
+
+    for (auto &task : tasks) {
+        recover_app_max_replica_count(task.first, task.second, tracker);
+    }
+    tracker.wait_outstanding_tasks();
+}
+
+void server_state::recover_all_partitions_max_replica_count(std::pair<std::shared_ptr<app_state> &app, int32_t max_replica_count, dsn::task_tracker &tracker)
+{
+    ddebug_f("ready to recover max_replica_count for all partitions: app_name={}, app_id={}, partition_count={}, old_max_replica_count={}, new_max_replica_count={}", app->app_name, app->app_id, app->partition_count, app->max_replica_count, max_replica_count);
+
+    for (int i = 0; i < app->partition_count; ++i) {
+        zauto_read_lock l(_lock);
+
+        auto pc = app->partitions[i];
+        if (pc.max_replica_count == max_replica_count) {
+            dwarn_f("no need to recover partition-level max_replica_count since it has been updated before: app_name={}, app_id={}, partition_index={}, partition_count={}, new_max_replica_count={}", app->app_name, app->app_id, i, app->partition_count, max_replica_count);
+            continue;
+        }
+
+        pc.max_replica_count = max_replica_count;
+        ++(pc.ballot);
+        auto partition_path = get_partition_path(pc.pid);
+        auto value =
+            dsn::json::json_forwarder<partition_configuration>::encode(pc);
+        _meta_svc->get_remote_storage()->set_data(
+            partition_path,
+            value,
+            LPC_META_STATE_HIGH,
+            [this, app, max_replica_count, i](error_code ec) mutable {
+                zauto_write_lock l(_lock);
+
+                dassert_f(ec == ERR_OK,
+                          "An error that can't be handled occurs while recovering remote "
+                          "partition-level max_replica_count: error_code={}, app_name={}, "
+                          "app_id={}, partition_index={}, partition_count={}, new_max_replica_count={}",
+                          ec.to_string(),
+                          app->app_name,
+                          app->app_id,
+                          i,
+                          app->partition_count,
+                          max_replica_count);
+                app->partitions[i].max_replica_count = max_replica_count;
+
+                ddebug_f("partition-level max_replica_count has been recovered successfully: app_name={}, app_id={}, partition_index={}, partition_count={}, new_max_replica_count={}", app->app_name, app->app_id, i, app->partition_count, max_replica_count);
+            },
+            tracker);
+    }
+}
+
+void server_state::recover_app_max_replica_count(std::pair<std::shared_ptr<app_state> &app, int32_t max_replica_count, dsn::task_tracker &tracker)
+{
+    zauto_read_lock l(_lock);
+
+    auto ainfo = *(reinterpret_cast<app_info *>(app.get()));
+    ainfo.max_replica_count = max_replica_count;
+    ainfo.envs.erase(replica_envs::UPDATE_MAX_REPLICA_COUNT);
+    auto app_path = get_app_path(*app);
+    auto value = dsn::json::json_forwarder<app_info>::encode(ainfo);
+    _meta_svc->get_remote_storage()->set_data(
+            app_path, value, LPC_META_STATE_NORMAL, 
+            [this, app, max_replica_count](error_code ec) mutable {
+                zauto_write_lock l(_lock);
+
+                app->max_replica_count = max_replica_count;
+                app->envs.erase(replica_envs::UPDATE_MAX_REPLICA_COUNT);
+            },
+            tracker);
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3486,13 +3486,11 @@ void server_state::update_app_max_replica_count(std::shared_ptr<app_state> &app,
         app->envs.erase(replica_envs::UPDATE_MAX_REPLICA_COUNT);
         ddebug_f("both remote and local app-level max_replica_count have been updated "
                  "successfully: app_name={}, app_id={}, old_max_replica_count={}, "
-                 "new_max_replica_count={}, {}={}",
+                 "new_max_replica_count={}",
                  app->app_name,
                  app->app_id,
                  old_max_replica_count,
-                 new_max_replica_count,
-                 replica_envs::UPDATE_MAX_REPLICA_COUNT,
-                 app->envs[replica_envs::UPDATE_MAX_REPLICA_COUNT]);
+                 new_max_replica_count);
 
         auto &response = rpc.response();
         response.err = ERR_OK;

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3753,7 +3753,7 @@ void server_state::recover_from_max_replica_count_env()
 
             std::vector<std::string> args;
             utils::split_args(iter->second.c_str(), args, ';');
-            if (args[0] != "updating") {
+            if (args.empty() || args[0] != "updating") {
                 continue;
             }
 
@@ -3766,7 +3766,7 @@ void server_state::recover_from_max_replica_count_env()
                           app->app_name,
                           app->app_id,
                           app->max_replica_count,
-                          iter->first,
+                          replica_envs::UPDATE_MAX_REPLICA_COUNT,
                           iter->second);
             }
 

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -178,6 +178,7 @@ public:
     // get/set max_replica_count of an app
     void get_max_replica_count(configuration_get_max_replica_count_rpc rpc) const;
     void set_max_replica_count(configuration_set_max_replica_count_rpc rpc);
+    void recover_from_max_replica_count_env();
 
     // return true if no need to do any actions
     bool check_all_partitions();
@@ -336,6 +337,9 @@ private:
     void
     update_partition_max_replica_count_locally(std::shared_ptr<app_state> &app,
                                                const partition_configuration &new_partition_config);
+
+    void recover_all_partitions_max_replica_count(std::pair<std::shared_ptr<app_state> &app, int32_t max_replica_count, dsn::task_tracker &tracker);
+    void recover_app_max_replica_count(std::pair<std::shared_ptr<app_state> &app, int32_t max_replica_count, dsn::task_tracker &tracker);
 
     // Used for `on_start_manual_compaction`
     bool parse_compaction_envs(start_manual_compact_rpc rpc,

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -338,8 +338,12 @@ private:
     update_partition_max_replica_count_locally(std::shared_ptr<app_state> &app,
                                                const partition_configuration &new_partition_config);
 
-    void recover_all_partitions_max_replica_count(std::pair<std::shared_ptr<app_state> &app, int32_t max_replica_count, dsn::task_tracker &tracker);
-    void recover_app_max_replica_count(std::pair<std::shared_ptr<app_state> &app, int32_t max_replica_count, dsn::task_tracker &tracker);
+    void recover_all_partitions_max_replica_count(std::shared_ptr<app_state> &app,
+                                                  int32_t max_replica_count,
+                                                  dsn::task_tracker &tracker);
+    void recover_app_max_replica_count(std::shared_ptr<app_state> &app,
+                                       int32_t max_replica_count,
+                                       dsn::task_tracker &tracker);
 
     // Used for `on_start_manual_compaction`
     bool parse_compaction_envs(start_manual_compact_rpc rpc,

--- a/src/meta/test/meta_app_operation_test.cpp
+++ b/src/meta/test/meta_app_operation_test.cpp
@@ -766,5 +766,20 @@ TEST_F(meta_app_operation_test, set_max_replica_count)
     }
 }
 
+TEST_F(meta_app_operation_test, recover_from_max_replica_count_env)
+{
+    const uint32_t partition_count = 4;
+    create_app(APP_NAME, partition_count);
+
+    const int32_t new_max_replica_count = 5;
+    const auto env = fmt::format("updating;{}", new_max_replica_count);
+    set_max_replica_count_env(APP_NAME, env);
+
+    _ss->recover_from_max_replica_count_env();
+
+    verify_all_partitions_max_replica_count(APP_NAME, new_max_replica_count);
+    verify_app_max_replica_count(APP_NAME, new_max_replica_count);
+}
+
 } // namespace replication
 } // namespace dsn

--- a/src/meta/test/meta_app_operation_test.cpp
+++ b/src/meta/test/meta_app_operation_test.cpp
@@ -140,6 +140,18 @@ public:
         } else {
             app->envs[replica_envs::UPDATE_MAX_REPLICA_COUNT] = env;
         }
+
+        // set remote env of app
+        auto app_path = _ss->get_app_path(*app);
+        auto ainfo = *(reinterpret_cast<app_info *>(app.get()));
+        auto json_config = dsn::json::json_forwarder<app_info>::encode(ainfo);
+        dsn::task_tracker tracker;
+        _ms->get_remote_storage()->set_data(app_path,
+                                            json_config,
+                                            LPC_META_STATE_HIGH,
+                                            [](dsn::error_code ec) { ASSERT_EQ(ec, ERR_OK); },
+                                            &tracker);
+        tracker.wait_outstanding_tasks();
     }
 
     configuration_set_max_replica_count_response set_max_replica_count(const std::string &app_name,
@@ -239,6 +251,8 @@ public:
 
         // verify local max_replica_count of the app
         ASSERT_EQ(app->max_replica_count, expected_max_replica_count);
+        // env of max_replica_count should have been removed under normal circumstances
+        ASSERT_EQ(app->envs.find(replica_envs::UPDATE_MAX_REPLICA_COUNT), app->envs.end());
 
         // verify remote max_replica_count of the app
         auto app_path = _ss->get_app_path(*app);
@@ -255,6 +269,9 @@ public:
                 ASSERT_EQ(ainfo.app_name, app->app_name);
                 ASSERT_EQ(ainfo.app_id, app->app_id);
                 ASSERT_EQ(ainfo.max_replica_count, expected_max_replica_count);
+                // env of max_replica_count should have been removed under normal circumstances
+                ASSERT_EQ(ainfo.envs.find(replica_envs::UPDATE_MAX_REPLICA_COUNT),
+                          ainfo.envs.end());
             },
             &tracker);
         tracker.wait_outstanding_tasks();


### PR DESCRIPTION
This is a subtask of https://github.com/apache/incubator-pegasus/issues/865.

Since in https://github.com/XiaoMi/rdsn/pull/1087 we've supported to set env for the replication factor in case there are duplicate requests trying to update the same table, there is still a problem that the request for updating replication factor may fail once meta server crashes. It's possible that there are partial steps finished while others are uncompleted.

Therefore, After meta server has got primary lock, it will initialize, during which recovering replication factor should be relaunched.  Any table whose env of updating replication factor is not removed (once updating replication factor is complete, the env will be eliminated) will be the candidate that needs to recover as long as it's available. All tables should have been restored before the initialization is finished.