### PR TITLE
fix: assert is not necessary when the table config is updated

### DIFF
--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -270,8 +270,7 @@ void partition_resolver_simple::query_config_reply(error_code err,
             zauto_write_lock l(_config_lock);
 
             if (_app_id != -1 && _app_id != resp.app_id) {
-                dassert(false,
-                        "app id is changed (mostly the app was removed and created with the same "
+                dwarn_f("app id is changed (mostly the app was removed and created with the same "
                         "name), local Vs remote: %u vs %u ",
                         _app_id,
                         resp.app_id);
@@ -279,8 +278,7 @@ void partition_resolver_simple::query_config_reply(error_code err,
             if (_app_partition_count != -1 && _app_partition_count != resp.partition_count &&
                 _app_partition_count * 2 != resp.partition_count &&
                 _app_partition_count != resp.partition_count * 2) {
-                dassert(false,
-                        "partition count is changed (mostly the app was removed and created with "
+                dwarn_f("partition count is changed (mostly the app was removed and created with "
                         "the same name), local Vs remote: %u vs %u ",
                         _app_partition_count,
                         resp.partition_count);


### PR DESCRIPTION
# Related-Issue
https://github.com/apache/incubator-pegasus/issues/903.

# Change
c++ client will crush for `assert` if server table config is changed, for example, remove table and re-build same name table.
But it's not necessary because `config-update` will trigger the client fetch `latest right config`, which don't has any problem.

I found the problem is that the `duplication module` use the c++ client code: if one duplication failed, I want drop the remote table and re-start new duplication task, but it will result that all the master replica crush for the remote table config changing

### So please must merge this pr when release `duplication`(https://github.com/apache/incubator-pegasus/issues/892)