### PR TITLE
fix: drop unused 'this' from lambda capture for unit-tests that verify replication factor

### DIFF
--- a/src/meta/test/meta_app_operation_test.cpp
+++ b/src/meta/test/meta_app_operation_test.cpp
@@ -227,7 +227,7 @@ public:
             _ms->get_remote_storage()->get_data(
                 partition_path,
                 LPC_META_CALLBACK,
-                [ this, expected_pid = partition_config.pid, expected_max_replica_count ](
+                [ expected_pid = partition_config.pid, expected_max_replica_count ](
                     error_code ec, const blob &value) {
                     ASSERT_EQ(ec, ERR_OK);
 
@@ -260,7 +260,7 @@ public:
         _ms->get_remote_storage()->get_data(
             app_path,
             LPC_META_CALLBACK,
-            [this, app, expected_max_replica_count](error_code ec, const blob &value) {
+            [app, expected_max_replica_count](error_code ec, const blob &value) {
                 ASSERT_EQ(ec, ERR_OK);
 
                 app_info ainfo;

--- a/src/meta/test/meta_app_operation_test.cpp
+++ b/src/meta/test/meta_app_operation_test.cpp
@@ -227,8 +227,8 @@ public:
             _ms->get_remote_storage()->get_data(
                 partition_path,
                 LPC_META_CALLBACK,
-                [ expected_pid = partition_config.pid, expected_max_replica_count ](
-                    error_code ec, const blob &value) {
+                [ expected_pid = partition_config.pid,
+                  expected_max_replica_count ](error_code ec, const blob &value) {
                     ASSERT_EQ(ec, ERR_OK);
 
                     partition_configuration partition_config;


### PR DESCRIPTION
Fix unit tests for the issue: https://github.com/apache/incubator-pegasus/issues/1002.